### PR TITLE
[Fix] Local Load and save for ORTModel for optimized/quantized models

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -167,6 +167,7 @@ class ORTModel(OptimizedModel):
             config = PretrainedConfig.from_dict(config_dict)
             model = ORTModel.load_model(os.path.join(model_id, model_file_name))
             kwargs["model_save_dir"] = Path(model_id)
+            kwargs["latest_model_name"] = model_file_name
         # load model from hub
         else:
             # download model

--- a/tests/onnxruntime/test_modeling_ort.py
+++ b/tests/onnxruntime/test_modeling_ort.py
@@ -1,6 +1,8 @@
 import os
+import shutil
 import tempfile
 import unittest
+from pathlib import Path
 
 import torch
 from transformers import (
@@ -66,6 +68,18 @@ class ORTModelIntergrationTest(unittest.TestCase):
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(ONNX_WEIGHTS_NAME in folder_contents)
             self.assertTrue(CONFIG_NAME in folder_contents)
+
+    def test_save_model_with_different_name(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            test_model_name = "model-test.onnx"
+            local_model_path = str(Path(f"tests/{self.LOCAL_MODEL_PATH}").joinpath("model.onnx").absolute())
+            # copy two models to simulate a optimization
+            shutil.copy(local_model_path, os.path.join(tmpdirname, test_model_name))
+            shutil.copy(local_model_path, os.path.join(tmpdirname, "model.onnx"))
+
+            model = ORTModel.from_pretrained(tmpdirname, file_name=test_model_name)
+
+            self.assertEqual(model.latest_model_name, test_model_name)
 
     @require_hf_token
     def test_save_model_from_hub(self):

--- a/tests/onnxruntime/test_modeling_ort.py
+++ b/tests/onnxruntime/test_modeling_ort.py
@@ -72,7 +72,7 @@ class ORTModelIntergrationTest(unittest.TestCase):
     def test_save_model_with_different_name(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             test_model_name = "model-test.onnx"
-            local_model_path = str(Path(f"tests/{self.LOCAL_MODEL_PATH}").joinpath("model.onnx").absolute())
+            local_model_path = str(Path(self.LOCAL_MODEL_PATH).joinpath("model.onnx").absolute())
             # copy two models to simulate a optimization
             shutil.copy(local_model_path, os.path.join(tmpdirname, test_model_name))
             shutil.copy(local_model_path, os.path.join(tmpdirname, "model.onnx"))


### PR DESCRIPTION
# What does this PR do?

Currently when you load a locally saved optimized/quantized model (different file name than `model.onnx`) with `from_pretrained` it will correctly load but is not saving the "file" name for saving the model in a later state. Currently it always defaults to `model.onnx`. 

Reproduce:

```python
model = ORTModelForSequenceClassification.from_pretrained(onnx_path,file_name="model-quantized.onnx")
print(model.latest_model_name)
# model.onnx
model.save_pretrained(tmp_store_directory)
# save the model.onnx and not the model-quantized.onnx
```

Current workaround is to set `model.latest_model_name` to `file_name` after loading. 