### PR TITLE
Add quantization preprocess to include fully connected layer nodes

### DIFF
--- a/optimum/onnxruntime/preprocessors/passes/excluders.py
+++ b/optimum/onnxruntime/preprocessors/passes/excluders.py
@@ -41,9 +41,7 @@ class ExcludeNodeFollowedBy(PreprocessorPass):
 
         # Intersection of both are the one we want to remove
         to_exclude = set(candidate_nodes_to_exclude.keys()).intersection(nodes_of_following_type.keys())
-        nodes_to_exclude = {
-            candidate_nodes_to_exclude[node] for node in to_exclude if node in candidate_nodes_to_exclude
-        }
+        nodes_to_exclude = {candidate_nodes_to_exclude[node] for node in to_exclude}
 
         return set(), nodes_to_exclude
 
@@ -71,8 +69,6 @@ class ExcludeNodeAfter(PreprocessorPass):
 
         # Intersection of both are the one we want to remove
         to_exclude = set(candidate_nodes_to_exclude.keys()).intersection(parent_node.keys())
-        nodes_to_exclude = {
-            candidate_nodes_to_exclude[node] for node in to_exclude if node in candidate_nodes_to_exclude
-        }
+        nodes_to_exclude = {candidate_nodes_to_exclude[node] for node in to_exclude}
 
         return set(), nodes_to_exclude

--- a/optimum/onnxruntime/preprocessors/passes/excluders.py
+++ b/optimum/onnxruntime/preprocessors/passes/excluders.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 
 from onnx import ModelProto
 from onnxruntime.transformers.onnx_model import OnnxModel
@@ -25,7 +25,7 @@ class ExcludeNodeFollowedBy(PreprocessorPass):
         self.operator_type_to_exclude = operator_type_to_exclude
         self.following_operator_type = following_operator_type
 
-    def __call__(self, _: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+    def __call__(self, _: ModelProto, model: OnnxModel) -> Tuple[Set[str], Set[str]]:
         # Find out the nodes to exclude in the graph
         candidate_nodes_to_exclude = {
             candidate_output: candidate.name
@@ -53,7 +53,7 @@ class ExcludeNodeAfter(PreprocessorPass):
         self.parent_operator_type = parent_operator_type
         self.operator_type_to_exclude = operator_type_to_exclude
 
-    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Set[str], Set[str]]:
         # Find out the nodes to exclude in the graph
         candidate_nodes_to_exclude = {
             candidate_input: candidate.name

--- a/optimum/onnxruntime/preprocessors/passes/fully_connected.py
+++ b/optimum/onnxruntime/preprocessors/passes/fully_connected.py
@@ -1,0 +1,33 @@
+#  Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Optional, Set, Tuple
+
+from onnx import ModelProto
+from onnxruntime.transformers.onnx_model import OnnxModel
+from optimum.onnxruntime.preprocessors import PreprocessorPass
+
+
+class IncludeFullyConnectedNodes(PreprocessorPass):
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+        fc_subgraphs = []
+        for matmul_node in model.get_nodes_by_op_type("Add"):
+            fc_components = model.match_parent_path(matmul_node, ["MatMul"], [1])
+            if fc_components is not None:
+                fc_components.append(matmul_node)
+                fc_subgraphs.append(fc_components)
+        fc_components = {node.name for fc in fc_subgraphs for node in fc}
+        return fc_components, set()

--- a/optimum/onnxruntime/preprocessors/passes/fully_connected.py
+++ b/optimum/onnxruntime/preprocessors/passes/fully_connected.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 
 from onnx import ModelProto
 from onnxruntime.transformers.onnx_model import OnnxModel
@@ -22,7 +22,7 @@ class IncludeFullyConnectedNodes(PreprocessorPass):
     def __init__(self):
         super().__init__()
 
-    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Set[str], Set[str]]:
         fc_subgraphs = []
         for add_node in model.get_nodes_by_op_type("Add"):
             fc_components = model.match_parent_path(add_node, ["MatMul"], [1])

--- a/optimum/onnxruntime/preprocessors/passes/fully_connected.py
+++ b/optimum/onnxruntime/preprocessors/passes/fully_connected.py
@@ -24,10 +24,10 @@ class IncludeFullyConnectedNodes(PreprocessorPass):
 
     def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
         fc_subgraphs = []
-        for matmul_node in model.get_nodes_by_op_type("Add"):
-            fc_components = model.match_parent_path(matmul_node, ["MatMul"], [1])
+        for add_node in model.get_nodes_by_op_type("Add"):
+            fc_components = model.match_parent_path(add_node, ["MatMul"], [1])
             if fc_components is not None:
-                fc_components.append(matmul_node)
+                fc_components.append(add_node)
                 fc_subgraphs.append(fc_components)
         fc_components = {node.name for fc in fc_subgraphs for node in fc}
         return fc_components, set()

--- a/optimum/onnxruntime/preprocessors/passes/gelu.py
+++ b/optimum/onnxruntime/preprocessors/passes/gelu.py
@@ -31,5 +31,5 @@ class ExcludeGeLUNodes(PreprocessorPass):
                 gelu_components.append(mul_node)
                 gelu_subgraphs.append(gelu_components)
 
-        ln_components = (node.name for ln in gelu_subgraphs for node in ln)
-        return set(), set(ln_components)
+        gl_components = (node.name for gl in gelu_subgraphs for node in gl)
+        return set(), set(gl_components)

--- a/optimum/onnxruntime/preprocessors/passes/gelu.py
+++ b/optimum/onnxruntime/preprocessors/passes/gelu.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 
 from onnx import ModelProto
 from onnxruntime.transformers.onnx_model import OnnxModel
@@ -22,7 +22,7 @@ class ExcludeGeLUNodes(PreprocessorPass):
     def __init__(self):
         super().__init__()
 
-    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Set[str], Set[str]]:
         gelu_subgraphs = []
         for mul_node in model.get_nodes_by_op_type("Mul"):
             gelu_components = model.match_parent_path(mul_node, ["Mul", "Add", "Erf", "Div"], [0, 1, 0, 0])

