### PR TITLE
Fix version number shown in doc build

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Make documentation
         run: |
           cd doc-builder &&
-          doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version ${{ env.VERSION }} --html &&
+          doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version v${{ env.VERSION }} --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656


### PR DESCRIPTION
# What does this PR do?

This PR fixes a small bug by including a `v` prefix to the generated builds in the `doc-build` repo: https://github.com/huggingface/doc-build/tree/main/optimum

