### PR TITLE
Update examples test quantization approach from dynamic to static

### DIFF
--- a/examples/pytorch/language-modeling/config/inc/quantization.yml
+++ b/examples/pytorch/language-modeling/config/inc/quantization.yml
@@ -17,16 +17,17 @@ version: 1.0
 
 model:                                               # mandatory.
   name: bert
-  framework: pytorch                                 # mandatory.
+  framework: pytorch                                 # mandatory. possible values are pytorch and pytorch_fx.
+
+device: cpu
+
 quantization:                                        # optional.
   approach: post_training_dynamic_quant
 
-
-
 tuning:
   accuracy_criterion:
-    absolute:  1.5                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
+    absolute:  2                                     # optional. default value is relative, other value is absolute. this example allows absolute accuracy loss of 2.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 600
+    max_trials: 30
   random_seed: 9527                                  # optional.

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -146,6 +146,10 @@ class OptimizationArguments:
         default="eval_loss",
         metadata={"help": "Metric used for the tuning strategy."},
     )
+    perf_tol: Optional[float] = field(
+        default=None,
+        metadata={"help": "Performance tolerance when optimizing the model."},
+    )
     verify_loading: bool = field(
         default=False,
         metadata={"help": "Whether or not to verify the loading of the quantized model."},
@@ -568,6 +572,10 @@ def main():
             cache_dir=model_args.cache_dir,
         )
 
+        # Set metric tolerance if specified
+        if optim_args.perf_tol is not None:
+            q8_config.set_tolerance(optim_args.perf_tol)
+
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:
             supported_approach = {"static", "dynamic", "aware_training"}
@@ -577,9 +585,12 @@ def main():
                 )
             quant_approach = getattr(IncQuantizationMode, optim_args.quantization_approach.upper()).value
             q8_config.set_config("quantization.approach", quant_approach)
+
+        if "loss" in optim_args.tune_metric:
+            q8_config.set_config("tuning.accuracy_criterion.higher_is_better", False)
+
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        q8_config.set_config("tuning.accuracy_criterion.higher_is_better", False)
         if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
             from transformers.utils.fx import symbolic_trace
 

--- a/examples/pytorch/multiple-choice/config/inc/quantization.yml
+++ b/examples/pytorch/multiple-choice/config/inc/quantization.yml
@@ -26,8 +26,8 @@ quantization:                                        # optional.
 
 tuning:
   accuracy_criterion:
-    absolute:  0.05                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
+    relative:  0.02                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 2%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 600
+    max_trials: 30
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/multiple-choice/run_swag.py
+++ b/examples/pytorch/multiple-choice/run_swag.py
@@ -117,6 +117,10 @@ class OptimizationArguments:
         default="eval_accuracy",
         metadata={"help": "Metric used for the tuning strategy."},
     )
+    perf_tol: Optional[float] = field(
+        default=None,
+        metadata={"help": "Performance tolerance when optimizing the model."},
+    )
     verify_loading: bool = field(
         default=False,
         metadata={"help": "Whether or not to verify the loading of the quantized model."},
@@ -499,6 +503,10 @@ def main():
             config_file_name="quantization.yml",
             cache_dir=model_args.cache_dir,
         )
+
+        # Set metric tolerance if specified
+        if optim_args.perf_tol is not None:
+            q8_config.set_tolerance(optim_args.perf_tol)
 
         num_choices = len(eval_dataset[0]["input_ids"])
         # Set quantization approach if specified

--- a/examples/pytorch/question-answering/config/inc/quantization.yml
+++ b/examples/pytorch/question-answering/config/inc/quantization.yml
@@ -26,8 +26,8 @@ quantization:                                        # optional.
 
 tuning:
   accuracy_criterion:
-    relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
+    relative:  0.02                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 2%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 20
+    max_trials: 30
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/question-answering/config/inc/quantization.yml
+++ b/examples/pytorch/question-answering/config/inc/quantization.yml
@@ -29,5 +29,5 @@ tuning:
     relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 1200
