### PR TITLE
Add list of the types of operators to quantize to ORT quantization

### DIFF
--- a/examples/onnxruntime/pytorch/question-answering/run_qa.py
+++ b/examples/onnxruntime/pytorch/question-answering/run_qa.py
@@ -737,6 +737,9 @@ def main():
         onnx_config = optimizer.onnx_config
         opt_model_path = output_dir.joinpath("model-optimized.onnx")
 
+    # Save the ONNX Runtime configuration
+    ort_config.save_pretrained(training_args.output_dir)
+
     # Evaluation
     if training_args.do_eval:
         logger.info("*** Evaluate ***")

--- a/examples/onnxruntime/pytorch/text-classification/run_glue.py
+++ b/examples/onnxruntime/pytorch/text-classification/run_glue.py
@@ -652,6 +652,9 @@ def main():
         onnx_config = optimizer.onnx_config
         opt_model_path = output_dir.joinpath("model-optimized.onnx")
 
+    # Save the ONNX Runtime configuration
+    ort_config.save_pretrained(training_args.output_dir)
+    
     # Evaluation
     if training_args.do_eval:
         logger.info("*** Evaluate ***")

--- a/examples/onnxruntime/pytorch/text-classification/run_glue.py
+++ b/examples/onnxruntime/pytorch/text-classification/run_glue.py
@@ -654,7 +654,7 @@ def main():
 
     # Save the ONNX Runtime configuration
     ort_config.save_pretrained(training_args.output_dir)
-    
+
     # Evaluation
     if training_args.do_eval:
         logger.info("*** Evaluate ***")

--- a/examples/onnxruntime/pytorch/token-classification/run_ner.py
+++ b/examples/onnxruntime/pytorch/token-classification/run_ner.py
@@ -688,6 +688,9 @@ def main():
         onnx_config = optimizer.onnx_config
         opt_model_path = output_dir.joinpath("model-optimized.onnx")
 
+    # Save the ONNX Runtime configuration
+    ort_config.save_pretrained(training_args.output_dir)
+    
     # Evaluation
     if training_args.do_eval:
         logger.info("*** Evaluate ***")

--- a/examples/onnxruntime/pytorch/token-classification/run_ner.py
+++ b/examples/onnxruntime/pytorch/token-classification/run_ner.py
@@ -690,7 +690,7 @@ def main():
 
     # Save the ONNX Runtime configuration
     ort_config.save_pretrained(training_args.output_dir)
-    
+
     # Evaluation
     if training_args.do_eval:
         logger.info("*** Evaluate ***")

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -78,10 +78,12 @@ class ORTConfig(BaseConfig):
             Maximum number of examples to use for the calibration step resulting from static quantization.
         calib_batch_size (`int`, `optional`, defaults to 8):
             The batch size to use for the calibration step resulting from static quantization.
+        op_types_to_quantize (`List`, `optional`):
+            List of the types of operators to quantize. By default, all the supported operators are quantized.
         nodes_to_quantize (`List`, `optional`):
-            List of nodes names to quantize.
+            List of the nodes names to quantize.
         nodes_to_exclude (`List`, `optional`):
-            List of nodes names to exclude when applying quantization.
+            List of the nodes names to exclude when applying quantization.
         extra_options (`Dict[str, Any]`, `optional`):
             The dictionary mapping each extra options to the desired value, such as :
                 ActivationSymmetric (`bool`, `optional`, defaults to `False`):
@@ -135,6 +137,7 @@ class ORTConfig(BaseConfig):
         calib_batch_size: Optional[int] = 8,
         seed: Optional[int] = 42,
         use_external_data_format: Optional[bool] = False,
+        op_types_to_quantize: Optional[List] = None,
         nodes_to_quantize: Optional[List] = None,
         nodes_to_exclude: Optional[List] = None,
         extra_options: Optional[Dict[str, Any]] = None,
@@ -156,6 +159,7 @@ class ORTConfig(BaseConfig):
         self.calib_batch_size = calib_batch_size
         self.seed = seed
         self.use_external_data_format = use_external_data_format
+        self.op_types_to_quantize = op_types_to_quantize
         self.nodes_to_quantize = nodes_to_quantize
         self.nodes_to_exclude = nodes_to_exclude
         self.extra_options = extra_options

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -238,8 +238,12 @@ class ORTQuantizer:
                 reduce_range=self.ort_config.reduce_range,
                 activation_type=self.activation_type,
                 weight_type=self.weight_type,
+                op_types_to_quantize=self.ort_config.op_types_to_quantize,
+                nodes_to_quantize=self.ort_config.nodes_to_quantize,
+                nodes_to_exclude=self.ort_config.nodes_to_exclude,
                 optimize_model=self.ort_config.optimize_model,
                 use_external_data_format=self.ort_config.use_external_data_format,
+                extra_options=self.ort_config.extra_options,
             )
         elif self.quantization_approach == ORTQuantizationMode.STATIC:
             calib_dataset = self.calib_dataset if self.calib_dataset is not None else self.get_calib_dataset()
@@ -254,11 +258,12 @@ class ORTQuantizer:
                 reduce_range=self.ort_config.reduce_range,
                 activation_type=self.activation_type,
                 weight_type=self.weight_type,
-                optimize_model=self.ort_config.optimize_model,
-                use_external_data_format=self.ort_config.use_external_data_format,
-                calibrate_method=self.calibrate_method,
+                op_types_to_quantize=self.ort_config.op_types_to_quantize,
                 nodes_to_quantize=self.ort_config.nodes_to_quantize,
                 nodes_to_exclude=self.ort_config.nodes_to_exclude,
+                calibrate_method=self.calibrate_method,
+                optimize_model=self.ort_config.optimize_model,
+                use_external_data_format=self.ort_config.use_external_data_format,
                 extra_options=self.ort_config.extra_options,
             )
         else:


### PR DESCRIPTION
In this PR we add the list of the types of operators to quantize `op_types_to_quantize` as argument to when applying an ONNX Runtime quantization. We also add the saving of the ORT configuration in the examples scripts.