### PR TITLE
Add lpot dataloader

### DIFF
--- a/examples/pytorch/text-classification/run_glue.py
+++ b/examples/pytorch/text-classification/run_glue.py
@@ -536,7 +536,9 @@ def main():
         if quantizer.approach == LpotQuantizationMode.DYNAMIC.value:
             q_model = quantizer.fit_dynamic()
         elif quantizer.approach == LpotQuantizationMode.STATIC.value:
-            quantizer.calib_dataloader = trainer.get_eval_dataloader()
+            from optimum.intel.lpot.utils import LpotDataloader
+            eval_dataloader = trainer.get_eval_dataloader()
+            quantizer.calib_dataloader = LpotDataloader(eval_dataloader)
             q_model = quantizer.fit_static()
         elif quantizer.approach == LpotQuantizationMode.AWARE_TRAINING.value:
             if not training_args.do_train:

--- a/src/optimum/intel/lpot/utils.py
+++ b/src/optimum/intel/lpot/utils.py
@@ -12,12 +12,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-def model_calibration(self, q_model, dataloader, iterations=1):
-    import torch
-    assert iterations > 0
-    with torch.no_grad():
-        for idx, input in enumerate(dataloader):
-            _ = q_model(**input)
-            if idx >= iterations - 1:
-                break
+from torch.utils.data import DataLoader
+
+
+class LpotDataloader:
+
+    def __init__(self, dataloader: DataLoader):
+        self.dataloader = dataloader
+        self.batch_size = dataloader.batch_size
+
+    def __iter__(self):
+        for input in self.dataloader:
+            if isinstance(input, dict) and "labels" in input:
+                yield input, input["labels"]
+            else:
+                yield input, None
 


### PR DESCRIPTION
This PR adds lpot dataloader for lpot pytorch adaptor model calibration compatibility as suggested by @huggingface/intel-optimus  