### PR TITLE
Pin protobuf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ REQUIRED_PKGS = [
     "packaging",
     "numpy",
     "huggingface_hub==0.4.0",
+    "protobuf<=3.20.1"
 ]
 
 TESTS_REQUIRE = ["pytest", "requests", "parameterized", "pytest-xdist"]


### PR DESCRIPTION
# What does this PR do?

The recent release of Protobuf (4.21) has broken the doc build & ONNX Runtime modules:

```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

This PR pins protobuf to fix the issue.
