### PR TITLE
Adding support for float16 conversion for GPUs

### DIFF
--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -615,6 +615,8 @@ class OptimizationConfig:
         optimize_for_gpu (`bool`, defaults to `False`):
             Whether to optimize the model for GPU inference.
             The optimized graph might contain operators for GPU or CPU only when `optimization_level` > 1.
+        fp16 (`bool`, defaults to `False`):
+            Wether all weights and nodes should be converted from float32 to float16.
         optimize_with_onnxruntime_only (`bool`, defaults to `False`):
             Whether to only use ONNX Runtime to optimize the model and no graph fusion in Python.
         disable_gelu (`bool`, defaults to `False`):
@@ -643,6 +645,7 @@ class OptimizationConfig:
 
     optimization_level: int = 1
     optimize_for_gpu: bool = False
+    fp16: bool = False
     optimize_with_onnxruntime_only: bool = False
     disable_gelu: bool = False
     disable_layer_norm: bool = False

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -616,7 +616,7 @@ class OptimizationConfig:
             Whether to optimize the model for GPU inference.
             The optimized graph might contain operators for GPU or CPU only when `optimization_level` > 1.
         fp16 (`bool`, defaults to `False`):
-            Wether all weights and nodes should be converted from float32 to float16.
+            Whether all weights and nodes should be converted from float32 to float16.
         optimize_with_onnxruntime_only (`bool`, defaults to `False`):
             Whether to only use ONNX Runtime to optimize the model and no graph fusion in Python.
         disable_gelu (`bool`, defaults to `False`):

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -141,6 +141,10 @@ class ORTOptimizer:
             only_onnxruntime=optimization_config.optimize_with_onnxruntime_only,
         )
 
+        if optimization_config.fp16:
+            # keep_io_types to keep inputs/outputs as float32
+            optimizer.convert_float_to_float16(keep_io_types=True)
+
         optimizer.save_model_to_file(onnx_optimized_model_output_path, use_external_data_format)
 
         if optimizer.is_fully_optimized():

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -120,7 +120,9 @@ class ORTOptimizerTest(unittest.TestCase):
             for w in model.graph.initializer:
                 self.assertNotEqual(w.data_type, onnx.onnx_pb.TensorProto.FLOAT)
 
-            onnx_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir, file_name="model-optimized.onnx")
+            onnx_model = ORTModelForSequenceClassification.from_pretrained(
+                output_dir.as_posix(), file_name="model-optimized.onnx"
+            )
             transformers_model = AutoModelForSequenceClassification.from_pretrained(model_name)
             tokenizer = AutoTokenizer.from_pretrained(model_name)
             tokens = tokenizer("This is a sample output", return_tensors="pt")

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -110,6 +110,9 @@ class ORTOptimizerTest(unittest.TestCase):
             output_dir = Path(tmp_dir)
             model_path = output_dir.joinpath("model.onnx")
             optimized_model_path = output_dir.joinpath("model-optimized.onnx")
+            onnx_model = ORTModelForSequenceClassification.from_pretrained(model_name, from_transformers=True)
+            onnx_model.save_pretrained(output_dir.as_posix())
+
             optimizer = ORTOptimizer.from_pretrained(model_name, feature="sequence-classification")
             optimizer.export(
                 onnx_model_path=model_path,

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -20,8 +20,8 @@ from pathlib import Path
 
 import numpy as np
 import torch
-import onnx
 
+import onnx
 from onnx import load as onnx_load
 from onnxruntime import InferenceSession
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType


### PR DESCRIPTION
# What does this PR do?

This PR adds support for converting model weights from `fp32` to `fp16` by adding a new Optimization parameter. If the `fp16` arg is provided in the `OptimizationConfig` the weights are converted. I also added a test to make sure the model is not containing any fp32 weights


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