--- a/optimum/onnxruntime/preprocessors/passes/layernorm.py
+++ b/optimum/onnxruntime/preprocessors/passes/layernorm.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 
 from onnx import ModelProto
 from onnxruntime.transformers.onnx_model import OnnxModel
@@ -22,7 +22,7 @@ class ExcludeLayerNormNodes(PreprocessorPass):
     def __init__(self):
         super().__init__()
 
-    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Optional[Set[str]], Optional[Set[str]]]:
+    def __call__(self, graph: ModelProto, model: OnnxModel) -> Tuple[Set[str], Set[str]]:
         layer_norm_subgraphs = []
         for add_node in model.get_nodes_by_op_type("Add"):
             layer_norm_components = model.match_parent_path(

--- a/optimum/onnxruntime/preprocessors/quantization.py
+++ b/optimum/onnxruntime/preprocessors/quantization.py
@@ -60,4 +60,7 @@ class QuantizationPreprocessor:
             if nodes_to_exclude is not None:
                 global_nodes_to_exclude.update(nodes_to_exclude)
 
+        # Exclude the nodes present in both sets from quantization
+        global_nodes_to_quantize = global_nodes_to_quantize - global_nodes_to_exclude
+
         return global_nodes_to_quantize, global_nodes_to_exclude

--- a/optimum/onnxruntime/preprocessors/quantization.py
+++ b/optimum/onnxruntime/preprocessors/quantization.py
@@ -60,7 +60,7 @@ class QuantizationPreprocessor:
             if nodes_to_exclude is not None:
                 global_nodes_to_exclude.update(nodes_to_exclude)
 
-        # Exclude the nodes present in both sets from quantization
+        # Exclude the nodes from quantization when present in both sets
         global_nodes_to_quantize = global_nodes_to_quantize - global_nodes_to_exclude
 
         return global_nodes_to_quantize, global_nodes_to_exclude


### PR DESCRIPTION
In this PR, we add the `IncludeFullyConnectedNodes` class, which allows to find the nodes composing the model's fully connected layers, in order to include those to the list of nodes to quantize. We also force the intersection of the two sets respectively representing the nodes to quantize `global_nodes_to_quantize` an the nodes to exclude `global_nodes_to_exclude` to be an empty set, in order to prevent any overlap.
