### PR TITLE
Ensure attention mask is on same device as inputs IDs during text generation

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -687,3 +687,25 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
         return CausalLMOutputWithCrossAttentions(
             logits=torch.from_numpy(outputs[self.model_outputs["logits"]]),
         )
+
+    def _prepare_attention_mask_for_generation(
+        self,
+        inputs: torch.Tensor,
+        pad_token_id: int,
+        eos_token_id: int,
+    ) -> torch.LongTensor:
+        """
+        Overrides the base method of `GenerationMixin` to ensure input IDs and
+        attention mask are on the same device.
+        """
+        is_input_ids = len(inputs.shape) == 2 and inputs.dtype in [torch.int, torch.long]
+        is_pad_token_in_inputs = (pad_token_id is not None) and (pad_token_id in inputs)
+        is_pad_token_not_equal_to_eos_token_id = (eos_token_id is None) or (
+            (eos_token_id is not None) and (pad_token_id != eos_token_id)
+        )
+        # Check if input is input_ids and padded -> only then is attention_mask defined
+        if is_input_ids and is_pad_token_in_inputs and is_pad_token_not_equal_to_eos_token_id:
+            return inputs.ne(pad_token_id).long()
+        else:
+            # Ensure attention mask is on the same device as the input IDs
+            return torch.ones(inputs.shape[:2], dtype=torch.long, device=inputs.device)

--- a/tests/onnxruntime/test_modeling_ort.py
+++ b/tests/onnxruntime/test_modeling_ort.py
@@ -393,6 +393,7 @@ class ORTModelForFeatureExtractionIntergrationTest(unittest.TestCase):
 class ORTModelForCausalLMIntergrationTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = {
         "gpt2": "hf-internal-testing/tiny-random-gpt2",
+        "distilgpt2": "distilgpt2",
     }
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
@@ -432,6 +433,21 @@ class ORTModelForCausalLMIntergrationTest(unittest.TestCase):
             return_tensors="pt",
         )
         outputs = model.generate(**tokens)
+        res = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        self.assertTrue(isinstance(res[0], str))
+        self.assertTrue(len(res[0]) > len(text))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
+    def test_generate_utils_with_inputids(self, *args, **kwargs):
+        model_arch, model_id = args
+        model = ORTModelForCausalLM.from_pretrained(model_id, from_transformers=True)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        text = "This is a sample output"
+        tokens = tokenizer(
+            text,
+            return_tensors="pt",
+        )
+        outputs = model.generate(input_ids=tokens["input_ids"])
         res = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertTrue(isinstance(res[0], str))
         self.assertTrue(len(res[0]) > len(text))

--- a/tests/onnxruntime/test_modeling_ort.py
+++ b/tests/onnxruntime/test_modeling_ort.py
@@ -438,7 +438,7 @@ class ORTModelForCausalLMIntergrationTest(unittest.TestCase):
         self.assertTrue(len(res[0]) > len(text))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
-    def test_generate_utils_with_inputids(self, *args, **kwargs):
+    def test_generate_utils_with_input_ids(self, *args, **kwargs):
         model_arch, model_id = args
         model = ORTModelForCausalLM.from_pretrained(model_id, from_transformers=True)
         tokenizer = AutoTokenizer.from_pretrained(model_id)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes an issue where the input IDs and attention mask were on different devices, thus triggering the error reported in #161.

With this fix, one can now do text generation with GPT-2 models as follows:

```python
  model_id ="gpt2"
  onnx_model = ORTModelForCausalLM.from_pretrained(model_id, from_transformers=True)
  tokenizer = AutoTokenizer.from_pretrained(model_id)
  pp = pipeline("text-generation", model=onnx_model, tokenizer=tokenizer)
  text = "My Name is Philipp and i live"
  outputs = pp(text)
```

I've also added:

* A new unit test that would have caught the error at the level of `ORTModelForCausalLM.generate()`
* A new model checkpoint that triggers the error in the `pipeline()` function

Fixes #161 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

