### PR TITLE
Add InferenceSession options and Provider to ORTModel

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, Union
 
-from transformers import AutoConfig
+from transformers import AutoConfig, add_start_docstrings
 
 import requests
 from huggingface_hub import HfApi, HfFolder, hf_hub_download
@@ -15,6 +15,32 @@ from .utils import CONFIG_NAME
 
 
 logger = logging.getLogger(__name__)
+
+FROM_PRETRAINED_START_DOCSTRING = r"""
+    Instantiate a pretrained model from a pre-trained model configuration.
+
+    Arguments:
+        model_id (`Union[str, Path]`):
+            Can be either:
+                - A string, the *model id* of a pretrained model hosted inside a model repo on huggingface.co.
+                    Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
+                    user or organization name, like `dbmdz/bert-base-german-cased`.
+                - A path to a *directory* containing a model saved using [`~OptimizedModel.save_pretrained`],
+                    e.g., `./my_model_directory/`.
+        from_transformers (`bool`, *optional*, defaults to `False`):
+            Defines whether the provided `model_id` contains a vanilla Transformers checkpoint.
+        force_download (`bool`, *optional*, defaults to `True`):
+            Whether or not to force the (re-)download of the model weights and configuration files, overriding the
+            cached versions if they exist.
+        use_auth_token (`str`, *optional*, defaults to `None`):
+            The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+            when running `transformers-cli login` (stored in `~/.huggingface`).
+        cache_dir (`str`, *optional*, defaults to `None`):
+            Path to a directory in which a downloaded pretrained model configuration should be cached if the
+            standard cache should not be used.
+        local_files_only(`bool`, *optional*, defaults to `False`):
+            Whether or not to only look at local files (i.e., do not try to download the model).
+"""
 
 
 class OptimizedModel(ABC):
@@ -163,6 +189,7 @@ class OptimizedModel(ABC):
         raise NotImplementedError("Overwrite this method in subclass to define how to load your model from pretrained")
 
     @classmethod
+    @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
     def from_pretrained(
         cls,
         model_id: Union[str, Path],
@@ -172,30 +199,7 @@ class OptimizedModel(ABC):
         cache_dir: Optional[str] = None,
         **model_kwargs,
     ):
-        """Instantiate a pretrained model from a pre-trained model configuration.
-
-        Arguments:
-            model_id (`Union[str, Path]`):
-                Can be either:
-                    - A string, the *model id* of a pretrained model hosted inside a model repo on huggingface.co.
-                      Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
-                      user or organization name, like `dbmdz/bert-base-german-cased`.
-                    - A path to a *directory* containing a model saved using [`~OptimizedModel.save_pretrained`],
-                      e.g., `./my_model_directory/`.
-            from_transformers (`bool`, *optional*, defaults to `False`):
-                Defines whether the provided `model_id` contains a vanilla Transformers checkpoint.
-            force_download (`bool`, *optional*, defaults to `True`):
-                Whether or not to force the (re-)download of the model weights and configuration files, overriding the
-                cached versions if they exist.
-            use_auth_token (`str`, *optional*, defaults to `None`):
-                The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
-                when running `transformers-cli login` (stored in `~/.huggingface`).
-            cache_dir (`str`, *optional*, defaults to `None`):
-                Path to a directory in which a downloaded pretrained model configuration should be cached if the
-                standard cache should not be used.
-            local_files_only(`bool`, *optional*, defaults to `False`):
-                Whether or not to only look at local files (i.e., do not try to download the model).
-
+        """
         Returns:
             `OptimizedModel`: The loaded optimized model.
         """

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -116,7 +116,7 @@ class ORTModel(OptimizedModel):
         self._device = get_device_for_provider(self.providers[0])
 
         if self._device == None:
-            logger.warn(
+            logger.warning(
                 f"ORTModel outputs will be sent to CPU as the device could not be inferred from the execution provider {self.providers[0]}."
                 f" Use `ort_model.to()` to send the outputs to the wanted device."
             )

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -158,7 +158,7 @@ class ORTModel(OptimizedModel):
     @staticmethod
     def load_model(
         path: Union[str, Path],
-        provider: Optional[Union[str, List[str]]] = "CPUExecutionProvider",
+        provider: Optional[str] = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
         **kwargs
     ):
@@ -168,25 +168,19 @@ class ORTModel(OptimizedModel):
         Arguments:
             path (`str` or `Path`):
                 Directory from which to load the model.
-            provider (`str` or `List[str]`, *optional*):
-                ONNX Runtime providers to use for loading the model. This can either be a single provider given as a string (for example
-                `CUDAExecutionProvider`) or a list of execution providers to use in priority order.
-                See https://onnxruntime.ai/docs/execution-providers/ for more details. Defaults to `CPUExecutionProvider`.
+            provider (`str`, *optional*):
+                ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/
+                for possible providers. Defaults to `CPUExecutionProvider`.
             session_options (`onnxruntime.SessionOptions`, *optional*),:
                 ONNX Runtime session options to use for loading the model. Defaults to `None`.
         """
