### PR TITLE
Correct bug in post-processing benchmark/eval

### DIFF
--- a/optimum/utils/preprocessing/text_classification.py
+++ b/optimum/utils/preprocessing/text_classification.py
@@ -119,10 +119,9 @@ class TextClassificationProcessing(DatasetProcessing):
             preds = pipeline.postprocess(model_outputs, function_to_apply=ClassificationFunction.NONE)
 
             if not self.task_args["is_regression"]:
-                # the dataset label ids may be different from the label2id of predictions
                 if self.label_to_id is not None:
-                    preds = self.config.label2id[preds["label"]]
-                    preds = self.label_to_id[preds]
+                    preds = int(self.config.label2id[preds["label"]])
+                    preds = self.label_to_id[preds]  # dataset label ids than of the model
                 else:
                     preds = self.config.label2id[preds["label"]]
             else:


### PR DESCRIPTION
Correct a bug where for text-classification, stored label ids in config.json can be strings. This is temporary as we will use `TextClassificationEvaluator` from evaluate ultimately (when it supports regression and multi-column tasks).