### PR TITLE
Remove pydantic for benchmarks & use dataclass instead

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -30,3 +30,7 @@
   - local: intel/trainer
     title: Trainer
   title: Intel Neural Compressor
+- sections:
+  - local: benchmark
+    title: Benchmark Optimum models
+  title: API Reference

--- a/docs/source/benchmark.mdx
+++ b/docs/source/benchmark.mdx
@@ -1,0 +1,43 @@
+
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Benchmarking
+
+## Run
+
+[[autodoc]] optimum.runs_base.Run
+    - __init__
+    - launch
+    - load_datasets
+    - get_calibration_dataset
+    - get_eval_dataset
+
+## RunConfig
+
+[[autodoc]] optimum.utils.runs.RunConfig
+    - all
+
+[[autodoc]] optimum.utils.runs.Calibration
+    - all
+
+[[autodoc]] optimum.utils.runs.DatasetArgs
+    - all
+
+[[autodoc]] optimum.utils.runs.TaskArgs
+    - all
+
+## Processing utility methods
+
+[[autodoc]] optimum.utils.preprocessing.base.DatasetProcessing
+    - __init__
+    - load_datasets
+    - run_inference
+    - get_metrics
+    - get_pipeline_kwargs

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -17,7 +17,12 @@ import importlib.util
 CONFIG_NAME = "config.json"
 
 _onnxruntime_available = importlib.util.find_spec("onnxruntime") is not None
+_pydantic_available = importlib.util.find_spec("pydantic") is not None
 
 
 def is_onnxruntime_available():
     return _onnxruntime_available
+
+
+def is_pydantic_available():
+    return _pydantic_available

--- a/optimum/utils/doc.py
+++ b/optimum/utils/doc.py
@@ -1,20 +1,31 @@
-def generate_doc_basemodel(cls) -> str:
-    """Class decorator for pydantic's BaseModel to generate the documentation."""
+from dataclasses import fields
+
+
+def generate_doc_dataclass(cls) -> str:
+    """Class decorator for generate the documentation for dataclass."""
     doc = "\f\nAttributes:\n"
-    for name, field in cls.__fields__.items():
-        field_info = field.field_info
-        doc += f"   {name}"  # argument name
+    for attribute in fields(cls):
+        doc += f"   {attribute.name}"  # attribute name
 
-        # argument type and whether optional
-        type_display = str(field._type_display())
-        optional = True if type_display.startswith("Optional") else False
-        if optional:
-            type_str = type_display[type_display.find("[") + 1 : -1]
-            doc += f" (`{type_str}`, *optional*): "
+        # whether optional
+        attribute_type = str(attribute.type)
+        if attribute_type.startswith("typing.Optional"):
+            optional = True
+            type_display = attribute_type[attribute_type.find("[") + 1 : -1]
+            type_display = type_display.split(".")[-1]
         else:
-            type_str = type_display
-            doc += f" (`{type_str}`): "
+            optional = False
 
-        doc += f"{field_info.description}\n"  # argument description
+            if attribute_type.startswith("typing"):
+                type_display = attribute_type.split(".")[-1]
+            else:
+                type_display = attribute.type.__name__
+
+        if optional:
+            doc += f" (`{type_display}`, *optional*): "
+        else:
+            doc += f" (`{type_display}`): "
+
+        doc += f"{attribute.metadata['description']}\n"  # argument description
     cls.__doc__ = (cls.__doc__ if cls.__doc__ is not None else "") + "\n\n" + "".join(doc)
     return cls

--- a/optimum/utils/runs.py
+++ b/optimum/utils/runs.py
@@ -1,9 +1,15 @@
+from dataclasses import field
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Extra, Field, validator
+from . import is_pydantic_available
+from .doc import generate_doc_dataclass
 
-from .doc import generate_doc_basemodel
+
+if is_pydantic_available():
+    from pydantic.dataclasses import dataclass
+else:
+    from dataclasses import dataclass
 
 
 class APIFeaturesManager:
@@ -50,167 +56,210 @@ class QuantizationApproach(str, Enum):
     dynamic = "dynamic"
 
 
-class BaseModelNoExtra(BaseModel):
-    class Config:
-        extra = Extra.forbid  # ban additional arguments
-
-
-@generate_doc_basemodel
-class Calibration(BaseModelNoExtra):
+@generate_doc_dataclass
+@dataclass
+class Calibration:
     """Parameters for post-training calibration with static quantization."""
 
