### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The two steps mentioned above can be performed in one step using the following c
 ```bash
 optimum_export_optimize \
     --model_name_or_path bert-base-uncased \
-    --output /tmp/onnx_models/model.onnx
+    --output /tmp/onnx_models/model.onnx \
     --opt_level 1 \
     --quantize \
     --atol 1.5 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ cd optimum
 pip install -e .
 ```
 
+To use Intel Neural Compressor (INC),
+
+`pip install optimum[intel]`
+
+To use ONNX Runtime,
+
+`pip install optimum[onnxruntime]`
 
 ## Usage
 


### PR DESCRIPTION
This PR adds installation instructions for optional dependencies needed when using `intel` or `onnxruntime`.