+    max_trials: 20
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -230,7 +230,7 @@ class OptimizationArguments:
     )
     perf_tol: Optional[float] = field(
         default=None,
-        metadata={"help": "Accepted relative perfomance tolerance percentage when optimizing the model."},
+        metadata={"help": "Performance tolerance when optimizing the model."},
     )
     verify_loading: bool = field(
         default=False,
@@ -662,9 +662,7 @@ def main():
 
         # Set metric tolerance if specified
         if optim_args.perf_tol is not None:
-            if not -1 < optim_args.perf_tol < 1:
-                raise ValueError("perf_tol must not be <=-1 or >=1.")
-            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.perf_tol)
+            q8_config.set_tolerance(optim_args.perf_tol)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -228,9 +228,9 @@ class OptimizationArguments:
         default="eval_f1",
         metadata={"help": "Metric used for the tuning strategy."},
     )
-    metric_tolerance: Optional[float] = field(
+    perf_tol: Optional[float] = field(
         default=None,
-        metadata={"help": "Metric tolerance accepted during the tuning strategy."},
+        metadata={"help": "Accepted relative perfomance tolerance percentage when optimizing the model."},
     )
     verify_loading: bool = field(
         default=False,
@@ -661,10 +661,10 @@ def main():
         )
 
         # Set metric tolerance if specified
-        if optim_args.metric_tolerance is not None:
-            if not -1 < optim_args.metric_tolerance < 1:
-                raise ValueError("metric_tolerance must not be <=-1 or >=1.")
-            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.metric_tolerance)
+        if optim_args.perf_tol is not None:
+            if not -1 < optim_args.perf_tol < 1:
+                raise ValueError("perf_tol must not be <=-1 or >=1.")
+            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.perf_tol)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/question-answering/run_qa.py
+++ b/examples/pytorch/question-answering/run_qa.py
@@ -228,6 +228,10 @@ class OptimizationArguments:
         default="eval_f1",
         metadata={"help": "Metric used for the tuning strategy."},
     )
+    metric_tolerance: Optional[float] = field(
+        default=None,
+        metadata={"help": "Metric tolerance accepted during the tuning strategy."},
+    )
     verify_loading: bool = field(
         default=False,
         metadata={"help": "Whether or not to verify the loading of the quantized model."},
@@ -655,6 +659,12 @@ def main():
             config_file_name="quantization.yml",
             cache_dir=model_args.cache_dir,
         )
+
+        # Set metric tolerance if specified
+        if optim_args.metric_tolerance is not None:
+            if not -1 < optim_args.metric_tolerance < 1:
+                raise ValueError("metric_tolerance must not be <=-1 or >=1.")
+            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.metric_tolerance)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/test_examples.py
+++ b/examples/pytorch/test_examples.py
@@ -63,23 +63,24 @@ class TestExamples(unittest.TestCase):
             test_args = f"""
                 run_glue.py
                 --model_name_or_path distilbert-base-uncased-finetuned-sst-2-english
-                --task_name=sst2
-                --provider={provider}
+                --task_name sst2
+                --provider {provider}
                 --quantize
-                --quantization_approach={quantization_approach}
-                --metric_tolerance 0.03
+                --quantization_approach {quantization_approach}
+                --tune_metric eval_accuracy
+                --perf_tol 0.1
                 --do_eval
-                --per_device_eval_batch_size=8
-                --max_eval_samples=256
+                --per_device_eval_batch_size 1
+                --max_eval_samples 50
                 --verify_loading
                 --dataloader_drop_last
-                --output_dir={tmp_dir}
+                --output_dir {tmp_dir}
                 """.split()
 
             with patch.object(sys, "argv", test_args):
                 run_glue.main()
                 results = get_results(tmp_dir)
-                self.assertGreaterEqual(results["eval_accuracy"], 0.85)
+                self.assertGreaterEqual(results["eval_accuracy"], 0.70)
 
     def test_run_qa(self):
         provider = "inc"
