### PR TITLE
Fix logging mistake where "dynamic" is logged if static quantization is performed

### DIFF
--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -323,7 +323,7 @@ class ORTQuantizer(ABC):
                 )
 
         LOGGER.info(
-            f"Creating {'dynamic' if quantization_config.is_static else 'static'} quantizer: {quantization_config}"
+            f"Creating {'static' if quantization_config.is_static else 'dynamic'} quantizer: {quantization_config}"
         )
 
         if preprocessor is not None:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In `optimum/onnxruntime/quantization.py`, we currently have:
```python
LOGGER.info(
    f"Creating {'dynamic' if quantization_config.is_static else 'static'} quantizer: {quantization_config}"
)
```
'dynamic' and 'static' should be swapped.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

