### PR TITLE
Fix protobuf dependency in doc build

### DIFF
--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -49,6 +49,7 @@ jobs:
 
           cd optimum
           sudo apt install -y libopencv-dev python3-opencv
+          pip install --upgrade protobuf
           pip install .[dev,onnxruntime,intel]
           cd ..
 
@@ -66,23 +67,23 @@ jobs:
           message: 'The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/optimum/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.'
           GITHUB_TOKEN: ${{ env.WRITE }}
 
-#      - name: Find Comment
-#        if: github.event.action == 'reopened'
-#        uses: peter-evans/find-comment@v1
-#        id: fc
-#        with:
-#          issue-number: ${{ env.PR_NUMBER }}
-#          comment-author: HuggingFaceDocBuilder
+      - name: Find Comment
+        if: github.event.action == 'reopened'
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: HuggingFaceDocBuilderDev
 
-#      - name: Update comment
-#        if: github.event.action == 'reopened'
-#        uses: peter-evans/create-or-update-comment@v1
-#        with:
-#          comment-id: ${{ steps.fc.outputs.comment-id }}
-#          token: ${{ env.WRITE }}
-#          edit-mode: replace
-#          body: |
-#            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/optimum/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
+      - name: Update comment
+        if: github.event.action == 'reopened'
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ env.WRITE }}
+          edit-mode: replace
+          body: |
+            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
 
       - name: Make documentation
         env:

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -49,7 +49,7 @@ jobs:
 
           cd optimum
           sudo apt install -y libopencv-dev python3-opencv
-          pip install --upgrade protobuf
+          sudo pip install --upgrade protobuf
           pip install .[dev,onnxruntime,intel]
           cd ..
 

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -83,7 +83,7 @@ jobs:
           token: ${{ env.WRITE }}
           edit-mode: replace
           body: |
-            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
+            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/optimum/pr_${{ env.PR_NUMBER }}). All of your documentation changes will be reflected on that endpoint.
 
       - name: Make documentation
         env:

--- a/.github/workflows/build_dev_documentation.yml
+++ b/.github/workflows/build_dev_documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_package:
     runs-on: ubuntu-latest
     container:
-      image: huggingface/transformers-doc-builder # Not sure if we can also use this image for optimum
+      image: huggingface/transformers-doc-builder
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
@@ -48,8 +48,8 @@ jobs:
           cd ..
 
           cd optimum
-          sudo apt install -y libopencv-dev python3-opencv
-          sudo pip install --upgrade protobuf
+          apt install -y libopencv-dev python3-opencv
+          pip install --upgrade protobuf
           pip install .[dev,onnxruntime,intel]
           cd ..
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -50,7 +50,7 @@ jobs:
           pip install git+https://github.com/huggingface/doc-builder
           cd optimum
           sudo apt install -y libopencv-dev python3-opencv
-          pip install --upgrade protobuf
+          sudo pip install --upgrade protobuf
           pip install .[dev,onnxruntime,intel]
           cd ..
 

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -35,12 +35,6 @@ jobs:
           repository: 'huggingface/optimum'
           path: optimum
 
-      # - uses: actions/checkout@v2
-      #   with:
-      #     repository: 'huggingface/notebooks'
-      #     path: notebooks
-      #     token: ${{ secrets.HUGGINGFACE_PUSH }}
-
       - name: Loading cache.
         uses: actions/cache@v2
         id: cache
@@ -56,6 +50,7 @@ jobs:
           pip install git+https://github.com/huggingface/doc-builder
           cd optimum
           sudo apt install -y libopencv-dev python3-opencv
+          pip install --upgrade protobuf
           pip install .[dev,onnxruntime,intel]
           cd ..
 


### PR DESCRIPTION
# What does this PR do?

This PR attempts to fix a `module 'google.protobuf.descriptor' has no attribute '_internal_create_key'` error in the doc build on the `main` branch. According to [this SO answer](https://stackoverflow.com/questions/61922334/how-to-solve-attributeerror-module-google-protobuf-descriptor-has-no-attribu), the solution is to simply upgrade `protobuf`. 

This PR also re-instates the checks to auto-update the docs on changes to the PR. As this doesn't touch any other parts of the codebase, I'll do a merge once the CI passes.

cc @echarlaix 