@@ -89,22 +90,23 @@ class TestExamples(unittest.TestCase):
             test_args = f"""
                 run_qa.py
                 --model_name_or_path distilbert-base-uncased-distilled-squad
-                --dataset_name=squad
-                --provider={provider}
+                --dataset_name squad
+                --provider {provider}
                 --quantize
-                --quantization_approach={quantization_approach}
-                --metric_tolerance 0.03
+                --quantization_approach {quantization_approach}
+                --tune_metric eval_f1
+                --perf_tol 0.1
                 --do_eval
-                --per_device_eval_batch_size=8
-                --max_eval_samples=256
+                --per_device_eval_batch_size 1
+                --max_eval_samples 50
                 --verify_loading
-                --output_dir={tmp_dir}
+                --output_dir {tmp_dir}
                 """.split()
 
             with patch.object(sys, "argv", test_args):
                 run_qa.main()
                 results = get_results(tmp_dir)
-                self.assertGreaterEqual(results["eval_f1"], 80)
+                self.assertGreaterEqual(results["eval_f1"], 70)
                 self.assertGreaterEqual(results["eval_exact_match"], 70)
 
     def test_run_ner(self):
@@ -113,99 +115,110 @@ class TestExamples(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
-                run_ner.py 
+                run_ner.py
                 --model_name_or_path elastic/distilbert-base-uncased-finetuned-conll03-english
-                --dataset_name=conll2003
-                --provider={provider}
+                --dataset_name conll2003
+                --provider {provider}
                 --quantize
-                --quantization_approach={quantization_approach}
-                --metric_tolerance 0.04
+                --quantization_approach {quantization_approach}
+                --tune_metric eval_f1
+                --perf_tol 0.1
                 --do_eval
-                --per_device_eval_batch_size=8
-                --max_eval_samples=256
+                --per_device_eval_batch_size 1
+                --max_eval_samples 50
+                --pad_to_max_length
                 --verify_loading
-                --output_dir={tmp_dir}
+                --output_dir {tmp_dir}
                 """.split()
 
             with patch.object(sys, "argv", test_args):
                 run_ner.main()
                 results = get_results(tmp_dir)
-                self.assertGreaterEqual(results["eval_accuracy"], 0.90)
-                self.assertGreaterEqual(results["eval_f1"], 0.90)
-                self.assertGreaterEqual(results["eval_precision"], 0.90)
-                self.assertGreaterEqual(results["eval_recall"], 0.90)
+                self.assertGreaterEqual(results["eval_accuracy"], 0.70)
+                self.assertGreaterEqual(results["eval_f1"], 0.70)
+                self.assertGreaterEqual(results["eval_precision"], 0.70)
+                self.assertGreaterEqual(results["eval_recall"], 0.70)
 
     def test_run_swag(self):
         provider = "inc"
-        quantization_approach = "dynamic"
+        quantization_approach = "static"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
-                run_swag.py 
-                --model_name_or_path bert-base-cased
-                --provider={provider}
+                run_swag.py
+                --model_name_or_path ehdwns1516/bert-base-uncased_SWAG
+                --provider {provider}
                 --quantize
-                --quantization_approach={quantization_approach}
+                --quantization_approach {quantization_approach}
+                --tune_metric eval_accuracy
+                --perf_tol 0.1
                 --do_eval
+                --per_device_eval_batch_size 1
+                --max_eval_samples 50
+                --pad_to_max_length
                 --verify_loading
-                --output_dir={tmp_dir}
-                --max_eval_samples=100
+                --output_dir {tmp_dir}
                 """.split()
 
             with patch.object(sys, "argv", test_args):
                 run_swag.main()
                 results = get_results(tmp_dir)
-                self.assertGreaterEqual(results["eval_accuracy"], 0.50)
+                self.assertGreaterEqual(results["eval_accuracy"], 0.60)
 
     def test_run_clm(self):
         provider = "inc"
-        quantization_approach = "dynamic"
+        quantization_approach = "static"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
-                run_clm.py 
-                --model_name_or_path microsoft/DialoGPT-medium
+                run_clm.py
+                --model_name_or_path EleutherAI/gpt-neo-125M
                 --dataset_name wikitext
                 --dataset_config_name wikitext-2-raw-v1
-                --provider={provider}
+                --provider {provider}
                 --quantize
-                --quantization_approach={quantization_approach}
-                --do_eval
-                --verify_loading
-                --output_dir={tmp_dir}
-                --max_eval_samples=100
+                --quantization_approach {quantization_approach}
                 --tune_metric eval_loss
+                --perf_tol 4
+                --do_eval
+                --per_device_eval_batch_size 1
+                --max_eval_samples 50
+                --verify_loading
+                --output_dir {tmp_dir}
                 """.split()
 
             with patch.object(sys, "argv", test_args):
                 run_clm.main()
                 results = get_results(tmp_dir)
-                self.assertLessEqual(results["eval_loss"], 10)
+                self.assertLessEqual(results["eval_loss"], 13)
 
     def test_run_mlm(self):
         provider = "inc"
-        quantization_approach = "dynamic"
+        quantization_approach = "static"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
-                run_mlm.py 
+                run_mlm.py
                 --model_name_or_path google/electra-small-discriminator
                 --dataset_name wikitext
                 --dataset_config_name wikitext-2-raw-v1
-                --provider={provider}
+                --provider {provider}
                 --quantize
-                --quantization_approach={quantization_approach}
+                --quantization_approach {quantization_approach}
                 --do_eval
-                --verify_loading
-                --output_dir={tmp_dir}
-                --max_eval_samples 100
                 --tune_metric eval_loss
+                --perf_tol 4
+                --do_eval
+                --per_device_eval_batch_size 1
+                --max_eval_samples 50
+                --verify_loading
+                --output_dir {tmp_dir}
                 """.split()
 
             with patch.object(sys, "argv", test_args):
                 run_mlm.main()
                 results = get_results(tmp_dir)
-                self.assertLessEqual(results["eval_loss"], 10)
+                self.assertLessEqual(results["eval_loss"], 13)
 
 
 if __name__ == "__main__":

--- a/examples/pytorch/test_examples.py
+++ b/examples/pytorch/test_examples.py
@@ -52,7 +52,7 @@ def get_results(output_dir):
 class TestExamples(unittest.TestCase):
     def test_run_glue(self):
         provider = "inc"
-        quantization_approach = "dynamic"
+        quantization_approach = "static"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
@@ -62,9 +62,12 @@ class TestExamples(unittest.TestCase):
                 --provider={provider}
                 --quantize
                 --quantization_approach={quantization_approach}
+                --metric_tolerance 0.03
                 --do_eval
                 --per_device_eval_batch_size=8
+                --max_eval_samples=256
                 --verify_loading
+                --dataloader_drop_last
                 --output_dir={tmp_dir}
                 """.split()
 
@@ -75,7 +78,7 @@ class TestExamples(unittest.TestCase):
 
     def test_run_qa(self):
         provider = "inc"
-        quantization_approach = "dynamic"
+        quantization_approach = "static"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
@@ -85,8 +88,10 @@ class TestExamples(unittest.TestCase):
                 --provider={provider}
                 --quantize
                 --quantization_approach={quantization_approach}
+                --metric_tolerance 0.03
                 --do_eval
                 --per_device_eval_batch_size=8
+                --max_eval_samples=256
                 --verify_loading
                 --output_dir={tmp_dir}
                 """.split()
@@ -99,7 +104,7 @@ class TestExamples(unittest.TestCase):
 
     def test_run_ner(self):
         provider = "inc"
-        quantization_approach = "dynamic"
+        quantization_approach = "static"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             test_args = f"""
@@ -109,7 +114,10 @@ class TestExamples(unittest.TestCase):
                 --provider={provider}
                 --quantize
                 --quantization_approach={quantization_approach}
+                --metric_tolerance 0.04
                 --do_eval
+                --per_device_eval_batch_size=8
+                --max_eval_samples=256
                 --verify_loading
                 --output_dir={tmp_dir}
                 """.split()

--- a/examples/pytorch/text-classification/config/inc/quantization.yml
+++ b/examples/pytorch/text-classification/config/inc/quantization.yml
@@ -26,8 +26,8 @@ quantization:                                        # optional.
 
 tuning:
   accuracy_criterion:
-    relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
+    relative:  0.02                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 2%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 20
+    max_trials: 30
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/text-classification/config/inc/quantization.yml
+++ b/examples/pytorch/text-classification/config/inc/quantization.yml
@@ -29,5 +29,5 @@ tuning:
     relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 1200
+    max_trials: 20
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/text-classification/run_glue.py
+++ b/examples/pytorch/text-classification/run_glue.py
@@ -213,9 +213,9 @@ class OptimizationArguments:
         default="eval_accuracy",
         metadata={"help": "Metric used for the tuning strategy."},
     )
