### PR TITLE
Patch ORTTrainer's compatibility with DeepSpeed

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -41,7 +41,7 @@ from transformers import PreTrainedModel, __version__
 from transformers.configuration_utils import PretrainedConfig
 from transformers.data.data_collator import DataCollator
 from transformers.debug_utils import DebugOption, DebugUnderflowOverflow
-from transformers.deepspeed import deepspeed_init, deepspeed_reinit
+from transformers.deepspeed import deepspeed_init, deepspeed_reinit, is_deepspeed_zero3_enabled
 from transformers.file_utils import (
     CONFIG_NAME,
     WEIGHTS_NAME,
@@ -95,6 +95,12 @@ if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
     import torch_xla.debug.metrics as met
     import torch_xla.distributed.parallel_loader as pl
+
+if is_fairscale_available():
+    dep_version_check("fairscale")
+    from fairscale.nn.data_parallel import FullyShardedDataParallel as FullyShardedDDP
+    from fairscale.nn.data_parallel import ShardedDataParallel as ShardedDDP
+    from fairscale.nn.wrap import auto_wrap
 
 if is_sagemaker_dp_enabled():
     import smdistributed.dataparallel.torch.distributed as dist


### PR DESCRIPTION
# What does this PR do?

Fixes #145 and #146 

## Contents

- [ ] Add missing dependencies  
- [ ] Fix compatibility with `deepspeed`
- [ ] Enable `sharded_ddp`

## Checks
- [ ] Fixes typos 
- [ ] Updates the docs.
- [ ] Necessary tests of all above