-        if isinstance(provider, str):
-            providers = [provider]
-        elif isinstance(provider, list):
-            providers = provider
-
         available_providers = ort.get_available_providers()
-        for provider in providers:
-            if provider not in available_providers:
-                raise ValueError(
-                    f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
-                )
-        return ort.InferenceSession(path, providers=providers, sess_options=session_options)
+        if provider not in available_providers:
+            raise ValueError(
+                f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
+            )
+
+        return ort.InferenceSession(path, providers=[provider], sess_options=session_options)
 
     def _save_pretrained(self, save_directory: Union[str, Path], file_name: Optional[str] = None, **kwargs):
         """
@@ -214,16 +208,15 @@ class ORTModel(OptimizedModel):
         force_download: bool = False,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
-        provider: Union[str, List[str]] = "CPUExecutionProvider",
-        session_options: ort.SessionOptions = None,
+        provider: Optional[str] = "CPUExecutionProvider",
+        session_options: Optional[ort.SessionOptions] = None,
         *args,
         **kwargs
     ):
         """
-        provider (`str` or `List[str]`, *optional*):
-            ONNX Runtime providers to use for loading the model. This can either be a single provider given as a string (for example
-            `CUDAExecutionProvider`) or a list of execution providers to use in priority order.
-            See https://onnxruntime.ai/docs/execution-providers/ for more details. Defaults to `CPUExecutionProvider`.
+        provider (`str`, *optional*):
+            ONNX Runtime providers to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/ for
+            possible providers. Defaults to `CPUExecutionProvider`.
         session_options (`onnxruntime.SessionOptions`, *optional*),:
             ONNX Runtime session options to use for loading the model. Defaults to `None`.
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -107,7 +107,7 @@ class ORTModel(OptimizedModel):
     base_model_prefix = "onnx_model"
     auto_model_class = AutoModel
 
-    def __init__(self, model: ort.InferenceSession, config, **kwargs):
+    def __init__(self, model: ort.InferenceSession = None, config=None, **kwargs):
         self.model = model
         self.config = config
         self.model_save_dir = kwargs.get("model_save_dir", None)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -211,7 +211,7 @@ class ORTModel(OptimizedModel):
         cls,
         model_id: Union[str, Path],
         from_transformers: bool = False,
-        force_download: bool = True,
+        force_download: bool = False,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
         provider: Union[str, List[str]] = "CPUExecutionProvider",

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -186,7 +186,6 @@ class ORTModel(OptimizedModel):
                 raise ValueError(
                     f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
                 )
-
         return ort.InferenceSession(path, providers=providers, sess_options=session_options)
 
     def _save_pretrained(self, save_directory: Union[str, Path], file_name: Optional[str] = None, **kwargs):

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -276,7 +276,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         model_id: Union[str, Path],
         use_auth_token: Optional[Union[bool, str, None]] = None,
         revision: Optional[Union[str, None]] = None,
-        force_download: bool = True,
+        force_download: bool = False,
         cache_dir: Optional[str] = None,
         encoder_file_name: Optional[str] = None,
         decoder_file_name: Optional[str] = None,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, Mapping, Optional, Set, Tuple, Union
+from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 import torch
 import transformers
@@ -167,7 +167,10 @@ class ORTModelForConditionalGeneration(ORTModel):
     ):
         self.config = config
         self.model_save_dir = kwargs.get("model_save_dir", None)
+
+        self.providers = encoder_session.get_providers()
         self._device = get_device_for_provider(encoder_session.get_providers()[0])
+
         self.encoder = ORTEncoder(session=encoder_session, device=self._device)
         self.decoder = ORTDecoder(session=decoder_session, device=self._device)
         self.use_cache = decoder_with_past_session is not None
@@ -189,7 +192,8 @@ class ORTModelForConditionalGeneration(ORTModel):
         encoder_path: Union[str, Path],
         decoder_path: Union[str, Path],
         decoder_with_past_path: Union[str, Path] = None,