-    metric_tolerance: Optional[float] = field(
+    perf_tol: Optional[float] = field(
         default=None,
-        metadata={"help": "Metric tolerance accepted during the tuning strategy."},
+        metadata={"help": "Accepted relative perfomance tolerance percentage when optimizing the model."},
     )
     verify_loading: bool = field(
         default=False,
@@ -543,10 +543,10 @@ def main():
         )
 
         # Set metric tolerance if specified
-        if optim_args.metric_tolerance is not None:
-            if not -1 < optim_args.metric_tolerance < 1:
-                raise ValueError("metric_tolerance must not be <=-1 or >=1.")
-            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.metric_tolerance)
+        if optim_args.perf_tol is not None:
+            if not -1 < optim_args.perf_tol < 1:
+                raise ValueError("perf_tol must not be <=-1 or >=1.")
+            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.perf_tol)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/text-classification/run_glue.py
+++ b/examples/pytorch/text-classification/run_glue.py
@@ -215,7 +215,7 @@ class OptimizationArguments:
     )
     perf_tol: Optional[float] = field(
         default=None,
-        metadata={"help": "Accepted relative perfomance tolerance percentage when optimizing the model."},
+        metadata={"help": "Performance tolerance when optimizing the model."},
     )
     verify_loading: bool = field(
         default=False,
@@ -555,9 +555,7 @@ def main():
 
         # Set metric tolerance if specified
         if optim_args.perf_tol is not None:
-            if not -1 < optim_args.perf_tol < 1:
-                raise ValueError("perf_tol must not be <=-1 or >=1.")
-            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.perf_tol)
+            q8_config.set_tolerance(optim_args.perf_tol)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/text-classification/run_glue.py
+++ b/examples/pytorch/text-classification/run_glue.py
@@ -213,6 +213,10 @@ class OptimizationArguments:
         default="eval_accuracy",
         metadata={"help": "Metric used for the tuning strategy."},
     )
