### PR TITLE
ONNX weight sharing

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -119,7 +119,12 @@ def fix_atenops_to_gather(model_path):
 def _find_duplicate_weights(model) -> DefaultDict[Tuple[int, bytes], Set[str]]:
     duplicates = defaultdict(set)
     for initializer in model.graph.initializer:
-        duplicates[(initializer.data_type, initializer.raw_data)].add(initializer.name)
+        for data_attr in ["raw_data", "int32_data", "int64_data", "uint64_data", "float_data", "double_data"]:
+            tensor_data = getattr(initializer, data_attr)
+            if tensor_data:
+                tensor_data = tuple(tensor_data)
+                break
+        duplicates[(initializer.data_type, tensor_data)].add(initializer.name)
     return duplicates
 
 

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Dict, List, Option
 from transformers.utils import logging
 
 import onnx
+from onnx import ModelProto
 
 
 logger = logging.get_logger(__name__)
@@ -137,13 +138,13 @@ def _create_name_sharing_dict(duplicate_weights: Dict[str, Set[str]]) -> Dict[st
     return name_sharing_dict
 
 
-def _replace_input_names(model, name_sharing_dict):
+def _replace_input_names(model: ModelProto, name_sharing_dict: Dict[str, str]):
     for node in model.graph.node:
         for i in range(len(node.input)):
             node.input[i] = name_sharing_dict.get(node.input[i], node.input[i])
 
 
-def _remove_redundant_initializers(model, name_sharing_dict):
+def _remove_redundant_initializers(model: ModelProto, name_sharing_dict: Dict[str, str]):
     to_pop = []
     for idx, initializer in enumerate(model.graph.initializer):
         if initializer.name != name_sharing_dict[initializer.name]:
@@ -152,7 +153,7 @@ def _remove_redundant_initializers(model, name_sharing_dict):
         model.graph.initializer.pop(idx - i)
 
 
-def remove_duplicate_weights(model, inplace: bool = False):
+def remove_duplicate_weights(model: ModelProto, inplace: bool = False) -> ModelProto:
     if not inplace:
         model = copy.deepcopy(model)
     duplicates = _find_duplicate_weights(model)

--- a/tests/onnxruntime/test_onnx.py
+++ b/tests/onnxruntime/test_onnx.py
@@ -1,0 +1,58 @@
+#  Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+import numpy as np
+import torch
+from onnxruntime import InferenceSession
+from transformers import AutoTokenizer, AutoModel
+from transformers.models.albert import AlbertOnnxConfig
+from transformers.onnx import export
+from onnx import load as onnx_load
+from optimum.onnxruntime.utils import remove_duplicate_weights
+
+
+class WeightSharingTestCase(TestCase):
+
+    def test_weight_sharing_output_match(self):
+        with torch.no_grad():
+            for model in {"albert-base-v1", "albert-base-v2"}:
+                tokenizer = AutoTokenizer.from_pretrained(model)
+                model = AutoModel.from_pretrained(model)
+                onnx_config = AlbertOnnxConfig.from_model_config(model.config)
+
+                with NamedTemporaryFile("w+b") as original_onnx_f:
+                    export(tokenizer, model, onnx_config, opset=12, output=Path(original_onnx_f.name))
+
+                    original_albert_ir = onnx_load(original_onnx_f)
+                    compressed_albert_ir = remove_duplicate_weights(original_albert_ir, inplace=False)
+                    compressed_albert_session = InferenceSession(
+                        compressed_albert_ir.SerializeToString(),
+                        providers=["CPUExecutionProvider"]
+                    )
+
+                original_outputs = model(**tokenizer("Hello from Hugging Face", return_tensors="pt"))
+                compressed_outputs = compressed_albert_session.run(
+                    None, dict(tokenizer("Hello from Hugging Face", return_tensors="np"))
+                )
+
+            self.assertTrue(np.allclose(original_outputs.last_hidden_state.cpu().numpy(), compressed_outputs[0], atol=1e-4))
+            self.assertTrue(np.allclose(original_outputs.pooler_output.cpu().numpy(), compressed_outputs[1], atol=1e-4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

This PR adds a transformation on ONNX models that scans for weights that are shared (or exact duplicates) and prunes all the redundancy. The resulting model ends up smaller, and the computation remains unchanged.

This can be useful for models such as Albert.