-        provider: str = None,
+        provider: Union[str, List[str]] = "CPUExecutionProvider",
+        **kwargs
     ):
         """
         Creates an instance of [`~optimum.onnxruntime.modeling_seq2seq.ORTModelForConditionalGeneration`].
@@ -206,16 +210,27 @@ class ORTModelForConditionalGeneration(ORTModel):
             provider(`str`, *optional*):
                 The ONNX Runtime provider to use for loading the model. Defaults to `"CPUExecutionProvider"`.
         """
-        if provider is None:
-            provider = "CPUExecutionProvider"
+        if isinstance(provider, str):
+            providers = [provider]
+        elif isinstance(provider, list):
+            providers = provider
 
-        encoder_session = onnxruntime.InferenceSession(str(encoder_path), providers=[provider])
-        decoder_session = onnxruntime.InferenceSession(str(decoder_path), providers=[provider])
+        available_providers = onnxruntime.get_available_providers()
+        for provider in providers:
+            if provider not in available_providers:
+                raise ValueError(
+                    f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
+                )
+
+        encoder_session = onnxruntime.InferenceSession(str(encoder_path), providers=providers)
+        decoder_session = onnxruntime.InferenceSession(str(decoder_path), providers=providers)
+
         decoder_with_past_session = None
         # If a decoder_with_past_path is provided, an inference session for the decoder with past key/values as inputs
         # will be enabled
         if decoder_with_past_path is not None:
-            decoder_with_past_session = onnxruntime.InferenceSession(str(decoder_with_past_path), providers=[provider])
+            decoder_with_past_session = onnxruntime.InferenceSession(str(decoder_with_past_path), providers=providers)
+
         return encoder_session, decoder_session, decoder_with_past_session
 
     def _save_pretrained(
@@ -317,6 +332,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 encoder_path=os.path.join(model_id, encoder_file_name),
                 decoder_path=os.path.join(model_id, decoder_file_name),
                 decoder_with_past_path=decoder_with_past_path,
+                **kwargs,            
             )
             kwargs["model_save_dir"] = Path(model_id)
             kwargs["last_encoder_name"] = encoder_file_name
@@ -350,6 +366,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 encoder_path=kwargs["model_save_dir"].joinpath(kwargs["last_encoder_model_name"]),
                 decoder_path=kwargs["model_save_dir"].joinpath(kwargs["last_decoder_model_name"]),
                 decoder_with_past_path=last_decoder_with_past_name,
+                **kwargs,
             )
 
         return cls(*model, config=config, **kwargs)

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -332,7 +332,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 encoder_path=os.path.join(model_id, encoder_file_name),
                 decoder_path=os.path.join(model_id, decoder_file_name),
                 decoder_with_past_path=decoder_with_past_path,
-                **kwargs,            
+                **kwargs,
             )
             kwargs["model_save_dir"] = Path(model_id)
             kwargs["last_encoder_name"] = encoder_file_name

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import tempfile
 import unittest
-from pathlib import Path
 
 import pytest
 import torch
@@ -491,7 +490,6 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
 
         with torch.no_grad():
             transformers_outputs = transformers_model(**tokens)
-        onnx_outputs = onnx_model(**tokens)
 
         # compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
@@ -611,7 +609,6 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         outputs = pipe(text)
 
         self.assertEqual(pipe.device, onnx_model.device)
-        # TODO: shouldn't it be all instead of any?
         self.assertTrue(all(item["score"] > 0.0 for item in outputs))
 
         gc.collect()
