### PR TITLE
Add ORTOptimizer DeBERTa-V2 models support

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -57,6 +57,7 @@ class ORTConfigManager:
         "albert": ("num_attention_heads", "hidden_size", "bert"),
         "camembert": ("num_attention_heads", "hidden_size", "bert"),
         "distilbert": ("n_heads", "dim", "bert"),
+        "deberta": ("num_attention_heads", "hidden_size", "bert"),
         "deberta-v2": ("num_attention_heads", "hidden_size", "bert"),
         "electra": ("num_attention_heads", "hidden_size", "bert"),
         "roberta": ("num_attention_heads", "hidden_size", "bert"),

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -57,6 +57,7 @@ class ORTConfigManager:
         "albert": ("num_attention_heads", "hidden_size", "bert"),
         "camembert": ("num_attention_heads", "hidden_size", "bert"),
         "distilbert": ("n_heads", "dim", "bert"),
+        "deberta-v2": ("num_attention_heads", "hidden_size", "bert"),
         "electra": ("num_attention_heads", "hidden_size", "bert"),
         "roberta": ("num_attention_heads", "hidden_size", "bert"),
         "bart": ("encoder_attention_heads", "d_model", "bart"),

--- a/tests/onnxruntime/test_onnxruntime.py
+++ b/tests/onnxruntime/test_onnxruntime.py
@@ -52,7 +52,7 @@ class TestORTOptimizer(unittest.TestCase):
             "gpt2",
             "roberta-base",
             "google/electra-small-discriminator",
-            "microsoft/deberta-v2-xlarge",
+            "microsoft/deberta-v3-xsmall",
         }
         optimization_config = OptimizationConfig(optimization_level=99, optimize_with_onnxruntime_only=False)
         for model_name in model_names:

--- a/tests/onnxruntime/test_onnxruntime.py
+++ b/tests/onnxruntime/test_onnxruntime.py
@@ -52,7 +52,6 @@ class TestORTOptimizer(unittest.TestCase):
             "gpt2",
             "roberta-base",
             "google/electra-small-discriminator",
-            "microsoft/deberta-v3-xsmall",
         }
         optimization_config = OptimizationConfig(optimization_level=99, optimize_with_onnxruntime_only=False)
         for model_name in model_names:

--- a/tests/onnxruntime/test_onnxruntime.py
+++ b/tests/onnxruntime/test_onnxruntime.py
@@ -52,6 +52,7 @@ class TestORTOptimizer(unittest.TestCase):
             "gpt2",
             "roberta-base",
             "google/electra-small-discriminator",
+            "microsoft/deberta-v2-xlarge",
         }
         optimization_config = OptimizationConfig(optimization_level=99, optimize_with_onnxruntime_only=False)
         for model_name in model_names:


### PR DESCRIPTION
# What does this PR do?

* Register DeBERTa-V2 in `ORTConfigManager`.
* Add to the test.

Fixes #207 