### PR TITLE
[ORTTrainer] Fix to be compatible with onnxruntime 1.11.0

### DIFF
--- a/examples/onnxruntime/training/token-classification/run_ner.py
+++ b/examples/onnxruntime/training/token-classification/run_ner.py
@@ -352,6 +352,10 @@ def main():
         use_auth_token=True if model_args.use_auth_token else None,
     )
 
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+        model.config.pad_token_id = model.config.eos_token_id
+
     # Tokenizer check: this script requires a fast tokenizer.
     if not isinstance(tokenizer, PreTrainedTokenizerFast):
         raise ValueError(

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1239,7 +1239,8 @@ class ORTTrainer(Trainer):
             loss = self.label_smoother(outputs, labels)
         else:
             # We don't use .loss here since the model may return tuples instead of ModelOutput.
-            loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
+            # loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
+            loss = outputs[0]
 
         return (loss, outputs) if return_outputs else loss
 

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -648,6 +648,20 @@ class ORTTrainer(Trainer):
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
     ) -> Dict[str, float]:
+        try:
+            return self.evaluate_ort(eval_dataset, ignore_keys, metric_key_prefix)
+        except:
+            logger.warning(
+                f"Unable to do inference within ONNX Runtime for {self.model.config.name_or_path} model. Evaluate with PyTorch backend instead."
+            )
+            return super().evaluate(eval_dataset, ignore_keys, metric_key_prefix)
+
+    def evaluate_ort(
+        self,
+        eval_dataset: Optional[Dataset] = None,
+        ignore_keys: Optional[List[str]] = None,
+        metric_key_prefix: str = "eval",
+    ) -> Dict[str, float]:
         """
         Run evaluation within ONNX Runtime backend and returns metrics.(Overriden from `Trainer.evaluate()`)
         """
@@ -691,6 +705,17 @@ class ORTTrainer(Trainer):
         return output.metrics
 
     def predict(
+        self, test_dataset: Dataset, ignore_keys: Optional[List[str]] = None, metric_key_prefix: str = "test"
+    ) -> PredictionOutput:
+        try:
+            return self.predict_ort(test_dataset, ignore_keys, metric_key_prefix)
+        except:
+            logger.warning(
+                f"Unable to do inference within ONNX Runtime for {self.model.config.name_or_path} model. Predict with PyTorch backend instead."
+            )
+            return super().predict(test_dataset, ignore_keys, metric_key_prefix)
+
+    def predict_ort(
         self, test_dataset: Dataset, ignore_keys: Optional[List[str]] = None, metric_key_prefix: str = "test"
     ) -> PredictionOutput:
         """

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -741,6 +741,8 @@ class ORTTrainer(Trainer):
         if self.onnx_model_path:
             logger.info("------------------Evaluate with given ONNX IR----------------------")
             self.onnx_model_path = Path(self.onnx_model_path).as_posix()
+            fix_atenops_to_gather(self.onnx_model_path)
+            logger.info("The ONNX IR is store in:\n", self.onnx_model_path)
         else:
             onnx_model_path = Path(
                 os.path.join(self.args.output_dir, self.model.config.name_or_path.split("/")[-1] + ".onnx")
@@ -948,6 +950,8 @@ class ORTTrainer(Trainer):
         if self.onnx_model_path:
             # Evaluate an ONNX model
             self.onnx_model_path = Path(self.onnx_model_path).as_posix()
+            fix_atenops_to_gather(self.onnx_model_path)
+            logger.info("The ONNX IR is store in:\n", self.onnx_model_path)
         else:
             # Export a PyTorch model for ONNNX Runtime evaluation
             onnx_model_path = Path(

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1222,7 +1222,6 @@ class ORTTrainer(Trainer):
 
         input_feed = dict(map(lambda input_name: (input_name, inputs[input_name].cpu().numpy()), input_names))
         outputs = self.infer_sess.run(output_names, input_feed)
-        # outputs[0] = torch.Tensor(outputs[0])
         loss = None
         # Save past state if it exists
         # TODO: this needs to be fixed and made cleaner later.

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -678,12 +678,9 @@ class ORTTrainer(Trainer):
                 logger.error(error)
                 raise
         else:
-            logger.info(
-                f"Evaluating with PyTorch backend. If you want to use ONNX Runtime for the evaluation, set `trainer.evaluate(inference_with_ort=True)`."
+            logger.warning(
+                "[INFO] Evaluating with PyTorch backend. If you want to use ONNX Runtime for the evaluation, set `trainer.evaluate(inference_with_ort=True)`."
             )
-            # Correct device changed by the try
-            # if torch.cuda.is_available():
-            #     self.model.to("cuda")
             eval_loop = self.prediction_loop if self.args.use_legacy_prediction_loop else self.evaluation_loop
             output = eval_loop(
                 eval_dataloader,
@@ -751,8 +748,8 @@ class ORTTrainer(Trainer):
                 logger.error(error)
                 raise
         else:
-            logger.info(
-                f"Predicting with PyTorch backend. If you want to use ONNX Runtime for the prediction, set `trainer.predict(inference_with_ort=True)`."
+            logger.warning(
+                "[INFO] Predicting with PyTorch backend. If you want to use ONNX Runtime for the prediction, set `trainer.predict(inference_with_ort=True)`."
             )
             # Correct device changed by the try
             # if torch.cuda.is_available():

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -130,7 +130,7 @@ class Seq2SeqORTTrainer(ORTTrainer):
             logger.error(
                 f"[ERROR!] Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`."
             )
-            raise
+            raise NotImplementedError("Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`.")
         return super().predict(
             test_dataset,
             ignore_keys=ignore_keys,

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -68,17 +68,18 @@ class Seq2SeqORTTrainer(ORTTrainer):
             num_beams (:obj:`int`, `optional`):
                 Number of beams for beam search that will be used when predicting with the generate method. 1 means no
                 beam search.
+            inference_with_ort (:obj:`bool`, `optional`):
+                Whether enable inference within ONNX Runtime backend. The inference will be done within PyTorch by default.
         Returns:
-            A dictionary containing the evaluation loss and the potential metrics computed from the predictions. The
+            A dictionary containing the evaluation loss(only within PyTorch) and the potential metrics computed from the predictions. The
             dictionary also contains the epoch number which comes from the training state.
         """
         self._max_length = max_length
         self._num_beams = num_beams
         if self.args.predict_with_generate and inference_with_ort:
