### PR TITLE
Fix broken links 

### DIFF
--- a/examples/inc/pytorch/language-modeling/README.md
+++ b/examples/inc/pytorch/language-modeling/README.md
@@ -16,8 +16,8 @@ limitations under the License.
 
 # Language modeling training
 
-The scripts [`run_clm.py`](https://github.com/huggingface/optimum/blob/main/examples/pytorch/language-modeling/run_clm.py) 
-and [`run_mlm.py`](https://github.com/huggingface/optimum/blob/main/examples/pytorch/language-modeling/run_mlm.py)
+The scripts [`run_clm.py`](https://github.com/huggingface/optimum/blob/main/examples/inc/pytorch/language-modeling/run_clm.py) 
+and [`run_mlm.py`](https://github.com/huggingface/optimum/blob/main/examples/inc/pytorch/language-modeling/run_mlm.py)
 allow us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for language modeling tasks.
 

--- a/examples/inc/pytorch/language-modeling/run_clm.py
+++ b/examples/inc/pytorch/language-modeling/run_clm.py
@@ -684,8 +684,6 @@ def main():
 
     inc_optimizer = IncOptimizer(model, quantizer=quantizer, pruner=pruner)
     opt_model = inc_optimizer.fit()
-
-    _, sparsity = opt_model.report_sparsity()
     result_opt_model = take_eval_steps(opt_model.model, trainer, metric_name, save_metrics=True)
 
     trainer.save_model(training_args.output_dir)
@@ -693,8 +691,8 @@ def main():
         yaml.dump(opt_model.tune_cfg, f, default_flow_style=False)
 
     logger.info(
-        f"Optimized model with final sparsity of {sparsity} and {metric_name} of {result_opt_model} saved to: "
-        f"{training_args.output_dir}. Original model had an {metric_name} of {result_baseline_model}"
+        f"Optimized model with {metric_name} of {result_opt_model} saved to: {training_args.output_dir}."
+        f" Original model had an {metric_name} of {result_baseline_model}."
     )
 
     if optim_args.quantize and optim_args.verify_loading:

--- a/examples/inc/pytorch/language-modeling/run_clm.py
+++ b/examples/inc/pytorch/language-modeling/run_clm.py
@@ -613,10 +613,10 @@ def main():
 
         q8_config.set_config("tuning.accuracy_criterion.higher_is_better", False)
 
+        quant_approach = IncQuantizationMode(q8_config.get_config("quantization.approach"))
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
-
+        if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
 
@@ -639,7 +639,7 @@ def main():
                 sequence_length=block_size,
             )
 
-        calib_dataloader = trainer.get_train_dataloader()
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
         inc_quantizer = IncQuantizer(
             model, q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/inc/pytorch/language-modeling/run_mlm.py
+++ b/examples/inc/pytorch/language-modeling/run_mlm.py
@@ -649,10 +649,10 @@ def main():
 
         q8_config.set_config("tuning.accuracy_criterion.higher_is_better", False)
 
+        quant_approach = IncQuantizationMode(q8_config.get_config("quantization.approach"))
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
-
+        if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
 
@@ -675,7 +675,7 @@ def main():
                 sequence_length=max_seq_length,
             )
 
-        calib_dataloader = trainer.get_train_dataloader()
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
         inc_quantizer = IncQuantizer(
             model, q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/inc/pytorch/language-modeling/run_mlm.py
+++ b/examples/inc/pytorch/language-modeling/run_mlm.py
@@ -720,8 +720,6 @@ def main():
 
     inc_optimizer = IncOptimizer(model, quantizer=quantizer, pruner=pruner)
     opt_model = inc_optimizer.fit()
-
-    _, sparsity = opt_model.report_sparsity()
     result_opt_model = take_eval_steps(opt_model.model, trainer, metric_name, save_metrics=True)
 
     trainer.save_model(training_args.output_dir)
@@ -729,8 +727,8 @@ def main():
         yaml.dump(opt_model.tune_cfg, f, default_flow_style=False)
 
     logger.info(
-        f"Optimized model with final sparsity of {sparsity} and {metric_name} of {result_opt_model} saved to: "
-        f"{training_args.output_dir}. Original model had an {metric_name} of {result_baseline_model}"
+        f"Optimized model with {metric_name} of {result_opt_model} saved to: {training_args.output_dir}."
+        f" Original model had an {metric_name} of {result_baseline_model}."
     )
 
     if optim_args.quantize and optim_args.verify_loading:

--- a/examples/inc/pytorch/multiple-choice/README.md
+++ b/examples/inc/pytorch/multiple-choice/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Multiple choice 
 
-The script [`run_swag.py`](https://github.com/huggingface/optimum/blob/main/examples/pytorch/multiple-choice/run_swag.py) 
+The script [`run_swag.py`](https://github.com/huggingface/optimum/blob/main/examples/inc/pytorch/multiple-choice/run_swag.py) 
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for 
 multiple choice tasks.

--- a/examples/inc/pytorch/multiple-choice/run_swag.py
+++ b/examples/inc/pytorch/multiple-choice/run_swag.py
@@ -545,10 +545,10 @@ def main():
             quant_approach = getattr(IncQuantizationMode, optim_args.quantization_approach.upper()).value
             q8_config.set_config("quantization.approach", quant_approach)
 
+        quant_approach = IncQuantizationMode(q8_config.get_config("quantization.approach"))
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
-
+        if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
 
@@ -576,7 +576,7 @@ def main():
                 num_choices=num_choices,
             )
 
-        calib_dataloader = trainer.get_train_dataloader()
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
         inc_quantizer = IncQuantizer(
             model, q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/inc/pytorch/multiple-choice/run_swag.py
+++ b/examples/inc/pytorch/multiple-choice/run_swag.py
@@ -621,8 +621,6 @@ def main():
 
     inc_optimizer = IncOptimizer(model, quantizer=quantizer, pruner=pruner)
     opt_model = inc_optimizer.fit()
-
-    _, sparsity = opt_model.report_sparsity()
     result_opt_model = take_eval_steps(opt_model.model, trainer, metric_name, save_metrics=True)
 
     trainer.save_model(training_args.output_dir)
@@ -630,8 +628,8 @@ def main():
         yaml.dump(opt_model.tune_cfg, f, default_flow_style=False)
 
     logger.info(
-        f"Optimized model with final sparsity of {sparsity} and {metric_name} of {result_opt_model} saved to: "
-        f"{training_args.output_dir}. Original model had an {metric_name} of {result_baseline_model}"
+        f"Optimized model with {metric_name} of {result_opt_model} saved to: {training_args.output_dir}."
+        f" Original model had an {metric_name} of {result_baseline_model}."
     )
 
     if optim_args.quantize and optim_args.verify_loading:

--- a/examples/inc/pytorch/question-answering/README.md
+++ b/examples/inc/pytorch/question-answering/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 # Question answering
 
 
-The script [`run_qa.py`](https://github.com/huggingface/optimum/blob/main/examples/pytorch/question-answering/run_qa.py)
+The script [`run_qa.py`](https://github.com/huggingface/optimum/blob/main/examples/inc/pytorch/question-answering/run_qa.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for
 question answering tasks.

--- a/examples/inc/pytorch/question-answering/run_qa.py
+++ b/examples/inc/pytorch/question-answering/run_qa.py
@@ -773,8 +773,6 @@ def main():
 
     inc_optimizer = IncOptimizer(model, quantizer=quantizer, pruner=pruner)
     opt_model = inc_optimizer.fit()
-
-    _, sparsity = opt_model.report_sparsity()
     result_opt_model = take_eval_steps(opt_model.model, trainer, metric_name, save_metrics=True)
 
     trainer.save_model(training_args.output_dir)
@@ -782,8 +780,8 @@ def main():
         yaml.dump(opt_model.tune_cfg, f, default_flow_style=False)
 
     logger.info(
-        f"Optimized model with final sparsity of {sparsity} and {metric_name} of {result_opt_model} saved to: "
-        f"{training_args.output_dir}. Original model had an {metric_name} of {result_baseline_model}"
+        f"Optimized model with {metric_name} of {result_opt_model} saved to: {training_args.output_dir}."
+        f" Original model had an {metric_name} of {result_baseline_model}."
     )
 
     if optim_args.quantize and optim_args.verify_loading:

--- a/examples/inc/pytorch/question-answering/run_qa.py
+++ b/examples/inc/pytorch/question-answering/run_qa.py
@@ -700,10 +700,10 @@ def main():
             quant_approach = getattr(IncQuantizationMode, optim_args.quantization_approach.upper()).value
             q8_config.set_config("quantization.approach", quant_approach)
 
+        quant_approach = IncQuantizationMode(q8_config.get_config("quantization.approach"))
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
-
+        if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
 
@@ -728,7 +728,7 @@ def main():
                 sequence_length=max_seq_length,
             )
 
-        calib_dataloader = trainer.get_train_dataloader()
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
         inc_quantizer = IncQuantizer(
             model, q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/inc/pytorch/text-classification/README.md
+++ b/examples/inc/pytorch/text-classification/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 ## GLUE tasks
 
-The script [`run_glue.py`](https://github.com/huggingface/optimum/blob/main/examples/pytorch/text-classification/run_glue.py)
+The script [`run_glue.py`](https://github.com/huggingface/optimum/blob/main/examples/inc/pytorch/text-classification/run_glue.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for 
 sequence classification tasks such as the ones from the [GLUE benchmark](https://gluebenchmark.com/).

--- a/examples/inc/pytorch/text-classification/run_glue.py
+++ b/examples/inc/pytorch/text-classification/run_glue.py
@@ -676,8 +676,6 @@ def main():
 
     inc_optimizer = IncOptimizer(model, quantizer=quantizer, pruner=pruner)
     opt_model = inc_optimizer.fit()
-
-    _, sparsity = opt_model.report_sparsity()
     result_opt_model = take_eval_steps(opt_model.model, trainer, metric_name, save_metrics=True)
 
     trainer.save_model(training_args.output_dir)
@@ -685,8 +683,8 @@ def main():
         yaml.dump(opt_model.tune_cfg, f, default_flow_style=False)
 
     logger.info(
-        f"Optimized model with final sparsity of {sparsity} and {metric_name} of {result_opt_model} saved to: "
-        f"{training_args.output_dir}. Original model had an {metric_name} of {result_baseline_model}"
+        f"Optimized model with {metric_name} of {result_opt_model} saved to: {training_args.output_dir}."
+        f" Original model had an {metric_name} of {result_baseline_model}."
     )
 
     if optim_args.quantize and optim_args.verify_loading:

--- a/examples/inc/pytorch/text-classification/run_glue.py
+++ b/examples/inc/pytorch/text-classification/run_glue.py
@@ -605,10 +605,10 @@ def main():
             quant_approach = getattr(IncQuantizationMode, optim_args.quantization_approach.upper()).value
             q8_config.set_config("quantization.approach", quant_approach)
 
+        quant_approach = IncQuantizationMode(q8_config.get_config("quantization.approach"))
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
-
+        if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
 
@@ -631,7 +631,7 @@ def main():
                 sequence_length=max_seq_length,
             )
 
-        calib_dataloader = trainer.get_train_dataloader()
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
         inc_quantizer = IncQuantizer(
             model, q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/inc/pytorch/token-classification/README.md
+++ b/examples/inc/pytorch/token-classification/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 # Token classification
 
 
-The script [`run_ner.py`](https://github.com/huggingface/optimum/blob/main/examples/pytorch/token-classification/run_ner.py)
+The script [`run_ner.py`](https://github.com/huggingface/optimum/blob/main/examples/inc/pytorch/token-classification/run_ner.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for token classification tasks.
 

--- a/examples/inc/pytorch/token-classification/run_ner.py
+++ b/examples/inc/pytorch/token-classification/run_ner.py
@@ -643,10 +643,10 @@ def main():
             quant_approach = getattr(IncQuantizationMode, optim_args.quantization_approach.upper()).value
             q8_config.set_config("quantization.approach", quant_approach)
 
+        quant_approach = IncQuantizationMode(q8_config.get_config("quantization.approach"))
         # torch FX used for post-training quantization and quantization aware training
         # dynamic quantization will be added when torch FX is more mature
-        if q8_config.get_config("quantization.approach") != IncQuantizationMode.DYNAMIC.value:
-
+        if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
 
@@ -673,7 +673,7 @@ def main():
                 sequence_length=data_args.max_seq_length,
             )
 
-        calib_dataloader = trainer.get_train_dataloader()
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
         inc_quantizer = IncQuantizer(
             model, q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/inc/pytorch/token-classification/run_ner.py
+++ b/examples/inc/pytorch/token-classification/run_ner.py
@@ -718,8 +718,6 @@ def main():
 
     inc_optimizer = IncOptimizer(model, quantizer=quantizer, pruner=pruner)
     opt_model = inc_optimizer.fit()
-
-    _, sparsity = opt_model.report_sparsity()
     result_opt_model = take_eval_steps(opt_model.model, trainer, metric_name, save_metrics=True)
 
     trainer.save_model(training_args.output_dir)
@@ -727,8 +725,8 @@ def main():
         yaml.dump(opt_model.tune_cfg, f, default_flow_style=False)
 
     logger.info(
-        f"Optimized model with final sparsity of {sparsity} and {metric_name} of {result_opt_model} saved to: "
-        f"{training_args.output_dir}. Original model had an {metric_name} of {result_baseline_model}"
+        f"Optimized model with {metric_name} of {result_opt_model} saved to: {training_args.output_dir}."
+        f" Original model had an {metric_name} of {result_baseline_model}."
     )
 
     if optim_args.quantize and optim_args.verify_loading:

--- a/tests/intel/test_inc.py
+++ b/tests/intel/test_inc.py
@@ -15,9 +15,8 @@
 import os
 import tempfile
 import unittest
-import numpy as np
-import yaml
 
+import numpy as np
 from datasets import load_dataset, load_metric
 from transformers import (
     AutoModelForSequenceClassification,
@@ -28,25 +27,25 @@ from transformers import (
     default_data_collator,
 )
 from transformers.utils.fx import symbolic_trace
+
+import yaml
 from optimum.intel.neural_compressor import IncOptimizer, IncPruner, IncQuantizer, IncTrainer
 from optimum.intel.neural_compressor.config import IncPruningConfig, IncQuantizationConfig
+from optimum.intel.neural_compressor.pruning import IncPrunerForSequenceClassification
 from optimum.intel.neural_compressor.quantization import (
     IncQuantizationMode,
     IncQuantizedModelForSequenceClassification,
     IncQuantizer,
     IncQuantizerForSequenceClassification,
-
 )
-from optimum.intel.neural_compressor.pruning import IncPrunerForSequenceClassification
-from optimum.intel.neural_compressor.utils import CONFIG_NAME
 from optimum.intel.neural_compressor.trainer_inc import IncTrainer
+from optimum.intel.neural_compressor.utils import CONFIG_NAME
 
 
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 
 class TestINCQuantization(unittest.TestCase):
-
     def test_quantizer_from_config(self):
         model_name = "bert-base-uncased"
         config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "quantization.yml")


### PR DESCRIPTION
In this PR we fix broken links in examples readme files, remove the sparsity computation in the examples scripts as the latter is incompatible with static and aware training quantization and change the default value of calibration dataloader to None when the quantization applied is different from static quantization. 