+    metric_tolerance: Optional[float] = field(
+        default=None,
+        metadata={"help": "Metric tolerance accepted during the tuning strategy."},
+    )
     verify_loading: bool = field(
         default=False,
         metadata={"help": "Whether or not to verify the loading of the quantized model."},
@@ -537,6 +541,12 @@ def main():
             config_file_name="quantization.yml",
             cache_dir=model_args.cache_dir,
         )
+
+        # Set metric tolerance if specified
+        if optim_args.metric_tolerance is not None:
+            if not -1 < optim_args.metric_tolerance < 1:
+                raise ValueError("metric_tolerance must not be <=-1 or >=1.")
+            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.metric_tolerance)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/token-classification/config/inc/quantization.yml
+++ b/examples/pytorch/token-classification/config/inc/quantization.yml
@@ -26,8 +26,8 @@ quantization:                                        # optional.
 
 tuning:
   accuracy_criterion:
-    relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
+    relative:  0.02                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 2%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 20
+    max_trials: 30
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/token-classification/config/inc/quantization.yml
+++ b/examples/pytorch/token-classification/config/inc/quantization.yml
@@ -29,5 +29,5 @@ tuning:
     relative:  0.01                                  # optional. default value is relative, other value is absolute. this example allows relative accuracy loss: 1%.
   exit_policy:
     timeout: 0                                       # optional. tuning timeout (seconds). default value is 0 which means early stop. combine with max_trials field to decide when to exit.
-    max_trials: 1200
+    max_trials: 20
   random_seed: 9527                                  # optional. random seed for deterministic tuning.

--- a/examples/pytorch/token-classification/run_ner.py
+++ b/examples/pytorch/token-classification/run_ner.py
@@ -213,6 +213,10 @@ class OptimizationArguments:
         default="eval_f1",
         metadata={"help": "Metric used for the tuning strategy."},
     )
