### PR TITLE
updated transformers version in required packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.15.0",
+    "transformers[sentencepiece]>=4.18.0",
     "torch>=1.9",
     "packaging",
     "numpy",


### PR DESCRIPTION
# What does this PR do?
Updates the transformers version in the required packages in setup.py

This [PR](https://github.com/huggingface/optimum/pull/226) (#226) imports the ImageClassifierOutput function from modeling_outputs.py from transformers, but the ImageClassifierOutput function was only added to transformers in versions 4.18.0 and above. 
