### PR TITLE
Bump `huggingface_hub` version to be able to use `evaluate` & `protobuf` fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.5.4"]
 
 EXTRAS_REQUIRE = {
     #  pip install -e ".[onnxruntime,dev,intel]"  git+https://github.com/huggingface/transformers.git@main --upgrade
-    "onnxruntime": ["onnx", "onnxruntime>=1.9.0", "datasets>=1.2.1"],  # "transformers[sentencepiece]>4.17.0"],
-    "onnxruntime-gpu": ["onnx", "onnxruntime-gpu>=1.9.0", "datasets>=1.2.1"],  # "transformers[sentencepiece]>4.17.0"],
+    "onnxruntime": ["onnx", "onnxruntime>=1.9.0", "datasets>=1.2.1","protobuf==3.20.1"],  # "transformers[sentencepiece]>4.17.0"],
+    "onnxruntime-gpu": ["onnx", "onnxruntime-gpu>=1.9.0", "datasets>=1.2.1","protobuf==3.20.1"],  # "transformers[sentencepiece]>4.17.0"],
     "intel": [
         "pycocotools",
         "neural_compressor>=1.9",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIRED_PKGS = [
     "torch>=1.9",
     "packaging",
     "numpy",
-    "huggingface_hub==0.4.0",
+    "huggingface_hub>=0.4.0",
 ]
 
 TESTS_REQUIRE = ["pytest", "requests", "parameterized", "pytest-xdist"]


### PR DESCRIPTION
# What does this PR do?

Bump `huggingface_hub` version to be able to use evaluate