### PR TITLE
Use main branch as default "version" when building docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -69,9 +69,8 @@ jobs:
 
       - name: Make documentation
         run: |
-          version=$(pip show optimum | grep Version | cut -c 10-20) &&
           cd doc-builder &&
-          doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version $version --html &&
+          doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version main --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656


### PR DESCRIPTION
# What does this PR do?

In #86 I built the docs with the `optimum` version number, but in general we'll want to have the docs reflect the state on the `main` branch. This PR does that and once we have integrated the rest of the API docs, we can revisit setting the version number with future releases.

cc @mishig25 