### PR TITLE
[fix] Warning when loading ORTModels with pipelines of not supported class type

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -133,7 +133,7 @@ class ORTModel(OptimizedModel):
         model_id: Union[str, Path],
         use_auth_token: Optional[Union[bool, str, None]] = None,
         revision: Optional[Union[str, None]] = None,
-        force_download: bool = True,
+        force_download: bool = False,
         cache_dir: Optional[str] = None,
         file_name: Optional[str] = None,
         **kwargs,
@@ -191,7 +191,7 @@ class ORTModel(OptimizedModel):
         save_dir: Union[str, Path] = default_cache_path,
         use_auth_token: Optional[Union[bool, str, None]] = None,
         revision: Optional[Union[str, None]] = None,
-        force_download: bool = True,
+        force_download: bool = False,
         cache_dir: Optional[str] = None,
         **kwargs,
     ):
@@ -304,9 +304,6 @@ class ORTModelForFeatureExtraction(ORTModel):
         super().__init__(*args, **kwargs)
         # create {name:idx} dict for model outputs
         self.model_outputs = {output_key.name: idx for idx, output_key in enumerate(self.model.get_outputs())}
-
-        AutoConfig.register(self.base_model_prefix, AutoConfig)
-        AutoModel.register(AutoConfig, ORTModelForFeatureExtraction)
 
     @add_start_docstrings_to_model_forward(
         ONNX_INPUTS_DOCSTRING.format("batch_size, sequence_length")


### PR DESCRIPTION
# What does this PR do?

This PR fixes the log warning user received when loading an `ORTModelForXXX` when creating a `pipeline` instance. The `pipeline` has a [model_type_check](https://github.com/huggingface/transformers/blob/cad61b68396a1a387287a8e2e2fef78a25b79383/src/transformers/pipelines/base.py#L863) which prints out a warning when using a non transformers class. 

```bash
The model 'ORTModelForQuestionAnswering' is not supported for question-answering
. Supported models are ['YosoForQuestionAnswering', 'NystromformerForQuestionAns
wering', 'QDQBertForQuestionAnswering', ...].
```
After discussing with @LysandreJik and @Narsil the best/easiest way to solve this is to register the `ORTModelFor` for the `transformers` auto_classes. 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

