### PR TITLE
Fix qa data mismatch

### DIFF
--- a/examples/inc/pytorch/question-answering/run_qa.py
+++ b/examples/inc/pytorch/question-answering/run_qa.py
@@ -569,7 +569,10 @@ def main():
         if data_args.max_eval_samples is not None:
             # During Feature creation dataset samples might increase, we will select required samples again
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
-
+        if training_args.dataloader_drop_last:
+            data_lens = len(eval_dataset)
+            data_lens -= data_lens % training_args.per_device_eval_batch_size
+            eval_dataset = eval_dataset.select(range(data_lens))
     # Data collator
     # We have already padded to max length if the corresponding flag is True, otherwise we need to pad in the data
     # collator.


### PR DESCRIPTION
# What does this PR do?

This PR fixed `ValueError: Got [n] predictions and [n+m] features` of `run_qa.py`.
If `training_args.dataloader_drop_last` was set, the length of predictions may not match features, due to dataset didn't reduce last batch.