@@ -722,6 +719,54 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         gc.collect()
 
 
+class ORTModelForMultipleChoiceIntegrationTest(unittest.TestCase):
+    # Multiple Choice tests are conducted on different models due to mismatch size in model's classifier
+    SUPPORTED_ARCHITECTURES = (
+        "hf-internal-testing/tiny-bert",
+        "hf-internal-testing/tiny-random-camembert",
+        "hf-internal-testing/tiny-xlm-roberta",
+        "hf-internal-testing/tiny-albert",
+        "hf-internal-testing/tiny-electra",
+        "distilbert-base-uncased",
+        "haisongzhang/roberta-tiny-cased",
+    )
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_compare_to_transformers(self, model_id):
+        set_seed(SEED)
+        onnx_model = ORTModelForMultipleChoice.from_pretrained(model_id, from_transformers=True)
+
+        self.assertIsInstance(onnx_model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
+        self.assertIsInstance(onnx_model.config, PretrainedConfig)
+
+        set_seed(SEED)
+        transformers_model = AutoModelForMultipleChoice.from_pretrained(model_id)
+        tokenizer = get_preprocessor(model_id)
+        num_choices = 4
+        first_sentence = ["The sky is blue due to the shorter wavelength of blue light."] * num_choices
+        start = "The color of the sky is"
+        second_sentence = [start + "blue", start + "green", start + "red", start + "yellow"]
+        inputs = tokenizer(first_sentence, second_sentence, truncation=True, padding=True)
+
+        # Unflatten the tokenized inputs values expanding it to the shape [batch_size, num_choices, seq_length]
+        for k, v in inputs.items():
+            inputs[k] = [v[i : i + num_choices] for i in range(0, len(v), num_choices)]
+
+        inputs = dict(inputs.convert_to_tensors(tensor_type="pt"))
+        onnx_outputs = onnx_model(**inputs)
+
+        self.assertTrue("logits" in onnx_outputs)
+        self.assertIsInstance(onnx_outputs.logits, torch.Tensor)
+
+        with torch.no_grad():
+            transformers_outputs = transformers_model(**inputs)
+
+        # Compare tensor outputs
+        self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
+
+        gc.collect()
+
+
 class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES = ("gpt2",)
 
@@ -828,30 +873,11 @@ class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
         "vit": "hf-internal-testing/tiny-random-vit",
     }
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
-    def test_supported_transformers_architectures(self, *args, **kwargs):
-        model_arch, model_id = args
-        model = ORTModelForImageClassification.from_pretrained(model_id, from_transformers=True)
-        self.assertIsInstance(model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
-        self.assertIsInstance(model.config, PretrainedConfig)
-
     def test_load_vanilla_transformers_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:
             _ = ORTModelForImageClassification.from_pretrained(MODEL_NAMES["t5"], from_transformers=True)
 
         self.assertIn("Unrecognized configuration class", str(context.exception))
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
-    def test_model_forward_call(self, *args, **kwargs):
-        model_arch, model_id = args
-        model = ORTModelForImageClassification.from_pretrained(model_id, from_transformers=True)
-        preprocessor = get_preprocessor(model_id)
-        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        image = Image.open(requests.get(url, stream=True).raw)
-        inputs = preprocessor(images=image, return_tensors="pt")
-        outputs = model(**inputs)
-        self.assertTrue("logits" in outputs)
-        self.assertTrue(isinstance(outputs.logits, torch.Tensor))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_compare_to_transformers(self, *args, **kwargs):
@@ -875,7 +901,6 @@ class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
 
         with torch.no_grad():
             trtfs_outputs = trfs_model(**inputs)
-        onnx_outputs = onnx_model(**inputs)
 
         # compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, trtfs_outputs.logits, atol=1e-4))

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -143,6 +143,33 @@ class ORTModelIntegrationTest(unittest.TestCase):
         with self.assertRaises(Exception):
             _ = ORTModelForSeq2SeqLM.from_pretrained(self.TINY_ONNX_SEQ2SEQ_MODEL_ID, local_files_only=True)
 
+    @require_torch_gpu
+    def test_load_model_cuda_provider_list(self):
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider=["CUDAExecutionProvider"])
+        self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+        self.assertListEqual(model.model.get_providers(), model.providers)
+        self.assertEqual(model.device, torch.device("cuda"))
+
+    @require_torch_gpu
+    def test_load_model_cuda_provider_str(self):
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider="CUDAExecutionProvider")
+        self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+        self.assertListEqual(model.model.get_providers(), model.providers)
+        self.assertEqual(model.device, torch.device("cuda"))
+
+    @require_torch_gpu
+    def test_load_model_several_providers(self):
+        model = ORTModel.from_pretrained(
+            self.ONNX_MODEL_ID, provider=["CPUExecutionProvider", "CUDAExecutionProvider"]
+        )
+        self.assertListEqual(model.providers, ["CPUExecutionProvider", "CUDAExecutionProvider"])
+        self.assertListEqual(model.model.get_providers(), model.providers)
+        self.assertEqual(model.device, torch.device("cpu"))
+
+    def test_load_model_unknown_provider(self):
+        with self.assertRaises(ValueError):
+            ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider="FooExecutionProvider")
+
     def test_load_seq2seq_model_from_hub(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
         self.assertIsInstance(model.encoder, ORTEncoder)
@@ -156,6 +183,33 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertIsInstance(model.decoder, ORTDecoder)
         self.assertTrue(model.decoder_with_past is None)
         self.assertIsInstance(model.config, PretrainedConfig)
+
+    @require_torch_gpu
+    def test_load_seq2seq_model_cuda_provider_list(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, provider=["CUDAExecutionProvider"])
+        self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+        self.assertListEqual(model.encoder.get_providers(), model.providers)
+        self.assertEqual(model.device, torch.device("cuda"))
+
+    @require_torch_gpu
+    def test_load_seq2seq_model_cuda_provider_str(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, provider="CUDAExecutionProvider")
+        self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+        self.assertListEqual(model.encoder.get_providers(), model.providers)
+        self.assertEqual(model.device, torch.device("cuda"))
+
+    @require_torch_gpu
+    def test_load_seq2seq_model_several_providers(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained(
+            self.ONNX_SEQ2SEQ_MODEL_ID, provider=["CPUExecutionProvider", "CUDAExecutionProvider"]
+        )
+        self.assertListEqual(model.providers, ["CPUExecutionProvider", "CUDAExecutionProvider"])
+        self.assertListEqual(model.encoder.get_providers(), model.providers)
+        self.assertEqual(model.device, torch.device("cpu"))
+
+    def test_load_seq2seq_model_unknown_provider(self):
+        with self.assertRaises(ValueError):
+            ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, provider="FooExecutionProvider")
 
     def test_load_model_from_hub_without_onnx_model(self):
         with self.assertRaises(EntryNotFoundError):
@@ -557,6 +611,7 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         outputs = pipe(text)
 
         self.assertEqual(pipe.device, onnx_model.device)
+        # TODO: shouldn't it be all instead of any?
         self.assertTrue(all(item["score"] > 0.0 for item in outputs))
 
         gc.collect()
@@ -663,54 +718,6 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.model.device.type.lower(), "cuda")
         # compare model output class
         self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
