### PR TITLE
Change element type of list initializing the auto quantization config

### DIFF
--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -45,7 +45,7 @@ AUTO_MINIMUM_SUPPORTED_ONNX_OPSET = None
 
 # This value is used to indicate ORT which axis it should use to quantize an operator "per-channel"
 ORT_DEFAULT_CHANNEL_FOR_OPERATORS = {"MatMul": 1}
-ORT_FULLY_CONNECTED_OPERATORS = [ORTQuantizableOperator.MatMul, ORTQuantizableOperator.Add]
+ORT_FULLY_CONNECTED_OPERATORS = ["MatMul", "Add"]
 
 
 from .configuration import ORTConfig


### PR DESCRIPTION
In this PR, we change the type of the elements of the list `ORT_FULLY_CONNECTED_OPERATORS` used as the default value of the `operators_to_quantize` parameter when instantiating an `QuantizationConfig` object by using `AutoQuantizationConfig`. The elements composing the list were previously `ORTQuantizableOperator` instances, which resulted in errors as the `ORTQuantizer` `partial_fit` methods expects a list of strings (which is also the case for `QuantizationConfig`).