-            logger.error(
-                f"[ERROR!] Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`."
+            raise NotImplementedError(
+                "Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`."
             )
-            raise
         return super().evaluate(
             eval_dataset,
             ignore_keys=ignore_keys,
@@ -114,6 +115,8 @@ class Seq2SeqORTTrainer(ORTTrainer):
             num_beams (:obj:`int`, `optional`):
                 Number of beams for beam search that will be used when predicting with the generate method. 1 means no
                 beam search.
+            inference_with_ort (:obj:`bool`, `optional`):
+                Whether enable inference within ONNX Runtime backend. The inference will be done within PyTorch by default.
         .. note::
             If your predictions or labels have different sequence lengths (for instance because you're doing dynamic
             padding in a token classification task) the predictions will be padded (on the right) to allow for
@@ -127,10 +130,9 @@ class Seq2SeqORTTrainer(ORTTrainer):
         self._max_length = max_length
         self._num_beams = num_beams
         if self.args.predict_with_generate and inference_with_ort:
-            logger.error(
-                f"[ERROR!] Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`."
+            raise NotImplementedError(
+                "Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`."
             )
-            raise NotImplementedError("Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`.")
         return super().predict(
             test_dataset,
             ignore_keys=ignore_keys,
@@ -152,6 +154,8 @@ class Seq2SeqORTTrainer(ORTTrainer):
         Args:
             model (:obj:`nn.Module`):
                 The model to evaluate.
+            infer_sess (:obj:`onnxruntime.InferenceSession`):
+                The inference session of ONNX Runtime.
             inputs (:obj:`Dict[str, Union[torch.Tensor, Any]]`):
                 The inputs and targets of the model.
                 The dictionary will be unpacked before being fed to the model. Most models expect the targets under the
@@ -159,7 +163,7 @@ class Seq2SeqORTTrainer(ORTTrainer):
             prediction_loss_only (:obj:`bool`):
                 Whether or not to return the loss only.
         Return:
-            Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]: A tuple with the loss, logits and
+            Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]: A tuple with the loss=None, logits and
             labels (each being optional).
         """
 
@@ -169,7 +173,7 @@ class Seq2SeqORTTrainer(ORTTrainer):
             )
 
         logger.warning(
-            f"`predict_with_generate` is not available with ONNX Runtime inference for the moment. Evaluated with PyTorch backend instead."
+            "`predict_with_generate` is not available with ONNX Runtime inference for the moment. Evaluated with PyTorch backend instead."
         )
 
         has_labels = "labels" in inputs

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The HuggingFace Team. All rights reserved.
+# Copyright 2022 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import torch
 from packaging import version
 from torch import nn
 from torch.utils.data.dataset import Dataset
+from transformers.deepspeed import is_deepspeed_zero3_enabled
 
 # from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.trainer_utils import PredictionOutput
@@ -145,16 +146,18 @@ class Seq2SeqORTTrainer(ORTTrainer):
                 model, infer_sess, inputs, prediction_loss_only=prediction_loss_only, ignore_keys=ignore_keys
             )
 
+        logger.warning(
+            f"`predict_with_generate` is not available with ONNX Runtime inference for the moment. Evaluated with PyTorch backend instead."
+        )
+
         has_labels = "labels" in inputs
         inputs = self._prepare_inputs(inputs)
-        output_names = [output.name for output in infer_sess._outputs_meta]
-        input_names = [ort_input.name for ort_input in infer_sess._inputs_meta]
 
         # XXX: adapt synced_gpus for fairscale as well
         gen_kwargs = {
             "max_length": self._max_length if self._max_length is not None else self.model.config.max_length,
             "num_beams": self._num_beams if self._num_beams is not None else self.model.config.num_beams,
-            "synced_gpus": False,  # "synced_gpus": True if is_deepspeed_zero3_enabled() else False,
+            "synced_gpus": True if is_deepspeed_zero3_enabled() else False,
         }
 
         if "attention_mask" in inputs:
@@ -168,8 +171,8 @@ class Seq2SeqORTTrainer(ORTTrainer):
         else:
             generation_inputs = inputs[self.model.main_input_name]
 
-        if generation_inputs.device is not self.model.device:
-            self.model.to(generation_inputs.device)
+        if torch.cuda.is_available():
+            self.model.to("cuda")
 
         generated_tokens = self.model.generate(
             generation_inputs,
@@ -181,52 +184,24 @@ class Seq2SeqORTTrainer(ORTTrainer):
 
         with torch.no_grad():
             with self.autocast_smart_context_manager():
-                try:
-                    available_input_names = list(set(input_names) & set(inputs.keys()))
-                    input_feed = dict(
-                        map(lambda input_name: (input_name, inputs[input_name].cpu().numpy()), available_input_names)
-                    )
-                    if ("decoder_attention_mask" in input_names) and ("decoder_attention_mask" not in inputs.keys()):
-                        decoder_input_ids = inputs["decoder_input_ids"].cpu()
-                        decoder_attention_mask = np.concatenate(
-                            [
-                                np.ones(decoder_input_ids[:, :1].shape, np.int64),
-                                np.where(decoder_input_ids[:, 1:] != self.model.config.pad_token_id, 1, 0),
-                            ],
-                            axis=-1,
-                        )
-                        input_feed["decoder_attention_mask"] = decoder_attention_mask
-                    outputs = self.infer_sess.run(output_names, input_feed)
-                except:
-                    logger.warning(
-                        f"Unable to do inference within ONNX Runtime for {self.model.config.name_or_path} model. Evaluate with PyTorch backend instead."
-                    )
-                    logger.info(
-                        "ORT evaluation aborted, evaluate with pytorch. Check if you have every demanded input element."
-                    )
-                    outputs = model(**inputs)
-
+                outputs = model(**inputs)
             if has_labels:
                 if self.label_smoother is not None:
                     loss = self.label_smoother(outputs, inputs["labels"]).mean().detach()
                 else:
-                    if isinstance(outputs, dict):
-                        loss = outputs["loss"].mean().detach()
-                    else:
-                        loss = (
-                            outputs[0].mean().detach()
-                            if isinstance(outputs[0].mean(), torch.Tensor)
-                            else torch.tensor(outputs[0].mean())
-                        )
+                    loss = (outputs["loss"] if isinstance(outputs, dict) else outputs[0]).mean().detach()
             else:
                 loss = None
 
         if self.args.prediction_loss_only:
             return (loss, None, None)
 
-        labels = inputs["labels"]
-        if labels.shape[-1] < gen_kwargs["max_length"]:
-            labels = self._pad_tensors_to_max_len(labels, gen_kwargs["max_length"])
+        if has_labels:
+            labels = inputs["labels"]
+            if labels.shape[-1] < gen_kwargs["max_length"]:
+                labels = self._pad_tensors_to_max_len(labels, gen_kwargs["max_length"])
+        else:
+            labels = None
 
         return (loss, generated_tokens, labels)
 

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -74,6 +74,11 @@ class Seq2SeqORTTrainer(ORTTrainer):
         """
         self._max_length = max_length
         self._num_beams = num_beams
+        if self.args.predict_with_generate and inference_with_ort:
+            logger.error(
+                f"[ERROR!] Generate method is not available with prediction within ONNX Runtime. Remove `inference_with_ort` or `predict_with_generate`."
+            )
+            raise
         return super().evaluate(
             eval_dataset,
             ignore_keys=ignore_keys,
@@ -190,6 +195,87 @@ class Seq2SeqORTTrainer(ORTTrainer):
 
         if torch.cuda.is_available():
             self.model.to("cuda")
+
+        generated_tokens = self.model.generate(
+            generation_inputs,
+            **gen_kwargs,
+        )
+        # in case the batch is shorter than max length, the output should be padded
+        if generated_tokens.shape[-1] < gen_kwargs["max_length"]:
+            generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_kwargs["max_length"])
+
+        with torch.no_grad():
+            with self.autocast_smart_context_manager():
+                outputs = model(**inputs)
+            if has_labels:
+                if self.label_smoother is not None:
+                    loss = self.label_smoother(outputs, inputs["labels"]).mean().detach()
+                else:
+                    loss = (outputs["loss"] if isinstance(outputs, dict) else outputs[0]).mean().detach()
+            else:
+                loss = None
+
+        if self.args.prediction_loss_only:
+            return (loss, None, None)
+
+        if has_labels:
+            labels = inputs["labels"]
+            if labels.shape[-1] < gen_kwargs["max_length"]:
+                labels = self._pad_tensors_to_max_len(labels, gen_kwargs["max_length"])
+        else:
+            labels = None
+
+        return (loss, generated_tokens, labels)
+
+    def prediction_step(
+        self,
+        model: nn.Module,
+        inputs: Dict[str, Union[torch.Tensor, Any]],
+        prediction_loss_only: bool,
+        ignore_keys: Optional[List[str]] = None,
+    ) -> Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """
+        Perform an evaluation step on `model` using `inputs`.
+        Subclass and override to inject custom behavior.
+        Args:
+            model (`nn.Module`):
+                The model to evaluate.
+            inputs (`Dict[str, Union[torch.Tensor, Any]]`):
+                The inputs and targets of the model.
+                The dictionary will be unpacked before being fed to the model. Most models expect the targets under the
+                argument `labels`. Check your model's documentation for all accepted arguments.
+            prediction_loss_only (`bool`):
+                Whether or not to return the loss only.
+        Return:
+            Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]: A tuple with the loss, logits and
+            labels (each being optional).
+        """
+
+        if not self.args.predict_with_generate or prediction_loss_only:
+            return super().prediction_step(
+                model, inputs, prediction_loss_only=prediction_loss_only, ignore_keys=ignore_keys
+            )
+
+        has_labels = "labels" in inputs
+        inputs = self._prepare_inputs(inputs)
+
+        # XXX: adapt synced_gpus for fairscale as well
+        gen_kwargs = {
+            "max_length": self._max_length if self._max_length is not None else self.model.config.max_length,
+            "num_beams": self._num_beams if self._num_beams is not None else self.model.config.num_beams,
+            "synced_gpus": True if is_deepspeed_zero3_enabled() else False,
+        }
+
+        if "attention_mask" in inputs:
+            gen_kwargs["attention_mask"] = inputs.get("attention_mask", None)
+
+        # prepare generation inputs
+        # some encoder-decoder models can have varying encder's and thus
+        # varying model input names
+        if hasattr(self.model, "encoder") and self.model.encoder.main_input_name != self.model.main_input_name:
+            generation_inputs = inputs[self.model.encoder.main_input_name]
+        else:
+            generation_inputs = inputs[self.model.main_input_name]
 
         generated_tokens = self.model.generate(
             generation_inputs,

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -207,7 +207,11 @@ class Seq2SeqORTTrainer(ORTTrainer):
                 if self.label_smoother is not None:
                     loss = self.label_smoother(outputs, inputs["labels"]).mean().detach()
                 else:
-                    loss = (outputs["loss"] if isinstance(outputs, dict) else outputs[0]).mean().detach()
+                    try:
+                        loss = (outputs["loss"] if isinstance(outputs, dict) else outputs[0]).mean().detach()
+                    except:
+                        loss = (outputs["loss"] if isinstance(outputs, dict) else outputs[0]).mean()
+                        loss = torch.tensor(loss)
             else:
                 loss = None
 

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -211,7 +211,7 @@ class Seq2SeqORTTrainer(ORTTrainer):
                     loss = self.label_smoother(outputs, inputs["labels"]).mean().detach()
                 else:
                     if isinstance(outputs, dict):
-                        loss = outputs["loss"]
+                        loss = outputs["loss"].mean().detach()
                     else:
                         loss = (
                             outputs[0].mean().detach()

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -96,7 +96,8 @@ def fix_atenops_to_gather(model_path):
     nodes = model.graph.node
 
     for node in nodes:
-        if node.op_type == "ATenOp":
+        if node.op_type in ["ATenOp", "ATen"]:
+            # Fix for `onnxruntime.__version__<=1.9.0`
             logger.info(f"----Start fixing node: {node.name}----")
             op_num = node.name.split("_")[-1]
             new_node = onnx.helper.make_node(

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -89,7 +89,6 @@ def generate_identified_filename(filename, identifier):
 
 
 def fix_atenops_to_gather(model_path):
-    # Fix broken ATenOp nodes back to Gather nodes.
     model = onnx.load(model_path)
     onnx.checker.check_model(model)
 

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -89,6 +89,7 @@ def generate_identified_filename(filename, identifier):
 
 
 def fix_atenops_to_gather(model_path):
+    # Fix broken ATenOp nodes back to Gather nodes.
     model = onnx.load(model_path)
     onnx.checker.check_model(model)
 
@@ -96,7 +97,6 @@ def fix_atenops_to_gather(model_path):
 
     for node in nodes:
         if node.op_type in ["ATenOp", "ATen"]:
-            # Fix for `onnxruntime.__version__<=1.9.0`
             logger.info(f"----Start fixing node: {node.name}----")
             op_num = node.name.split("_")[-1]
             new_node = onnx.helper.make_node(

--- a/tests/onnxruntime/test_onnxruntime_train.py
+++ b/tests/onnxruntime/test_onnxruntime_train.py
@@ -86,8 +86,7 @@ class TestORTTrainer(unittest.TestCase):
                             return metric.compute(predictions=predictions, references=eval_pred.label_ids)
 
                         training_args = TrainingArguments(
-                            # output_dir=tmp_dir,
-                            output_dir="./results",
+                            output_dir=tmp_dir,
                             num_train_epochs=1,
                             per_device_train_batch_size=8,
                             per_device_eval_batch_size=8,
@@ -122,7 +121,7 @@ class TestORTTrainer(unittest.TestCase):
     def test_ort_seq2seq_trainer(self):
 
         model_names = {"t5-small", "facebook/bart-base"}  # "t5-small", "facebook/bart-base"
-        dataset_names = {"xsum"}
+        dataset_name = "xsum"
         metric_name = "rouge"
         batch_size = 8
         learning_rate = 2e-5
@@ -131,127 +130,123 @@ class TestORTTrainer(unittest.TestCase):
         if_predict_with_generate = {True, False}
 
         for model_name in model_names:
-            for dataset_name in dataset_names:
-                for predict_with_generate in if_predict_with_generate:
-                    with self.subTest(
-                        model_name=model_name, dataset_name=dataset_name, predict_with_generate=predict_with_generate
-                    ):
-                        with tempfile.TemporaryDirectory() as tmp_dir:
+            for predict_with_generate in if_predict_with_generate:
+                with self.subTest(model_name=model_name, predict_with_generate=predict_with_generate):
+                    with tempfile.TemporaryDirectory() as tmp_dir:
 
-                            # Prepare model
-                            model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
-                            tokenizer = AutoTokenizer.from_pretrained(model_name)
+                        # Prepare model
+                        model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+                        tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-                            # Prepare dataset
-                            dataset = load_dataset(dataset_name)
-                            metric = load_metric(metric_name)
-                            label_pad_token_id = tokenizer.pad_token_id
+                        # Prepare dataset
+                        dataset = load_dataset(dataset_name)
+                        metric = load_metric(metric_name)
+                        label_pad_token_id = tokenizer.pad_token_id
 
-                            if model_name in [
-                                "t5-small",
-                                "t5-base",
-                                "t5-large",
-                                "t5-3b",
-                                "t5-11b",
-                            ] and dataset_name in ["xsum"]:
-                                prefix = "summarize: "
-                            else:
-                                prefix = ""
+                        if model_name in [
+                            "t5-small",
+                            "t5-base",
+                            "t5-large",
+                            "t5-3b",
+                            "t5-11b",
+                        ] and dataset_name in ["xsum"]:
+                            prefix = "summarize: "
+                        else:
+                            prefix = ""
 
-                            max_input_length = 512
-                            max_target_length = 64
+                        max_input_length = 512
+                        max_target_length = 64
 
-                            def preprocess_function(examples):
-                                inputs = [prefix + doc for doc in examples["document"]]
-                                model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
+                        def preprocess_function(examples):
+                            inputs = [prefix + doc for doc in examples["document"]]
+                            model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
 
-                                # Setup the tokenizer for targets
-                                with tokenizer.as_target_tokenizer():
-                                    labels = tokenizer(
-                                        examples["summary"], max_length=max_target_length, truncation=True
-                                    )
+                            # Setup the tokenizer for targets
+                            with tokenizer.as_target_tokenizer():
+                                labels = tokenizer(examples["summary"], max_length=max_target_length, truncation=True)
 
-                                model_inputs["labels"] = labels["input_ids"]
-                                return model_inputs
+                            model_inputs["labels"] = labels["input_ids"]
+                            return model_inputs
 
-                            encoded_dataset = dataset.map(preprocess_function, batched=True)
-                            max_train_samples = 200
-                            max_valid_samples = 50
-                            max_test_samples = 20
-                            train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
-                            valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
-                            test_dataset = encoded_dataset["test"]  # .select(range(max_test_samples))
+                        encoded_dataset = dataset.map(preprocess_function, batched=True)
+                        max_train_samples = 200
+                        max_valid_samples = 50
+                        max_test_samples = 20
+                        train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
+                        valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
+                        test_dataset = encoded_dataset["test"]  # .select(range(max_test_samples))
 
-                            def compute_metrics(eval_pred):
-                                predictions, labels = eval_pred
-                                decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
-                                # Replace -100 in the labels as we can't decode them.
-                                labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
-                                decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+                        def compute_metrics(eval_pred):
+                            predictions, labels = eval_pred
+                            decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+                            # Replace -100 in the labels as we can't decode them.
+                            labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+                            decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
 
-                                # Rouge expects a newline after each sentence
-                                decoded_preds = ["\n".join(nltk.sent_tokenize(pred.strip())) for pred in decoded_preds]
-                                decoded_labels = [
-                                    "\n".join(nltk.sent_tokenize(label.strip())) for label in decoded_labels
-                                ]
+                            # Rouge expects a newline after each sentence
+                            decoded_preds = ["\n".join(nltk.sent_tokenize(pred.strip())) for pred in decoded_preds]
+                            decoded_labels = ["\n".join(nltk.sent_tokenize(label.strip())) for label in decoded_labels]
 
-                                result = metric.compute(
-                                    predictions=decoded_preds, references=decoded_labels, use_stemmer=True
-                                )
-                                # Extract a few results
-                                result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
-
-                                # Add mean generated length
-                                prediction_lens = [
-                                    np.count_nonzero(pred != tokenizer.pad_token_id) for pred in predictions
-                                ]
-                                result["gen_len"] = np.mean(prediction_lens)
-
-                                return {k: round(v, 4) for k, v in result.items()}
-
-                            training_args = Seq2SeqTrainingArguments(
-                                f"{model_name}-finetuned",
-                                evaluation_strategy="epoch",
-                                learning_rate=learning_rate,
-                                per_device_train_batch_size=batch_size,
-                                per_device_eval_batch_size=batch_size,
-                                weight_decay=weight_decay,
-                                save_total_limit=3,
-                                num_train_epochs=num_train_epochs,
-                                predict_with_generate=False,
-                                fp16=True,
-                                do_train=True,
-                                do_eval=True,
-                                label_smoothing_factor=0.1,
+                            result = metric.compute(
+                                predictions=decoded_preds, references=decoded_labels, use_stemmer=True
                             )
+                            # Extract a few results
+                            result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
 
-                            data_collator = DataCollatorForSeq2Seq(
-                                tokenizer,
-                                model=model,
-                                label_pad_token_id=label_pad_token_id,
-                                pad_to_multiple_of=8 if training_args.fp16 else None,
-                            )
+                            # Add mean generated length
+                            prediction_lens = [
+                                np.count_nonzero(pred != tokenizer.pad_token_id) for pred in predictions
+                            ]
+                            result["gen_len"] = np.mean(prediction_lens)
 
-                            trainer = Seq2SeqORTTrainer(
-                                model=model,
-                                args=training_args,
-                                train_dataset=train_dataset if training_args.do_train else None,
-                                eval_dataset=valid_dataset if training_args.do_eval else None,
-                                compute_metrics=compute_metrics if training_args.predict_with_generate else None,
-                                tokenizer=tokenizer,
-                                data_collator=data_collator,
-                                feature="seq2seq-lm",
-                            )
+                            return {k: round(v, 4) for k, v in result.items()}
 
-                            train_result = trainer.train()
-                            trainer.save_model()
-                            train_metrics = train_result.metrics
-                            ort_eval_metrics = trainer.evaluate()
-                            self.assertGreaterEqual(ort_eval_metrics["eval_bleu"], 30)
-                            ort_prediction = trainer.predict(test_dataset)
-                            print("Training metrics(ORT):\n", train_metrics)
-                            print("Evaluation metrics:\n", ort_eval_metrics)
-                            print("Prediction results):\n", ort_prediction)
+                        training_args = Seq2SeqTrainingArguments(
+                            output_dir=tmp_dir,
+                            evaluation_strategy="epoch",
+                            learning_rate=learning_rate,
+                            per_device_train_batch_size=batch_size,
+                            per_device_eval_batch_size=batch_size,
+                            weight_decay=weight_decay,
+                            save_total_limit=3,
+                            num_train_epochs=num_train_epochs,
+                            predict_with_generate=True,
+                            fp16=True,
+                            do_train=True,
+                            do_eval=True,
+                            label_smoothing_factor=0.1,
+                        )
+
+                        data_collator = DataCollatorForSeq2Seq(
+                            tokenizer,
+                            model=model,
+                            label_pad_token_id=label_pad_token_id,
+                            pad_to_multiple_of=8 if training_args.fp16 else None,
+                        )
+
+                        trainer = Seq2SeqORTTrainer(
+                            model=model,
+                            args=training_args,
+                            train_dataset=train_dataset if training_args.do_train else None,
+                            eval_dataset=valid_dataset if training_args.do_eval else None,
+                            compute_metrics=compute_metrics if training_args.predict_with_generate else None,
+                            tokenizer=tokenizer,
+                            data_collator=data_collator,
+                            feature="seq2seq-lm",
+                        )
+
+                        train_result = trainer.train()
+                        trainer.save_model()
+                        train_metrics = train_result.metrics
+                        ort_eval_metrics = trainer.evaluate()
+                        self.assertGreaterEqual(ort_eval_metrics["eval_rouge1"], 10)
+                        self.assertGreaterEqual(ort_eval_metrics["eval_rouge2"], 2)
+                        self.assertGreaterEqual(ort_eval_metrics["eval_rougeL"], 7)
+                        self.assertGreaterEqual(ort_eval_metrics["eval_rougeLsum"], 7)
+                        ort_prediction = trainer.predict(test_dataset)
+                        print("Training metrics(ORT):\n", train_metrics)
+                        print("Evaluation metrics:\n", ort_eval_metrics)
+                        print("Prediction results):\n", ort_prediction)
 
 
 if __name__ == "__main__":

--- a/tests/onnxruntime/test_onnxruntime_train.py
+++ b/tests/onnxruntime/test_onnxruntime_train.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import gc
 import tempfile
 import unittest
 
@@ -38,215 +38,217 @@ class TestORTTrainer(unittest.TestCase):
 
         model_names = {"distilbert-base-uncased", "bert-base-cased", "roberta-base", "gpt2", "facebook/bart-base"}
         dataset_names = {"sst2"}  # glue
+        if_inference_with_ort = {True, False}
 
         for model_name in model_names:
             for dataset_name in dataset_names:
-                with self.subTest(model_name=model_name, dataset_name=dataset_name):
-                    with tempfile.TemporaryDirectory() as tmp_dir:
+                for inference_with_ort in if_inference_with_ort:
+                    with self.subTest(
+                        model_name=model_name, dataset_name=dataset_name, inference_with_ort=inference_with_ort
+                    ):
+                        with tempfile.TemporaryDirectory() as tmp_dir:
 
-                        # Prepare model
-                        model = AutoModelForSequenceClassification.from_pretrained(model_name)
-                        tokenizer = AutoTokenizer.from_pretrained(model_name)
+                            # Prepare model
+                            model = AutoModelForSequenceClassification.from_pretrained(model_name)
+                            tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-                        # Prepare dataset
-                        dataset = load_dataset("glue", dataset_name)
-                        metric = load_metric("glue", dataset_name)
+                            # Prepare dataset
+                            dataset = load_dataset("glue", dataset_name)
+                            metric = load_metric("glue", dataset_name)
 
-                        max_seq_length = min(128, tokenizer.model_max_length)
-                        padding = "max_length"
+                            max_seq_length = min(128, tokenizer.model_max_length)
+                            padding = "max_length"
 
-                        if tokenizer.pad_token is None:
-                            tokenizer.pad_token = tokenizer.eos_token
-                            model.config.pad_token_id = model.config.eos_token_id
+                            if tokenizer.pad_token is None:
+                                tokenizer.pad_token = tokenizer.eos_token
+                                model.config.pad_token_id = model.config.eos_token_id
 
-                        def preprocess_function(examples):
-                            args = (examples["sentence"],)
-                            return tokenizer(*args, padding=padding, max_length=max_seq_length, truncation=True)
+                            def preprocess_function(examples):
+                                args = (examples["sentence"],)
+                                return tokenizer(*args, padding=padding, max_length=max_seq_length, truncation=True)
 
-                        encoded_dataset = dataset.map(preprocess_function, batched=True)
-                        max_train_samples = 200
-                        max_valid_samples = 50
-                        max_test_samples = 20
-                        train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
-                        valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
-                        test_dataset = encoded_dataset["test"].remove_columns(
-                            ["label"]
-                        )  # .select(range(max_test_samples))
+                            encoded_dataset = dataset.map(preprocess_function, batched=True)
+                            max_train_samples = 200
+                            max_valid_samples = 50
+                            max_test_samples = 20
+                            train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
+                            valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
+                            test_dataset = encoded_dataset["test"].remove_columns(
+                                ["label"]
+                            )  # .select(range(max_test_samples))
 
-                        def compute_metrics(eval_pred):
-                            predictions = (
-                                eval_pred.predictions[0]
-                                if isinstance(eval_pred.predictions, tuple)
-                                else eval_pred.predictions
+                            def compute_metrics(eval_pred):
+                                predictions = (
+                                    eval_pred.predictions[0]
+                                    if isinstance(eval_pred.predictions, tuple)
+                                    else eval_pred.predictions
+                                )
+                                if dataset_name != "stsb":
+                                    predictions = np.argmax(predictions, axis=1)
+                                else:
+                                    predictions = predictions[:, 0]
+                                return metric.compute(predictions=predictions, references=eval_pred.label_ids)
+
+                            training_args = TrainingArguments(
+                                output_dir=tmp_dir,
+                                num_train_epochs=1,
+                                per_device_train_batch_size=8,
+                                per_device_eval_batch_size=8,
+                                warmup_steps=500,
+                                weight_decay=0.01,
+                                logging_dir=tmp_dir,
+                                fp16=True,
                             )
-                            if dataset_name != "stsb":
-                                predictions = np.argmax(predictions, axis=1)
-                            else:
-                                predictions = predictions[:, 0]
-                            return metric.compute(predictions=predictions, references=eval_pred.label_ids)
 
-                        training_args = TrainingArguments(
-                            output_dir=tmp_dir,
-                            num_train_epochs=1,
-                            per_device_train_batch_size=8,
-                            per_device_eval_batch_size=8,
-                            warmup_steps=500,
-                            weight_decay=0.01,
-                            logging_dir=tmp_dir,
-                            fp16=True,
-                        )
+                            trainer = ORTTrainer(
+                                model=model,
+                                args=training_args,
+                                train_dataset=train_dataset,
+                                eval_dataset=valid_dataset,
+                                compute_metrics=compute_metrics,
+                                tokenizer=tokenizer,
+                                data_collator=default_data_collator,
+                                feature="sequence-classification",
+                            )
 
-                        trainer = ORTTrainer(
-                            model=model,
-                            args=training_args,
-                            train_dataset=train_dataset,
-                            eval_dataset=valid_dataset,
-                            compute_metrics=compute_metrics,
-                            tokenizer=tokenizer,
-                            data_collator=default_data_collator,
-                            feature="sequence-classification",
-                        )
-
-                        train_result = trainer.train()
-                        trainer.save_model()
-                        train_metrics = train_result.metrics
-                        ort_eval_metrics = trainer.evaluate()
-                        self.assertGreaterEqual(ort_eval_metrics["eval_accuracy"], 0.75)
-                        ort_prediction = trainer.predict(test_dataset)
-                        print("Training metrics(ORT):\n", train_metrics)
-                        print("Evaluation metrics:\n", ort_eval_metrics)
-                        print("Prediction results:\n", ort_prediction)
+                            train_result = trainer.train()
+                            trainer.save_model()
+                            train_metrics = train_result.metrics
+                            ort_eval_metrics = trainer.evaluate(inference_with_ort=inference_with_ort)
+                            self.assertGreaterEqual(ort_eval_metrics["eval_accuracy"], 0.75)
+                            ort_prediction = trainer.predict(test_dataset, inference_with_ort=inference_with_ort)
+                            print("Training metrics(ORT):\n", train_metrics)
+                            print("Evaluation metrics:\n", ort_eval_metrics)
+                            print("Prediction results:\n", ort_prediction)
+                            gc.collect()
 
     # @unittest.skip("Skip")
     def test_ort_seq2seq_trainer(self):
 
-        model_names = {"t5-small", "facebook/bart-base"}  # "t5-small", "facebook/bart-base"
+        model_names = {"t5-small", "facebook/bart-base"}
         dataset_name = "xsum"
         metric_name = "rouge"
         batch_size = 8
         learning_rate = 2e-5
         weight_decay = 0.01
         num_train_epochs = 1
-        if_predict_with_generate = {True, False}
+        predict_with_generate = True
+        inference_with_ort = False
 
         for model_name in model_names:
-            for predict_with_generate in if_predict_with_generate:
-                with self.subTest(model_name=model_name, predict_with_generate=predict_with_generate):
-                    with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.subTest(model_name=model_name):
+                with tempfile.TemporaryDirectory() as tmp_dir:
 
-                        # Prepare model
-                        model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
-                        tokenizer = AutoTokenizer.from_pretrained(model_name)
+                    # Prepare model
+                    model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+                    tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-                        # Prepare dataset
-                        dataset = load_dataset(dataset_name)
-                        metric = load_metric(metric_name)
-                        label_pad_token_id = tokenizer.pad_token_id
+                    # Prepare dataset
+                    dataset = load_dataset(dataset_name)
+                    metric = load_metric(metric_name)
+                    label_pad_token_id = tokenizer.pad_token_id
 
-                        if model_name in [
-                            "t5-small",
-                            "t5-base",
-                            "t5-large",
-                            "t5-3b",
-                            "t5-11b",
-                        ] and dataset_name in ["xsum"]:
-                            prefix = "summarize: "
-                        else:
-                            prefix = ""
+                    if model_name in [
+                        "t5-small",
+                        "t5-base",
+                        "t5-large",
+                        "t5-3b",
+                        "t5-11b",
+                    ] and dataset_name in ["xsum"]:
+                        prefix = "summarize: "
+                    else:
+                        prefix = ""
 
-                        max_input_length = 512
-                        max_target_length = 64
+                    max_input_length = 512
+                    max_target_length = 64
 
-                        def preprocess_function(examples):
-                            inputs = [prefix + doc for doc in examples["document"]]
-                            model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
+                    def preprocess_function(examples):
+                        inputs = [prefix + doc for doc in examples["document"]]
+                        model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
 
-                            # Setup the tokenizer for targets
-                            with tokenizer.as_target_tokenizer():
-                                labels = tokenizer(examples["summary"], max_length=max_target_length, truncation=True)
+                        # Setup the tokenizer for targets
+                        with tokenizer.as_target_tokenizer():
+                            labels = tokenizer(examples["summary"], max_length=max_target_length, truncation=True)
 
-                            model_inputs["labels"] = labels["input_ids"]
-                            return model_inputs
+                        model_inputs["labels"] = labels["input_ids"]
+                        return model_inputs
 
-                        encoded_dataset = dataset.map(preprocess_function, batched=True)
-                        max_train_samples = 200
-                        max_valid_samples = 50
-                        max_test_samples = 20
-                        train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
-                        valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
-                        test_dataset = encoded_dataset["test"]  # .select(range(max_test_samples))
+                    encoded_dataset = dataset.map(preprocess_function, batched=True)
+                    max_train_samples = 100
+                    max_valid_samples = 30
+                    max_test_samples = 10
+                    train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
+                    valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
+                    test_dataset = encoded_dataset["test"]  # .select(range(max_test_samples))
 
-                        def compute_metrics(eval_pred):
-                            predictions, labels = eval_pred
-                            decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
-                            # Replace -100 in the labels as we can't decode them.
-                            labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
-                            decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+                    def compute_metrics(eval_pred):
+                        predictions, labels = eval_pred
+                        decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+                        # Replace -100 in the labels as we can't decode them.
+                        labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+                        decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
 
-                            # Rouge expects a newline after each sentence
-                            decoded_preds = ["\n".join(nltk.sent_tokenize(pred.strip())) for pred in decoded_preds]
-                            decoded_labels = ["\n".join(nltk.sent_tokenize(label.strip())) for label in decoded_labels]
+                        # Rouge expects a newline after each sentence
+                        decoded_preds = ["\n".join(nltk.sent_tokenize(pred.strip())) for pred in decoded_preds]
+                        decoded_labels = ["\n".join(nltk.sent_tokenize(label.strip())) for label in decoded_labels]
 
-                            result = metric.compute(
-                                predictions=decoded_preds, references=decoded_labels, use_stemmer=True
-                            )
-                            # Extract a few results
-                            result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
+                        result = metric.compute(predictions=decoded_preds, references=decoded_labels, use_stemmer=True)
+                        # Extract a few results
+                        result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
 
-                            # Add mean generated length
-                            prediction_lens = [
-                                np.count_nonzero(pred != tokenizer.pad_token_id) for pred in predictions
-                            ]
-                            result["gen_len"] = np.mean(prediction_lens)
+                        # Add mean generated length
+                        prediction_lens = [np.count_nonzero(pred != tokenizer.pad_token_id) for pred in predictions]
+                        result["gen_len"] = np.mean(prediction_lens)
 
-                            return {k: round(v, 4) for k, v in result.items()}
+                        return {k: round(v, 4) for k, v in result.items()}
 
-                        training_args = Seq2SeqTrainingArguments(
-                            output_dir=tmp_dir,
-                            evaluation_strategy="epoch",
-                            learning_rate=learning_rate,
-                            per_device_train_batch_size=batch_size,
-                            per_device_eval_batch_size=batch_size,
-                            weight_decay=weight_decay,
-                            save_total_limit=3,
-                            num_train_epochs=num_train_epochs,
-                            predict_with_generate=True,
-                            fp16=True,
-                            do_train=True,
-                            do_eval=True,
-                            label_smoothing_factor=0.1,
-                        )
+                    training_args = Seq2SeqTrainingArguments(
+                        output_dir=tmp_dir,
+                        evaluation_strategy="epoch",
+                        learning_rate=learning_rate,
+                        per_device_train_batch_size=batch_size,
+                        per_device_eval_batch_size=batch_size,
+                        weight_decay=weight_decay,
+                        save_total_limit=3,
+                        num_train_epochs=num_train_epochs,
+                        predict_with_generate=predict_with_generate,
+                        fp16=True,
+                        do_train=True,
+                        do_eval=True,
+                        label_smoothing_factor=0.1,
+                    )
 
-                        data_collator = DataCollatorForSeq2Seq(
-                            tokenizer,
-                            model=model,
-                            label_pad_token_id=label_pad_token_id,
-                            pad_to_multiple_of=8 if training_args.fp16 else None,
-                        )
+                    data_collator = DataCollatorForSeq2Seq(
+                        tokenizer,
+                        model=model,
+                        label_pad_token_id=label_pad_token_id,
+                        pad_to_multiple_of=8 if training_args.fp16 else None,
+                    )
 
-                        trainer = Seq2SeqORTTrainer(
-                            model=model,
-                            args=training_args,
-                            train_dataset=train_dataset if training_args.do_train else None,
-                            eval_dataset=valid_dataset if training_args.do_eval else None,
-                            compute_metrics=compute_metrics if training_args.predict_with_generate else None,
-                            tokenizer=tokenizer,
-                            data_collator=data_collator,
-                            feature="seq2seq-lm",
-                        )
+                    trainer = Seq2SeqORTTrainer(
+                        model=model,
+                        args=training_args,
+                        train_dataset=train_dataset if training_args.do_train else None,
+                        eval_dataset=valid_dataset if training_args.do_eval else None,
+                        compute_metrics=compute_metrics if training_args.predict_with_generate else None,
+                        tokenizer=tokenizer,
+                        data_collator=data_collator,
+                        feature="seq2seq-lm",
+                    )
 
-                        train_result = trainer.train()
-                        trainer.save_model()
-                        train_metrics = train_result.metrics
-                        ort_eval_metrics = trainer.evaluate()
-                        self.assertGreaterEqual(ort_eval_metrics["eval_rouge1"], 10)
-                        self.assertGreaterEqual(ort_eval_metrics["eval_rouge2"], 2)
-                        self.assertGreaterEqual(ort_eval_metrics["eval_rougeL"], 7)
-                        self.assertGreaterEqual(ort_eval_metrics["eval_rougeLsum"], 7)
-                        ort_prediction = trainer.predict(test_dataset)
-                        print("Training metrics(ORT):\n", train_metrics)
-                        print("Evaluation metrics:\n", ort_eval_metrics)
-                        print("Prediction results):\n", ort_prediction)
+                    train_result = trainer.train()
+                    trainer.save_model()
+                    train_metrics = train_result.metrics
+                    ort_eval_metrics = trainer.evaluate(inference_with_ort=inference_with_ort)
+                    self.assertGreaterEqual(ort_eval_metrics["eval_rouge1"], 10)
+                    self.assertGreaterEqual(ort_eval_metrics["eval_rouge2"], 2)
+                    self.assertGreaterEqual(ort_eval_metrics["eval_rougeL"], 7)
+                    self.assertGreaterEqual(ort_eval_metrics["eval_rougeLsum"], 7)
+                    ort_prediction = trainer.predict(test_dataset, inference_with_ort=inference_with_ort)
+                    print("Training metrics(ORT):\n", train_metrics)
+                    print("Evaluation metrics:\n", ort_eval_metrics)
+                    print("Prediction results):\n", ort_prediction)
+                    gc.collect()
 
 
 if __name__ == "__main__":

--- a/tests/onnxruntime/test_onnxruntime_train.py
+++ b/tests/onnxruntime/test_onnxruntime_train.py
@@ -33,15 +33,10 @@ from optimum.onnxruntime import ORTTrainer, Seq2SeqORTTrainer
 
 
 class TestORTTrainer(unittest.TestCase):
-    @unittest.skip("Skip to just test seq2seq.")
+    # @unittest.skip("Skip to just test seq2seq.")
     def test_ort_trainer(self):
 
-        model_names = {
-            "distilbert-base-uncased",
-            "bert-base-cased",
-            "roberta-base",
-            "gpt2",
-        }  # "facebook/bart-base" in progress
+        model_names = {"distilbert-base-uncased", "bert-base-cased", "roberta-base", "gpt2", "facebook/bart-base"}
         dataset_names = {"sst2"}  # glue
 
         for model_name in model_names:
@@ -91,7 +86,8 @@ class TestORTTrainer(unittest.TestCase):
                             return metric.compute(predictions=predictions, references=eval_pred.label_ids)
 
                         training_args = TrainingArguments(
-                            output_dir=tmp_dir,
+                            # output_dir=tmp_dir,
+                            output_dir="./results",
                             num_train_epochs=1,
                             per_device_train_batch_size=8,
                             per_device_eval_batch_size=8,
@@ -119,129 +115,143 @@ class TestORTTrainer(unittest.TestCase):
                         self.assertGreaterEqual(ort_eval_metrics["eval_accuracy"], 0.75)
                         ort_prediction = trainer.predict(test_dataset)
                         print("Training metrics(ORT):\n", train_metrics)
-                        print("Evaluation metrics(ORT):\n", ort_eval_metrics)
-                        print("Prediction results(ORT):\n", ort_prediction)
+                        print("Evaluation metrics:\n", ort_eval_metrics)
+                        print("Prediction results:\n", ort_prediction)
 
+    # @unittest.skip("Skip")
     def test_ort_seq2seq_trainer(self):
 
-        model_names = {"t5-small"}
+        model_names = {"t5-small", "facebook/bart-base"}  # "t5-small", "facebook/bart-base"
         dataset_names = {"xsum"}
         metric_name = "rouge"
         batch_size = 8
         learning_rate = 2e-5
         weight_decay = 0.01
         num_train_epochs = 1
+        if_predict_with_generate = {True, False}
 
         for model_name in model_names:
             for dataset_name in dataset_names:
-                with self.subTest(model_name=model_name, dataset_name=dataset_name):
-                    with tempfile.TemporaryDirectory() as tmp_dir:
+                for predict_with_generate in if_predict_with_generate:
+                    with self.subTest(
+                        model_name=model_name, dataset_name=dataset_name, predict_with_generate=predict_with_generate
+                    ):
+                        with tempfile.TemporaryDirectory() as tmp_dir:
 
-                        # Prepare model
-                        model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
-                        tokenizer = AutoTokenizer.from_pretrained(model_name)
+                            # Prepare model
+                            model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+                            tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-                        # Prepare dataset
-                        dataset = load_dataset(dataset_name)
-                        metric = load_metric(metric_name)
-                        label_pad_token_id = tokenizer.pad_token_id
+                            # Prepare dataset
+                            dataset = load_dataset(dataset_name)
+                            metric = load_metric(metric_name)
+                            label_pad_token_id = tokenizer.pad_token_id
 
-                        if model_name in ["t5-small", "t5-base", "t5-large", "t5-3b", "t5-11b"] and dataset_name in [
-                            "xsum"
-                        ]:
-                            prefix = "summarize: "
-                        else:
-                            prefix = ""
+                            if model_name in [
+                                "t5-small",
+                                "t5-base",
+                                "t5-large",
+                                "t5-3b",
+                                "t5-11b",
+                            ] and dataset_name in ["xsum"]:
+                                prefix = "summarize: "
+                            else:
+                                prefix = ""
 
-                        max_input_length = 1024
-                        max_target_length = 128
+                            max_input_length = 512
+                            max_target_length = 64
 
-                        def preprocess_function(examples):
-                            inputs = [prefix + doc for doc in examples["document"]]
-                            model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
+                            def preprocess_function(examples):
+                                inputs = [prefix + doc for doc in examples["document"]]
+                                model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
 
-                            # Setup the tokenizer for targets
-                            with tokenizer.as_target_tokenizer():
-                                labels = tokenizer(examples["summary"], max_length=max_target_length, truncation=True)
+                                # Setup the tokenizer for targets
+                                with tokenizer.as_target_tokenizer():
+                                    labels = tokenizer(
+                                        examples["summary"], max_length=max_target_length, truncation=True
+                                    )
 
-                            model_inputs["labels"] = labels["input_ids"]
-                            return model_inputs
+                                model_inputs["labels"] = labels["input_ids"]
+                                return model_inputs
 
-                        encoded_dataset = dataset.map(preprocess_function, batched=True)
-                        max_train_samples = 200
-                        max_valid_samples = 50
-                        max_test_samples = 20
-                        train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
-                        valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
-                        test_dataset = encoded_dataset["test"]  # .select(range(max_test_samples))
+                            encoded_dataset = dataset.map(preprocess_function, batched=True)
+                            max_train_samples = 200
+                            max_valid_samples = 50
+                            max_test_samples = 20
+                            train_dataset = encoded_dataset["train"]  # .select(range(max_train_samples))
+                            valid_dataset = encoded_dataset["validation"]  # .select(range(max_valid_samples))
+                            test_dataset = encoded_dataset["test"]  # .select(range(max_test_samples))
 
-                        def compute_metrics(eval_pred):
-                            predictions, labels = eval_pred
-                            decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
-                            # Replace -100 in the labels as we can't decode them.
-                            labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
-                            decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+                            def compute_metrics(eval_pred):
+                                predictions, labels = eval_pred
+                                decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+                                # Replace -100 in the labels as we can't decode them.
+                                labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+                                decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
 
-                            # Rouge expects a newline after each sentence
-                            decoded_preds = ["\n".join(nltk.sent_tokenize(pred.strip())) for pred in decoded_preds]
-                            decoded_labels = ["\n".join(nltk.sent_tokenize(label.strip())) for label in decoded_labels]
+                                # Rouge expects a newline after each sentence
+                                decoded_preds = ["\n".join(nltk.sent_tokenize(pred.strip())) for pred in decoded_preds]
+                                decoded_labels = [
+                                    "\n".join(nltk.sent_tokenize(label.strip())) for label in decoded_labels
+                                ]
 
-                            result = metric.compute(
-                                predictions=decoded_preds, references=decoded_labels, use_stemmer=True
+                                result = metric.compute(
+                                    predictions=decoded_preds, references=decoded_labels, use_stemmer=True
+                                )
+                                # Extract a few results
+                                result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
+
+                                # Add mean generated length
+                                prediction_lens = [
+                                    np.count_nonzero(pred != tokenizer.pad_token_id) for pred in predictions
+                                ]
+                                result["gen_len"] = np.mean(prediction_lens)
+
+                                return {k: round(v, 4) for k, v in result.items()}
+
+                            training_args = Seq2SeqTrainingArguments(
+                                f"{model_name}-finetuned",
+                                evaluation_strategy="epoch",
+                                learning_rate=learning_rate,
+                                per_device_train_batch_size=batch_size,
+                                per_device_eval_batch_size=batch_size,
+                                weight_decay=weight_decay,
+                                save_total_limit=3,
+                                num_train_epochs=num_train_epochs,
+                                predict_with_generate=False,
+                                fp16=True,
+                                do_train=True,
+                                do_eval=True,
+                                label_smoothing_factor=0.1,
                             )
-                            # Extract a few results
-                            result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
 
-                            # Add mean generated length
-                            prediction_lens = [
-                                np.count_nonzero(pred != tokenizer.pad_token_id) for pred in predictions
-                            ]
-                            result["gen_len"] = np.mean(prediction_lens)
+                            data_collator = DataCollatorForSeq2Seq(
+                                tokenizer,
+                                model=model,
+                                label_pad_token_id=label_pad_token_id,
+                                pad_to_multiple_of=8 if training_args.fp16 else None,
+                            )
 
-                            return {k: round(v, 4) for k, v in result.items()}
+                            trainer = Seq2SeqORTTrainer(
+                                model=model,
+                                args=training_args,
+                                train_dataset=train_dataset if training_args.do_train else None,
+                                eval_dataset=valid_dataset if training_args.do_eval else None,
+                                compute_metrics=compute_metrics if training_args.predict_with_generate else None,
+                                tokenizer=tokenizer,
+                                data_collator=data_collator,
+                                feature="seq2seq-lm",
+                            )
 
-                        training_args = Seq2SeqTrainingArguments(
-                            f"{model_name}-finetuned",
-                            evaluation_strategy="epoch",
-                            learning_rate=learning_rate,
-                            per_device_train_batch_size=batch_size,
-                            per_device_eval_batch_size=batch_size,
-                            weight_decay=weight_decay,
-                            save_total_limit=3,
-                            num_train_epochs=num_train_epochs,
-                            predict_with_generate=True,
-                            fp16=True,
-                            do_train=True,
-                            do_eval=True,
-                        )
-
-                        data_collator = DataCollatorForSeq2Seq(
-                            tokenizer,
-                            model=model,
-                            label_pad_token_id=label_pad_token_id,
-                            pad_to_multiple_of=8 if training_args.fp16 else None,
-                        )
-
-                        trainer = Seq2SeqORTTrainer(
-                            model=model,
-                            args=training_args,
-                            train_dataset=train_dataset if training_args.do_train else None,
-                            eval_dataset=valid_dataset if training_args.do_eval else None,
-                            compute_metrics=compute_metrics if training_args.predict_with_generate else None,
-                            tokenizer=tokenizer,
-                            data_collator=data_collator,
-                            feature="seq2seq-lm",
-                        )
-
-                        train_result = trainer.train()
-                        trainer.save_model()
-                        train_metrics = train_result.metrics
-                        ort_eval_metrics = trainer.evaluate()
-                        self.assertGreaterEqual(ort_eval_metrics["eval_bleu"], 30)
-                        ort_prediction = trainer.predict(test_dataset)
-                        print("Training metrics(ORT):\n", train_metrics)
-                        print("Evaluation metrics(ORT):\n", ort_eval_metrics)
-                        print("Prediction results(ORT):\n", ort_prediction)
+                            train_result = trainer.train()
+                            trainer.save_model()
+                            train_metrics = train_result.metrics
+                            ort_eval_metrics = trainer.evaluate()
+                            self.assertGreaterEqual(ort_eval_metrics["eval_bleu"], 30)
+                            ort_prediction = trainer.predict(test_dataset)
+                            print("Training metrics(ORT):\n", train_metrics)
+                            print("Evaluation metrics:\n", ort_eval_metrics)
+                            print("Prediction results):\n", ort_prediction)
 
 
 if __name__ == "__main__":

--- a/tests/onnxruntime/test_onnxruntime_train.py
+++ b/tests/onnxruntime/test_onnxruntime_train.py
@@ -40,7 +40,8 @@ class TestORTTrainer(unittest.TestCase):
             "distilbert-base-uncased",
             "bert-base-cased",
             "roberta-base",
-        }  # "gpt2", "facebook/bart-base" in progress
+            "gpt2",
+        }  # "facebook/bart-base" in progress
         dataset_names = {"sst2"}  # glue
 
         for model_name in model_names:


### PR DESCRIPTION
# What does this PR do?
-  Fix `fix_atenops_to_gather` broken due to changed ops names.
-  Patch `Seq2SeqORTTrainer` to be compatible with `BART` model.
- Enable inference within PyTorch when ONNX Runtime doesn't work.