### PR TITLE
Fix documentation dependency

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -52,7 +52,7 @@ jobs:
           pip install git+https://github.com/huggingface/doc-builder
           cd optimum
           echo "VERSION=$(grep '^__version__ =' optimum/version.py | cut -d '=' -f 2- | xargs)" >> $GITHUB_ENV
-          pip install .[dev,onnxruntime,intel]
+          pip install .[dev,onnxruntime,intel,benchmark]
           python -c "from optimum import intel; print(dir(intel))" 
           cd ..
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -47,7 +47,7 @@ jobs:
           cd optimum
           apt install -y libopencv-dev python3-opencv
           pip install --upgrade protobuf
-          pip install .[dev,onnxruntime,intel]
+          pip install .[dev,onnxruntime,intel,benchmark]
           cd ..
 
       - name: Comment PR

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ EXTRAS_REQUIRE = {
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
     "quality": QUALITY_REQUIRE,
+    "benchmark": ["optuna", "tqdm"],
 }
 
 setup(


### PR DESCRIPTION
# What does this PR do?

Install the dependencies on `optuna` and `tqdm` before generating the documentation (necessary for the benchmark part). For some reason the action `build_pr_documentation` passed (see https://github.com/huggingface/optimum/actions/runs/2455809780 or this PR dev doc), but the `build_documentation` fails because of missing dependencies still (760a7e6e4aba963feefd1fae86fa8590d1200ada).


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

