### PR TITLE
Fix doc versions

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -51,10 +51,20 @@ jobs:
           sudo pip install --upgrade pip && sudo pip install --upgrade protobuf
           pip install git+https://github.com/huggingface/doc-builder
           cd optimum
-          echo "VERSION=$(grep '^__version__ =' optimum/version.py | cut -d '=' -f 2- | xargs)" >> $GITHUB_ENV
           pip install .[dev,onnxruntime,benchmark]
           python -c "from optimum import intel; print(dir(intel))" 
           cd ..
+
+      - name: Set env variables
+        run: |
+        version=`echo "$(grep '^__version__ =' optimum/version.py | cut -d '=' -f 2- | xargs)"`
+
+        if [[ $version == *.dev0 ]]
+        then
+          echo "VERSION=main" >> $GITHUB_ENV
+        else
+          "VERSION=v$version" >> $GITHUB_ENV
+        fi
 
       - name: Setup git
         run: |
@@ -67,8 +77,14 @@ jobs:
 
       - name: Make documentation
         run: |
+          if [[ $ver == *.dev0 ]] 
+          then
+            version="main"
+          else
+            version=ver
+          fi
           cd doc-builder &&
-          doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version v${{ env.VERSION }} --html &&
+          doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version ${{ env.VERSION }} --html &&
           cd ..
         env:
           NODE_OPTIONS: --max-old-space-size=6656

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -63,7 +63,7 @@ jobs:
         then
           echo "VERSION=main" >> $GITHUB_ENV
         else
-          "VERSION=v$version" >> $GITHUB_ENV
+          echo "VERSION=v$version" >> $GITHUB_ENV
         fi
 
       - name: Setup git

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -77,12 +77,6 @@ jobs:
 
       - name: Make documentation
         run: |
-          if [[ $ver == *.dev0 ]] 
-          then
-            version="main"
-          else
-            version=ver
-          fi
           cd doc-builder &&
           doc-builder build optimum ../optimum/docs/source --build_dir ../doc-build --clean --version ${{ env.VERSION }} --html &&
           cd ..


### PR DESCRIPTION
# What does this PR do?

This PR attempts to fix a problem with the way the docs are versioned with every push to `main` vs from a release branch.

I thought `doc-builder` would automatically build the `main` docs when the `--version` flag contained a `.dev0` suffix, but this turns out to be incorrect.

The current fix checks if `.dev0` exists in the version and then sets the appropriate flag in `doc-builder`

cc @fxmarty @mishig25 


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

