### PR TITLE
Correct bug in benchmarks post_init

### DIFF
--- a/optimum/runs_base.py
+++ b/optimum/runs_base.py
@@ -82,6 +82,7 @@ class Run:
         self.return_body = {
             "model_name_or_path": run_config["model_name_or_path"],
             "task": self.task,
+            "task_args": run_config["task_args"],
             "dataset": run_config["dataset"],
             "quantization_approach": run_config["quantization_approach"],
             "operators_to_quantize": run_config["operators_to_quantize"],

--- a/optimum/utils/runs.py
+++ b/optimum/utils/runs.py
@@ -260,6 +260,15 @@ class Run(_RunDefaults, _RunBase):
         # validate `aware_training`
         assert self.aware_training == False, "Quantization-Aware Training not supported."
 
+
+@generate_doc_dataclass
+@dataclass
+class RunConfig(Run, _RunConfigDefaults, _RunConfigBase):
+    """Class holding the parameters to launch a run."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
         # to support python 3.8 that does not support nested initialization of dataclass from dict
         if isinstance(self.dataset, dict):
             self.dataset = DatasetArgs(**self.dataset)
@@ -271,12 +280,3 @@ class Run(_RunDefaults, _RunBase):
             self.task_args = TaskArgs(**self.task_args)
         if isinstance(self.time_benchmark_args, dict):
             self.time_benchmark_args = BenchmarkTimeArgs(**self.time_benchmark_args)
-
-
-@generate_doc_dataclass
-@dataclass
-class RunConfig(Run, _RunConfigDefaults, _RunConfigBase):
-    """Class holding the parameters to launch a run."""
-
-    def __post_init__(self):
-        super().__post_init__()

--- a/optimum/utils/runs.py
+++ b/optimum/utils/runs.py
@@ -260,13 +260,6 @@ class Run(_RunDefaults, _RunBase):
         # validate `aware_training`
         assert self.aware_training == False, "Quantization-Aware Training not supported."
 
-
-@generate_doc_dataclass
-@dataclass
-class RunConfig(Run, _RunConfigDefaults, _RunConfigBase):
-    """Class holding the parameters to launch a run."""
-
-    def __post_init__(self):
         # to support python 3.8 that does not support nested initialization of dataclass from dict
         if isinstance(self.dataset, dict):
             self.dataset = DatasetArgs(**self.dataset)
@@ -278,3 +271,12 @@ class RunConfig(Run, _RunConfigDefaults, _RunConfigBase):
             self.task_args = TaskArgs(**self.task_args)
         if isinstance(self.time_benchmark_args, dict):
             self.time_benchmark_args = BenchmarkTimeArgs(**self.time_benchmark_args)
+
+
+@generate_doc_dataclass
+@dataclass
+class RunConfig(Run, _RunConfigDefaults, _RunConfigBase):
+    """Class holding the parameters to launch a run."""
+
+    def __post_init__(self):
+        super().__post_init__()


### PR DESCRIPTION
`__post_init__()` of parent `Run` class did not run in `RunConfig`. Also, a parameter was missing in the run returned body.
