### PR TITLE
Allow onnxruntime quantization preprocessor for dynamic quantization

### DIFF
--- a/examples/onnxruntime/quantization/question-answering/run_qa.py
+++ b/examples/onnxruntime/quantization/question-answering/run_qa.py
@@ -586,7 +586,8 @@ def main():
             predict_dataset = predict_dataset.select(range(data_args.max_predict_samples))
 
     ranges = None
-    quantization_preprocessor = None
+    # Create a quantization preprocessor to determine the nodes to exclude
+    quantization_preprocessor = QuantizationPreprocessor()
     if apply_static_quantization:
         # Remove the unnecessary columns of the calibration dataset before the calibration step
         calibration_dataset = quantizer.clean_calibration_dataset(calibration_dataset)
@@ -625,8 +626,6 @@ def main():
             )
         ranges = quantizer.compute_ranges()
 
-        # Create a quantization preprocessor to determine the nodes to exclude when applying static quantization
-        quantization_preprocessor = QuantizationPreprocessor(model_path)
         # Exclude the nodes constituting LayerNorm
         quantization_preprocessor.register_pass(ExcludeLayerNormNodes())
         # Exclude the nodes constituting GELU

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -399,7 +399,8 @@ def main():
     )
 
     ranges = None
-    quantization_preprocessor = None
+    # Create a quantization preprocessor to determine the nodes to exclude
+    quantization_preprocessor = QuantizationPreprocessor()
     if apply_static_quantization:
         # Create the calibration dataset used for the calibration step
         calibration_dataset = preprocessed_datasets["train"]
@@ -443,8 +444,6 @@ def main():
             )
         ranges = quantizer.compute_ranges()
 
-        # Create a quantization preprocessor to determine the nodes to exclude when applying static quantization
-        quantization_preprocessor = QuantizationPreprocessor(model_path)
         # Exclude the nodes constituting LayerNorm
         quantization_preprocessor.register_pass(ExcludeLayerNormNodes())
         # Exclude the nodes constituting GELU

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -448,7 +448,8 @@ def main():
     )
 
     ranges = None
-    quantization_preprocessor = None
+    # Create a quantization preprocessor to determine the nodes to exclude
+    quantization_preprocessor = QuantizationPreprocessor()
     if apply_static_quantization:
         # Preprocess the calibration dataset
         if "train" not in raw_datasets:
@@ -501,8 +502,6 @@ def main():
             )
         ranges = quantizer.compute_ranges()
 
-        # Create a quantization preprocessor to determine the nodes to exclude when applying static quantization
-        quantization_preprocessor = QuantizationPreprocessor(model_path)
         # Exclude the nodes constituting LayerNorm
         quantization_preprocessor.register_pass(ExcludeLayerNormNodes())
         # Exclude the nodes constituting GELU

--- a/optimum/onnxruntime/preprocessors/quantization.py
+++ b/optimum/onnxruntime/preprocessors/quantization.py
@@ -34,11 +34,9 @@ class PreprocessorPass(ABC):
 
 
 class QuantizationPreprocessor:
-    __slots__ = ("_graph", "_model", "_passes")
+    __slots__ = ("_passes",)
 
-    def __init__(self, model_or_path: Union[str, PathLike, Path, bytes]):
-        self._graph = load_model(model_or_path.as_posix() if isinstance(model_or_path, Path) else model_or_path)
-        self._model = OnnxModel(self._graph)
+    def __init__(self):
         self._passes = []
 
     def from_config(self, config):
@@ -48,11 +46,13 @@ class QuantizationPreprocessor:
         if target not in self._passes:
             self._passes.append(target)
 
-    def collect(self) -> Tuple[Set[str], Set[str]]:
+    def collect(self, model_or_path: Union[str, PathLike, Path, bytes]) -> Tuple[Set[str], Set[str]]:
         global_nodes_to_quantize, global_nodes_to_exclude = set(), set()
+        _graph = load_model(model_or_path.as_posix() if isinstance(model_or_path, Path) else model_or_path)
+        _model = OnnxModel(_graph)
 
         for walking_pass in self._passes:
-            nodes_to_quantize, nodes_to_exclude = walking_pass(self._graph, self._model)
+            nodes_to_quantize, nodes_to_exclude = walking_pass(_graph, _model)
 
             if nodes_to_quantize is not None:
                 global_nodes_to_quantize.update(nodes_to_quantize)

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -328,7 +328,7 @@ class ORTQuantizer(ABC):
 
         if preprocessor is not None:
             LOGGER.info("Preprocessor detected, collecting nodes to include/exclude")
-            nodes_to_quantize, nodes_to_exclude = preprocessor.collect()
+            nodes_to_quantize, nodes_to_exclude = preprocessor.collect(onnx_model_path)
 
             nodes_to_quantize.update(quantization_config.nodes_to_quantize)
             nodes_to_exclude.update(quantization_config.nodes_to_exclude)


### PR DESCRIPTION
# What does this PR do?

Currently, for the onnxruntime backend, the [`QuantizationPreprocessor`](https://github.com/huggingface/optimum/blob/3b522e4d82c765660d7f60839d65ad7eda208f58/optimum/onnxruntime/preprocessors/quantization.py#L36) is usable only for static quantization to exclude nodes to quantize, because the onnx model needs to be already saved when initializing `QuantizationPreprocessor`, which was handled by [`partial_fit`](https://github.com/huggingface/optimum/blob/3b522e4d82c765660d7f60839d65ad7eda208f58/optimum/onnxruntime/quantization.py#L237) method used during calibration.

With this PR, it is possible to use `QuantizationPreprocessor` for dynamic quantization (if it happens to be relevant at some point -- at least I would like to test it), while making no change to the current workflow.

## Before submitting
- `QuantizationPreprocessor` is largely (publicly) untested and documented, in a future PR we could improve that.
