### PR TITLE
Quantization related torch.fx transformations

### DIFF
--- a/src/optimum/fx/quantization_transformations.py
+++ b/src/optimum/fx/quantization_transformations.py
@@ -173,6 +173,7 @@ def remove_dequantize_after_getitem_on_size_(gm: GraphModule, lint_and_recompile
 
 
 pre_quantization_transformations = broadcast_add
+
 post_quantization_transformations = compose_transformations(
     change_attention_mask_value_, remove_dequantize_after_getitem_on_size_
 )


### PR DESCRIPTION
# What does this PR do?

This PR provides several torch.fx transformations useful when quantizing transformers models:

- `change_truediv_to_mul_when_possible`: changes x / y, where y is some static number to x * (1 / y), the reason for this is because there is not a quantized version of the truediv operator in PyTorch yet, this transformation allows you to get an equivalent quantized mul operator.
- `change_attention_mask_value`: the default attention mask value (-10000) can cause issues with range calibration which can hurt accuracy, this transformation allows you to change the default value to any value, -20 works fine in practice.
- `broadcast_add`: this makes quantization with torch.fx possible by executing the graph node-by-node, and broadcasting the operands of operator.add to make them match in size, without this the quantized model forward pass will fail because torch.ops.quantized.add does not support broadcasting out of the box.