-    method: CalibrationMethods = Field(
-        ..., description='Calibration method used, either "minmax", "entropy" or "percentile".'
+    method: CalibrationMethods = field(
+        metadata={"description": 'Calibration method used, either "minmax", "entropy" or "percentile".'}
     )
-    num_calibration_samples: int = Field(
-        ..., description="Number of examples to use for the calibration step resulting from static quantization."
+    num_calibration_samples: int = field(
+        metadata={
+            "description": "Number of examples to use for the calibration step resulting from static quantization."
+        }
     )
-    calibration_histogram_percentile: Optional[float] = Field(
-        None, description="The percentile used for the percentile calibration method."
+    calibration_histogram_percentile: Optional[float] = field(
+        default=None, metadata={"description": "The percentile used for the percentile calibration method."}
     )
-    calibration_moving_average: Optional[bool] = Field(
-        None,
-        description="Whether to compute the moving average of the minimum and maximum values for the minmax calibration method.",
+    calibration_moving_average: Optional[bool] = field(
+        default=None,
+        metadata={
+            "description": "Whether to compute the moving average of the minimum and maximum values for the minmax calibration method."
+        },
     )
-    calibration_moving_average_constant: Optional[float] = Field(
-        None,
-        description="Constant smoothing factor to use when computing the moving average of the minimum and maximum values. Effective only when the selected calibration method is minmax and `calibration_moving_average` is set to True.",
+    calibration_moving_average_constant: Optional[float] = field(
+        default=None,
+        metadata={
+            "description": "Constant smoothing factor to use when computing the moving average of the minimum and maximum values. Effective only when the selected calibration method is minmax and `calibration_moving_average` is set to True."
+        },
     )
 
 
-class FrameworkArgs(BaseModelNoExtra):
-    opset: Optional[int] = Field(15, description="ONNX opset version to export the model with.")
-    optimization_level: Optional[int] = 0
+@generate_doc_dataclass
+@dataclass
+class FrameworkArgs:
+    opset: Optional[int] = field(default=15, metadata={"description": "ONNX opset version to export the model with."})
+    optimization_level: Optional[int] = field(default=0, metadata={"description": "ONNX optimization level."})
 
-    @validator("opset")
-    def opset_check(cls, field_value):
-        assert field_value <= 15, f"Unsupported OnnxRuntime opset: {field_value}"
-        return field_value
+    def __post_init__(self):
+        # validate `opset`
+        assert self.opset <= 15, f"Unsupported OnnxRuntime opset: {self.opset}"
 
-    @validator("optimization_level")
-    def model_type_check(cls, field_value, values):
-        assert field_value in [0, 1, 2, 99], f"Unsupported OnnxRuntime optimization level: {field_value}"
-        return field_value
-
-
-class Versions(BaseModelNoExtra):
-    transformers: str = Field(..., description="Transformers version.")
-    optimum: str = Field(..., description="Optimum version.")
-    optimum_hash: Optional[str]
-    onnxruntime: Optional[str]
-    torch_ort: Optional[str]
+        # validate `optimization_level`
+        assert self.optimization_level in [
+            0,
+            1,
+            2,
+            99,
+        ], f"Unsupported OnnxRuntime optimization level: {self.optimization_level}"
 
 
-class Evaluation(BaseModelNoExtra):
-    time: List[Dict]
-    others: Dict
+@generate_doc_dataclass
+@dataclass
+class Versions:
+    transformers: str = field(metadata={"description": "Transformers version."})
+    optimum: str = field(metadata={"description": "Optimum version."})
+    optimum_hash: Optional[str] = field(
+        default=None, metadata={"description": "Optimum commit hash, in case the dev version is used."}
+    )
+    onnxruntime: Optional[str] = field(default=None, metadata={"description": "Onnx Runtime version."})
+    torch_ort: Optional[str] = field(default=None, metadata={"description": "Torch-ort version."})
 
-    @validator("others")
-    def others_check(cls, field_value):
-        assert "baseline" in field_value
-        assert "optimized" in field_value
-        for metric_name, metric_dict in field_value["baseline"].items():
-            assert metric_dict.keys() == field_value["optimized"][metric_name].keys()
-        return field_value
+
+@generate_doc_dataclass
+@dataclass
+class Evaluation:
+    time: List[Dict] = field(metadata={"description": "Measures of inference time (latency, throughput)."})
+    others: Dict = field(metadata={"description": "Metrics measuring the performance on the given task."})
+
+    def __post_init__(self):
+        # validate `others`
+        assert "baseline" in self.others
+        assert "optimized" in self.others
+        for metric_name, metric_dict in self.others["baseline"].items():
+            assert metric_dict.keys() == self.others["optimized"][metric_name].keys()
 
 
-@generate_doc_basemodel
-class DatasetArgs(BaseModelNoExtra):
+@generate_doc_dataclass
+@dataclass
+class DatasetArgs:
     """Parameters related to the dataset."""
 
-    path: str = Field(..., description="Path to the dataset, as in `datasets.load_dataset(path)`.")
-    name: Optional[str] = Field(None, description="Name of the dataset, as in `datasets.load_dataset(path, name)`.")
-    calibration_split: Optional[str] = Field(None, description='Dataset split used for calibration (e.g. "train").')
-    eval_split: str = Field(..., description='Dataset split used for evaluation (e.g. "test").')
-    # TODO auto-infer with train-eval-index if available
-    data_keys: Dict[str, Union[None, str]] = Field(
-        ..., description='Dataset columns used as input data. At most two, indicated with "primary" and "secondary".'
+    path: str = field(metadata={"description": "Path to the dataset, as in `datasets.load_dataset(path)`."})
+    eval_split: str = field(metadata={"description": 'Dataset split used for evaluation (e.g. "test").'})
+    data_keys: Dict[str, Union[None, str]] = field(
+        metadata={
+            "description": 'Dataset columns used as input data. At most two, indicated with "primary" and "secondary".'
+        }
     )
-    ref_keys: List[str] = Field(..., description="Dataset column used for references during evaluation.")
+    ref_keys: List[str] = field(metadata={"description": "Dataset column used for references during evaluation."})
+    name: Optional[str] = field(
+        default=None, metadata={"description": "Name of the dataset, as in `datasets.load_dataset(path, name)`."}
+    )
+    calibration_split: Optional[str] = field(
+        default=None, metadata={"description": 'Dataset split used for calibration (e.g. "train").'}
+    )
 
 
-@generate_doc_basemodel
-class TaskArgs(BaseModelNoExtra):
+@generate_doc_dataclass
+@dataclass
+class TaskArgs:
     """Task-specific parameters."""
 
-    is_regression: Optional[bool] = Field(
-        None, description="Text classification specific. Set whether the task is regression (output = one float)."
+    is_regression: Optional[bool] = field(
+        default=None,
+        metadata={
+            "description": "Text classification specific. Set whether the task is regression (output = one float)."
+        },
     )
 
 
-@generate_doc_basemodel
-class Run(BaseModelNoExtra):
-    model_name_or_path: str = Field(..., description="Name of the model hosted on the Hub to use for the run.")
-    task: str = Field(..., description="Task performed by the model.")
-    task_args: Optional[TaskArgs] = Field(None, description="Task-specific arguments (default: `None`).")
-    quantization_approach: QuantizationApproach = Field(
-        ..., description="Whether to use dynamic or static quantization."
+@dataclass
+class _RunBase:
+    model_name_or_path: str = field(
+        metadata={"description": "Name of the model hosted on the Hub to use for the run."}
     )
-    dataset: DatasetArgs = Field(
-        ..., description="Dataset to use. Several keys must be set on top of the dataset name."
+    task: str = field(metadata={"description": "Task performed by the model."})
+    quantization_approach: QuantizationApproach = field(
+        metadata={"description": "Whether to use dynamic or static quantization."}
     )
-    operators_to_quantize: Optional[List[str]] = Field(
-        ["Add", "MatMul"],
-        description='Operators to quantize, doing no modifications to others (default: `["Add", "MatMul"]`).',
+    dataset: DatasetArgs = field(
+        metadata={"description": "Dataset to use. Several keys must be set on top of the dataset name."}
     )
-    node_exclusion: Optional[List[str]] = Field(
-        [], description="Specific nodes to exclude from being quantized (default: `[]`)."
+    framework: Frameworks = field(metadata={"description": 'Name of the framework used (e.g. "onnxruntime").'})
+    framework_args: FrameworkArgs = field(metadata={"description": "Framework-specific arguments."})
+
+
+@dataclass
+class _RunDefaults:
+    operators_to_quantize: Optional[List[str]] = field(
+        default_factory=lambda: ["Add", "MatMul"],
+        metadata={
+            "description": 'Operators to quantize, doing no modifications to others (default: `["Add", "MatMul"]`).'
+        },
     )
-    per_channel: Optional[bool] = Field(False, description="Whether to quantize per channel (default: `False`).")
-    calibration: Optional[Calibration] = Field(
-        None, description="Calibration parameters, in case static quantization is used."
+    node_exclusion: Optional[List[str]] = field(
+        default_factory=lambda: [],
+        metadata={"description": "Specific nodes to exclude from being quantized (default: `[]`)."},
     )
-    framework: Frameworks = Field(..., description='Name of the framework used (e.g. "onnxruntime").')
-    framework_args: FrameworkArgs = Field(..., description="Framework-specific arguments.")
-    aware_training: Optional[bool] = Field(
-        False, description="Whether the quantization is to be done with Quantization-Aware Training (not supported)."
+    per_channel: Optional[bool] = field(
+        default=False, metadata={"description": "Whether to quantize per channel (default: `False`)."}
+    )
+    calibration: Optional[Calibration] = field(
+        default=None, metadata={"description": "Calibration parameters, in case static quantization is used."}
+    )
+    task_args: Optional[TaskArgs] = field(
+        default=None, metadata={"description": "Task-specific arguments (default: `None`)."}
+    )
+    aware_training: Optional[bool] = field(
+        default=False,
+        metadata={
+            "description": "Whether the quantization is to be done with Quantization-Aware Training (not supported)."
+        },
     )
 
-    @validator("task")
-    def model_type_check(cls, field_value):
-        APIFeaturesManager.check_supported_task(task=field_value)
-        return field_value
 
-    @validator("task_args")
-    def task_args_check(cls, field_value, values):
-        if values["task"] == "text-classification":
-            message = "For text classification, whether the task is regression should be explicity specified in the task_args.is_regression key."
-            assert field_value != None, message
-            assert field_value.is_regression != None, message
-        return field_value
-
-    @validator("dataset")
-    def dataset_check(cls, field_value, values):
-        if values["quantization_approach"] == "static":
-            assert (
-                field_value.calibration_split
-            ), "Calibration split should be passed for static quantization in the dataset.calibration_split key."
-        return field_value
-
-    @validator("calibration")
-    def calibration_check(cls, field_value, values):
-        if values["quantization_approach"] == "static":
-            assert (
-                field_value
-            ), "Calibration parameters should be passed for static quantization in the calibration key."
-        return field_value
-
-    @validator("aware_training")
-    def aware_training_check(cls, field_value):
-        assert field_value == False, "Quantization-Aware Training not supported."
-        return field_value
-
-
-@generate_doc_basemodel
-class RunConfig(Run):
+@dataclass
+class _RunConfigBase:
     """Parameters defining a run. A run is an evaluation of a triplet (model, dataset, metric) coupled with optimization parameters, allowing to compare a transformers baseline and a model optimized with Optimum."""
 
-    metrics: List[str] = Field(
-        ..., description="List of metrics to evaluate on."
-    )  # TODO check that the passed metrics are fine for the given task/dataset
-    batch_sizes: Optional[List[int]] = Field(
-        [4, 8], description="Batch sizes to include in the run to measure time metrics."
+    metrics: List[str] = field(metadata={"description": "List of metrics to evaluate on."})
+
+
+@dataclass
+class _RunConfigDefaults(_RunDefaults):
+    batch_sizes: Optional[List[int]] = field(
+        default_factory=lambda: [4, 8],
+        metadata={"description": "Batch sizes to include in the run to measure time metrics."},
     )
-    input_lengths: Optional[List[int]] = Field(
-        [128], description="Input lengths to include in the run to measure time metrics."
+    input_lengths: Optional[List[int]] = field(
+        default_factory=lambda: [128],
+        metadata={"description": "Input lengths to include in the run to measure time metrics."},
     )
+
+
+@dataclass
+class Run(_RunDefaults, _RunBase):
+    def __post_init__(self):
+        # validate `task`
+        APIFeaturesManager.check_supported_task(task=self.task)
+
+        # validate `task_args`
+        if self.task == "text-classification":
+            message = "For text classification, whether the task is regression should be explicity specified in the task_args.is_regression key."
+            assert self.task_args != None, message
+            assert self.task_args["is_regression"] != None, message
+
+        # validate `dataset`
+        if self.quantization_approach == "static":
+            assert self.dataset[
+                "calibration_split"
+            ], "Calibration split should be passed for static quantization in the dataset.calibration_split key."
+
+        # validate `calibration`
+        if self.quantization_approach == "static":
+            assert (
+                self.calibration
+            ), "Calibration parameters should be passed for static quantization in the calibration key."
+
+        # validate `aware_training`
+        assert self.aware_training == False, "Quantization-Aware Training not supported."
+
+
+@generate_doc_dataclass
+@dataclass
+class RunConfig(Run, _RunConfigDefaults, _RunConfigBase):
+    """Class holding the parameters to launch a run."""
+
+    pass

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ EXTRAS_REQUIRE = {
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
     "quality": QUALITY_REQUIRE,
-    "benchmarks": ["pydantic"],
 }
 
 setup(


### PR DESCRIPTION
# What does this PR do?

Remove the previous pydantic dependency for the benchmark code. This PR allows to generate the documentation without additional dependencies.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

