### PR TITLE
Fix wrong mapping between dataset label ids and model.config.label2id in examples

### DIFF
--- a/examples/onnxruntime/optimization/text-classification/run_glue.py
+++ b/examples/onnxruntime/optimization/text-classification/run_glue.py
@@ -341,6 +341,7 @@ def main():
                     sentence1_key, sentence2_key = non_label_column_names[:2]
                 else:
                     sentence1_key, sentence2_key = non_label_column_names[0], None
+
         # Some models have set the order of the labels to use, so let's make sure we do use it.
         label_to_id = None
         model_config = AutoConfig.from_pretrained(model_args.model_name_or_path)

--- a/examples/onnxruntime/optimization/text-classification/run_glue.py
+++ b/examples/onnxruntime/optimization/text-classification/run_glue.py
@@ -350,7 +350,7 @@ def main():
             and not is_regression
         ):
             # Some have all caps in their config, some don't.
-            label_name_to_id = {k.lower(): v for k, v in model_config.config.label2id.items()}
+            label_name_to_id = {k.lower(): v for k, v in model_config.label2id.items()}
             if list(sorted(label_name_to_id.keys())) == list(sorted(label_list)):
                 label_to_id = {i: int(label_name_to_id[label_list[i]]) for i in range(num_labels)}
             else:

--- a/examples/onnxruntime/optimization/token-classification/run_ner.py
+++ b/examples/onnxruntime/optimization/token-classification/run_ner.py
@@ -31,7 +31,7 @@ import datasets
 import numpy as np
 import transformers
 from datasets import ClassLabel, load_dataset, load_metric
-from transformers import HfArgumentParser, PreTrainedTokenizer, TrainingArguments
+from transformers import HfArgumentParser, PretrainedConfig, PreTrainedTokenizer, TrainingArguments
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
@@ -313,11 +313,11 @@ def main():
             raw_datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
 
         if training_args.do_eval:
+            if "validation" not in raw_datasets:
+                raise ValueError("--do_eval requires a validation dataset")
             column_names = raw_datasets["validation"].column_names
-            features = raw_datasets["validation"].features
         else:
-            column_names = raw_datasets["test"].column_names
-            features = raw_datasets["test"].features
+            column_names = raw_datasets["train"].column_names
 
         if data_args.text_column_name is not None:
             text_column_name = data_args.text_column_name
@@ -332,6 +332,21 @@ def main():
             label_column_name = f"{data_args.task_name}_tags"
         else:
             label_column_name = column_names[1]
+
+        if training_args.do_eval:
+            # Preprocess the evaluation dataset
+            eval_dataset = raw_datasets["validation"]
+            if data_args.max_eval_samples is not None:
+                eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
+
+            label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
+            if label2id:
+                eval_dataset = eval_dataset.align_labels_with_mapping(
+                    label2id=label2id, label_column=label_column_name
+                )
+            features = eval_dataset.features
+        else:
+            features = raw_datasets["train"].features
 
         # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
         # unique labels.
@@ -437,12 +452,6 @@ def main():
     if training_args.do_eval:
         logger.info("*** Evaluate ***")
 
-        # Preprocess the evaluation dataset
-        if "validation" not in raw_datasets:
-            raise ValueError("--do_eval requires a validation dataset")
-        eval_dataset = raw_datasets["validation"]
-        if data_args.max_eval_samples is not None:
-            eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
         eval_dataset = eval_dataset.map(
             partial(tokenize_and_align_labels, tokenizer=optimizer.tokenizer),
             batched=True,

--- a/examples/onnxruntime/quantization/image-classification/run_image_classification.py
+++ b/examples/onnxruntime/quantization/image-classification/run_image_classification.py
@@ -378,6 +378,11 @@ def main():
 
         if data_args.max_eval_samples is not None:
             dataset["validation"] = dataset["validation"].select(range(data_args.max_eval_samples))
+
+        if quantizer.model.config.label2id:
+            eval_dataset = eval_dataset.align_labels_with_mapping(
+                label2id=quantizer.model.config.label2id, label_column="labels"
+            )
         # Set the validation transforms
         eval_dataset = dataset["validation"].with_transform(preprocess_function)
 

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -362,7 +362,7 @@ def main():
         and not is_regression
     ):
         # Some have all caps in their config, some don't.
-        label_name_to_id = {k.lower(): v for k, v in model_config.config.label2id.items()}
+        label_name_to_id = {k.lower(): v for k, v in model_config.label2id.items()}
         if list(sorted(label_name_to_id.keys())) == list(sorted(label_list)):
             label_to_id = {i: int(label_name_to_id[label_list[i]]) for i in range(num_labels)}
         else:

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -30,7 +30,14 @@ import datasets
 import numpy as np
 import transformers
 from datasets import load_dataset, load_metric