-
-        gc.collect()
-
-
-class ORTModelForMultipleChoiceIntegrationTest(unittest.TestCase):
-    # Multiple Choice tests are conducted on different models due to mismatch size in model's classifier
-    SUPPORTED_ARCHITECTURES = (
-        "hf-internal-testing/tiny-bert",
-        "hf-internal-testing/tiny-random-camembert",
-        "hf-internal-testing/tiny-xlm-roberta",
-        "hf-internal-testing/tiny-albert",
-        "hf-internal-testing/tiny-electra",
-        "distilbert-base-uncased",
-        "haisongzhang/roberta-tiny-cased",
-    )
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    def test_compare_to_transformers(self, model_id):
-        set_seed(SEED)
-        onnx_model = ORTModelForMultipleChoice.from_pretrained(model_id, from_transformers=True)
-
-        self.assertIsInstance(onnx_model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
-        self.assertIsInstance(onnx_model.config, PretrainedConfig)
-
-        set_seed(SEED)
-        transformers_model = AutoModelForMultipleChoice.from_pretrained(model_id)
-        tokenizer = get_preprocessor(model_id)
-        num_choices = 4
-        first_sentence = ["The sky is blue due to the shorter wavelength of blue light."] * num_choices
-        start = "The color of the sky is"
-        second_sentence = [start + "blue", start + "green", start + "red", start + "yellow"]
-        inputs = tokenizer(first_sentence, second_sentence, truncation=True, padding=True)
-
-        # Unflatten the tokenized inputs values expanding it to the shape [batch_size, num_choices, seq_length]
-        for k, v in inputs.items():
-            inputs[k] = [v[i : i + num_choices] for i in range(0, len(v), num_choices)]
-
-        inputs = dict(inputs.convert_to_tensors(tensor_type="pt"))
-        onnx_outputs = onnx_model(**inputs)
-
-        self.assertTrue("logits" in onnx_outputs)
-        self.assertIsInstance(onnx_outputs.logits, torch.Tensor)
-
-        with torch.no_grad():
-            transformers_outputs = transformers_model(**inputs)
-
-        # Compare tensor outputs
-        self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
 
         gc.collect()
 


### PR DESCRIPTION
`ORTModel.load_model` was not accepting custom session options, making it hard for example to use a given number of CPU cores with an `ORTModel` for inference. Indeed, onnxruntime obey neither `psutil.cpu_affinity` nor `taskset`.

This may close https://github.com/huggingface/optimum/issues/262

## Before submitting
- [x] Did you make sure to update the documentation with your changes?


