### PR TITLE
Use sudo for doc builder installs

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -48,7 +48,7 @@ jobs:
           cd ..
 
           cd optimum
-          apt install -y libopencv-dev python3-opencv
+          sudo apt-get install -y libopencv-dev python3-opencv
           pip install .[dev,onnxruntime,intel]
           cd ..
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           pip install git+https://github.com/huggingface/doc-builder
           cd optimum
-          apt install -y libopencv-dev python3-opencv
+          sudo apt-get install -y libopencv-dev python3-opencv
           pip install .[dev,onnxruntime,intel]
           cd ..
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a problem introduced in #100 where we need to install `opencv` in the same env as the `intel-neural-compressor`. Installing this on the `main` branch requires `sudo`.

This doesn't touch any other parts of the codebase, so I'm going to do a quick merge if the CI passes

cc @echarlaix 