-from transformers import EvalPrediction, HfArgumentParser, PreTrainedTokenizer, TrainingArguments
+from transformers import (
+    AutoConfig,
+    EvalPrediction,
+    HfArgumentParser,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+    TrainingArguments,
+)
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
@@ -317,14 +324,20 @@ def main():
         is_regression = data_args.task_name == "stsb"
         if not is_regression:
             label_list = raw_datasets["train"].features["label"].names
+            num_labels = len(label_list)
+        else:
+            num_labels = 1
     else:
         # Trying to have good defaults here, don't hesitate to tweak to your needs.
         is_regression = raw_datasets["train"].features["label"].dtype in ["float32", "float64"]
-        if not is_regression:
+        if is_regression:
+            num_labels = 1
+        else:
             # A useful fast method:
             # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.unique
             label_list = raw_datasets["train"].unique("label")
             label_list.sort()  # Let's sort it for determinism
+            num_labels = len(label_list)
 
     # Preprocessing the raw_datasets
     if data_args.task_name is not None:
@@ -340,6 +353,27 @@ def main():
             else:
                 sentence1_key, sentence2_key = non_label_column_names[0], None
 
+    # Some models have set the order of the labels to use, so let's make sure we do use it.
+    label_to_id = None
+    model_config = AutoConfig.from_pretrained(model_args.model_name_or_path)
+    if (
+        model_config.label2id != PretrainedConfig(num_labels=num_labels).label2id
+        and data_args.task_name is not None
+        and not is_regression
+    ):
+        # Some have all caps in their config, some don't.
+        label_name_to_id = {k.lower(): v for k, v in model_config.config.label2id.items()}
+        if list(sorted(label_name_to_id.keys())) == list(sorted(label_list)):
+            label_to_id = {i: int(label_name_to_id[label_list[i]]) for i in range(num_labels)}
+        else:
+            logger.warning(
+                "Your model seems to have been trained with labels, but they don't match the dataset: ",
+                f"model labels: {list(sorted(label_name_to_id.keys()))}, dataset labels: {list(sorted(label_list))}."
+                "\nIgnoring the model labels as a result.",
+            )
+    elif data_args.task_name is None and not is_regression:
+        label_to_id = {v: i for i, v in enumerate(label_list)}
+
     def preprocess_function(examples, tokenizer: PreTrainedTokenizer, max_length: Optional[int] = None):
         # Tokenize the texts
         args = (
@@ -348,6 +382,10 @@ def main():
         result = tokenizer(
             *args, padding="max_length", max_length=min(max_length, tokenizer.model_max_length), truncation=True
         )
+
+        # Map labels to IDs (not necessary for GLUE tasks)
+        if label_to_id is not None and "label" in examples:
+            result["label"] = [(label_to_id[l] if l != -1 else -1) for l in examples["label"]]
         return result
 
     # Get the metric function

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -324,20 +324,14 @@ def main():
         is_regression = data_args.task_name == "stsb"
         if not is_regression:
             label_list = raw_datasets["train"].features["label"].names
-            num_labels = len(label_list)
-        else:
-            num_labels = 1
     else:
         # Trying to have good defaults here, don't hesitate to tweak to your needs.
         is_regression = raw_datasets["train"].features["label"].dtype in ["float32", "float64"]
-        if is_regression:
-            num_labels = 1
-        else:
+        if not is_regression:
             # A useful fast method:
             # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.unique
             label_list = raw_datasets["train"].unique("label")
             label_list.sort()  # Let's sort it for determinism
-            num_labels = len(label_list)
 
     # Preprocessing the raw_datasets
     if data_args.task_name is not None:
@@ -353,27 +347,6 @@ def main():
             else:
                 sentence1_key, sentence2_key = non_label_column_names[0], None
 
-    # Some models have set the order of the labels to use, so let's make sure we do use it.
-    label_to_id = None
-    model_config = AutoConfig.from_pretrained(model_args.model_name_or_path)
-    if (
-        model_config.label2id != PretrainedConfig(num_labels=num_labels).label2id
-        and data_args.task_name is not None
-        and not is_regression
-    ):
-        # Some have all caps in their config, some don't.
-        label_name_to_id = {k.lower(): v for k, v in model_config.label2id.items()}
-        if list(sorted(label_name_to_id.keys())) == list(sorted(label_list)):
-            label_to_id = {i: int(label_name_to_id[label_list[i]]) for i in range(num_labels)}
-        else:
-            logger.warning(
-                "Your model seems to have been trained with labels, but they don't match the dataset: ",
-                f"model labels: {list(sorted(label_name_to_id.keys()))}, dataset labels: {list(sorted(label_list))}."
-                "\nIgnoring the model labels as a result.",
-            )
-    elif data_args.task_name is None and not is_regression:
-        label_to_id = {v: i for i, v in enumerate(label_list)}
-
     def preprocess_function(examples, tokenizer: PreTrainedTokenizer, max_length: Optional[int] = None):
         # Tokenize the texts
         args = (
@@ -382,10 +355,6 @@ def main():
         result = tokenizer(
             *args, padding="max_length", max_length=min(max_length, tokenizer.model_max_length), truncation=True
         )
-
-        # Map labels to IDs (not necessary for GLUE tasks)
-        if label_to_id is not None and "label" in examples:
-            result["label"] = [(label_to_id[l] if l != -1 else -1) for l in examples["label"]]
         return result
 
     # Get the metric function
@@ -516,6 +485,10 @@ def main():
         eval_dataset = preprocessed_datasets["validation_matched" if data_args.task_name == "mnli" else "validation"]
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
+        if quantizer.model.config.label2id:
+            eval_dataset = eval_dataset.align_labels_with_mapping(
+                label2id=quantizer.model.config.label2id, label_column="label"
+            )
 
         ort_model = ORTModel(
             quantized_model_path,

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -31,7 +31,7 @@ import datasets
 import numpy as np
 import transformers
 from datasets import ClassLabel, load_dataset, load_metric
-from transformers import HfArgumentParser, PreTrainedTokenizer, TrainingArguments
+from transformers import HfArgumentParser, PretrainedConfig, PreTrainedTokenizer, TrainingArguments
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
@@ -308,11 +308,11 @@ def main():
     # https://huggingface.co/docs/datasets/loading_datasets.html.
 
     if training_args.do_eval:
+        if "validation" not in raw_datasets:
+            raise ValueError("--do_eval requires a validation dataset")
         column_names = raw_datasets["validation"].column_names
-        features = raw_datasets["validation"].features
     else:
         column_names = raw_datasets["train"].column_names
-        features = raw_datasets["train"].features
 
     if data_args.text_column_name is not None:
         text_column_name = data_args.text_column_name
@@ -327,6 +327,19 @@ def main():
         label_column_name = f"{data_args.task_name}_tags"
     else:
         label_column_name = column_names[1]
+
+    if training_args.do_eval:
+        # Preprocess the evaluation dataset
+        eval_dataset = raw_datasets["validation"]
+        if data_args.max_eval_samples is not None:
+            eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
+
+        label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
+        if label2id:
+            eval_dataset = eval_dataset.align_labels_with_mapping(label2id=label2id, label_column=label_column_name)
+        features = eval_dataset.features
+    else:
+        features = raw_datasets["train"].features
 
     # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
     # unique labels.
@@ -531,12 +544,6 @@ def main():
     if training_args.do_eval:
         logger.info("*** Evaluate ***")
 
-        # Preprocess the evaluation dataset
-        if "validation" not in raw_datasets:
-            raise ValueError("--do_eval requires a validation dataset")
-        eval_dataset = raw_datasets["validation"]
-        if data_args.max_eval_samples is not None:
-            eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
         with training_args.main_process_first(desc="validation dataset map pre-processing"):
             eval_dataset = eval_dataset.map(
                 partial(tokenize_and_align_labels, tokenizer=quantizer.preprocessor),


### PR DESCRIPTION
# What does this PR do?

Fix a bug for certain text-classification models using a sentence pair input. 

In text classification, some models have different ids than the dataset label for the same label name. For example, in glue/mnli, the model `roberta-large-mnli` has

```
  "label2id": {
    "CONTRADICTION": 0,
    "ENTAILMENT": 2,
    "NEUTRAL": 1
  },
```

while the dataset labels has the order `"label": {"num_classes": 3, "names": ["entailment", "neutral", "contradiction"]`, effectively swapping "contradiction" and "entailment" labels.

In transformers example, this is fixed using an additional piece of code, see https://github.com/huggingface/transformers/blob/d6b8e9cec7301ba02f642588a6f12e78ec3b9798/examples/pytorch/text-classification/run_glue.py#L395-L413 . This piece of code is missing in the optimization and quantization examples (although not in the training example) and this PR add it back.

Note that, for example for glue/mnli, the `label_to_id` ends up being `{0: 2, 1: 1, 2: 0}`, correcting the swap between the labels 0 and 2.


## Before submitting
- [x] This PR fixes a bug
