### PR TITLE
Add moving average computation of the minimum and maximum when applyi…

### DIFF
--- a/examples/onnxruntime/pytorch/question-answering/run_qa.py
+++ b/examples/onnxruntime/pytorch/question-answering/run_qa.py
@@ -690,6 +690,9 @@ def main():
         max_samples=optim_args.max_calib_samples,
         calib_batch_size=training_args.per_device_eval_batch_size,
         seed=training_args.seed,
+        extra_options={
+            "CalibMovingAverage": True
+        },  # activations quantization parameters will be computed using the moving average of the minimum and maximum
     )
 
     eval_dataloader = trainer.get_eval_dataloader(eval_dataset)

--- a/examples/onnxruntime/pytorch/text-classification/run_glue.py
+++ b/examples/onnxruntime/pytorch/text-classification/run_glue.py
@@ -599,6 +599,9 @@ def main():
         max_samples=optim_args.max_calib_samples,
         calib_batch_size=training_args.per_device_eval_batch_size,
         seed=training_args.seed,
+        extra_options={
+            "CalibMovingAverage": True
+        },  # activations quantization parameters will be computed using the moving average of the minimum and maximum
     )
 
     eval_dataloader = trainer.get_eval_dataloader()

--- a/examples/onnxruntime/pytorch/token-classification/run_ner.py
+++ b/examples/onnxruntime/pytorch/token-classification/run_ner.py
@@ -643,6 +643,9 @@ def main():
         max_samples=optim_args.max_calib_samples,
         calib_batch_size=training_args.per_device_eval_batch_size,
         seed=training_args.seed,
+        extra_options={
+            "CalibMovingAverage": True
+        },  # activations quantization parameters will be computed using the moving average of the minimum and maximum
     )
 
     eval_dataloader = trainer.get_eval_dataloader()

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -113,6 +113,13 @@ class ORTConfig(BaseConfig):
                 QDQOpTypePerChannelSupportToAxis (`Dict`, `optional`, defaults to `{}`):
                     Set the channel axis for a specific op type. Effective only when per channel quantization is
                     supported and per_channel is set to True.
+                CalibMovingAverage (`bool`, `optional`, defaults to `False`):
+                    If enabled, the moving average of the minimum and maximum values will be computed when the
+                    calibration method selected is MinMax.
+                CalibMovingAverage (`float`, `optional`, defaults to `0.01`):
+                    Constant smoothing factor to use when computing the moving average of the minimum and maximum
+                    values. Effective only when the calibration method selected is MinMax and when CalibMovingAverage
+                    is set to True.
     """
 
     CONFIG_NAME = "ort_config.json"


### PR DESCRIPTION
In this PR we apply a variant of the min max calibration method when static quantization is applied. The latter computes the exponential moving average of the minimum and maximum values instead of the global minimum and maximum. This can be useful when the calibration datasets is composed of a large number of examples, in which case the activations quantization ranges will increase with the number of examples, resulting in a drop in precision which could lead to an important accuracy drop.