+    metric_tolerance: Optional[float] = field(
+        default=None,
+        metadata={"help": "Metric tolerance accepted during the tuning strategy."},
+    )
     verify_loading: bool = field(
         default=False,
         metadata={"help": "Whether or not to verify the loading of the quantized model."},
@@ -586,6 +590,12 @@ def main():
             config_file_name="quantization.yml",
             cache_dir=model_args.cache_dir,
         )
+
+        # Set metric tolerance if specified
+        if optim_args.metric_tolerance is not None:
+            if not -1 < optim_args.metric_tolerance < 1:
+                raise ValueError("metric_tolerance must not be <=-1 or >=1.")
+            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.metric_tolerance)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/token-classification/run_ner.py
+++ b/examples/pytorch/token-classification/run_ner.py
@@ -213,9 +213,9 @@ class OptimizationArguments:
         default="eval_f1",
         metadata={"help": "Metric used for the tuning strategy."},
     )
-    metric_tolerance: Optional[float] = field(
+    perf_tol: Optional[float] = field(
         default=None,
-        metadata={"help": "Metric tolerance accepted during the tuning strategy."},
+        metadata={"help": "Accepted relative perfomance tolerance percentage when optimizing the model."},
     )
     verify_loading: bool = field(
         default=False,
@@ -592,10 +592,10 @@ def main():
         )
 
         # Set metric tolerance if specified
-        if optim_args.metric_tolerance is not None:
-            if not -1 < optim_args.metric_tolerance < 1:
-                raise ValueError("metric_tolerance must not be <=-1 or >=1.")
-            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.metric_tolerance)
+        if optim_args.perf_tol is not None:
+            if not -1 < optim_args.perf_tol < 1:
+                raise ValueError("perf_tol must not be <=-1 or >=1.")
+            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.perf_tol)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/examples/pytorch/token-classification/run_ner.py
+++ b/examples/pytorch/token-classification/run_ner.py
@@ -215,7 +215,7 @@ class OptimizationArguments:
     )
     perf_tol: Optional[float] = field(
         default=None,
-        metadata={"help": "Accepted relative perfomance tolerance percentage when optimizing the model."},
+        metadata={"help": "Performance tolerance when optimizing the model."},
     )
     verify_loading: bool = field(
         default=False,
@@ -605,9 +605,7 @@ def main():
 
         # Set metric tolerance if specified
         if optim_args.perf_tol is not None:
-            if not -1 < optim_args.perf_tol < 1:
-                raise ValueError("perf_tol must not be <=-1 or >=1.")
-            q8_config.set_config("tuning.accuracy_criterion.relative", optim_args.perf_tol)
+            q8_config.set_tolerance(optim_args.perf_tol)
 
         # Set quantization approach if specified
         if optim_args.quantization_approach is not None:

--- a/src/optimum/intel/neural_compressor/config.py
+++ b/src/optimum/intel/neural_compressor/config.py
@@ -49,6 +49,16 @@ class IncConfig:
             d = d.setdefault(key, {})
         d[keys[-1]] = value
 
+    def set_tolerance(self, perf_tol: Union[int, float]):
+        if not isinstance(perf_tol, (int, float)):
+            raise TypeError(f"Supported type for performance tolerance are int and float, got {type(perf_tol)}")
+        if "absolute" in self.get_config("tuning.accuracy_criterion"):
+            self.set_config("tuning.accuracy_criterion.absolute", perf_tol)
+        else:
+            if not -1 < perf_tol < 1:
+                raise ValueError("Relative performance tolerance must not be <=-1 or >=1.")
+            self.set_config("tuning.accuracy_criterion.relative", perf_tol)
+
     @classmethod
     def from_pretrained(cls, config_name_or_path: str, config_file_name: Optional[str] = None, **kwargs):
         """


### PR DESCRIPTION
This PR adds a metric tolerance argument in order for the user to easily set an accepted drop in performance without having to directly change the config file. This PR also changes the test examples quantization approach from dynamic to static and furthermore reduce the number of evaluation and training examples of the INC quantization tests.