### PR TITLE
Add documentation of OptimizedModel methods

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -23,6 +23,8 @@
     title: Optimization
   title: Torch FX
 - sections:
+  - local: modeling_base
+    title: Optimized models
   - local: benchmark
-    title: Benchmark Optimum models
-  title: API Reference
+    title: Benchmark
+  title: Main classes

--- a/docs/source/modeling_base.mdx
+++ b/docs/source/modeling_base.mdx
@@ -1,0 +1,17 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# OptimizedModel
+
+[[autodoc]] optimum.modeling_base.OptimizedModel
+    - from_pretrained
+    - save_pretrained

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -172,6 +172,31 @@ class OptimizedModel(ABC):
         cache_dir: Optional[str] = None,
         **model_kwargs,
     ):
+        """Instantiate a pretrained model from a pre-trained model configuration.
+
+        Arguments:
+            model_id (`Union[str, Path]`):
+                Can be either:
+                    - A string, the *model id* of a pretrained model hosted inside a model repo on huggingface.co.
+                      Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
+                      user or organization name, like `dbmdz/bert-base-german-cased`.
+                    - A path to a *directory* containing a model saved using [`~OptimizedModel.save_pretrained`],
+                      e.g., `./my_model_directory/`.
+            from_transformers (`bool`, *optional*, defaults to `False`):
+                Defines whether the provided `model_id` contains a vanilla Transformers checkpoint.
+            force_download (`bool`, *optional*, defaults to `True`):
+                Whether or not to force the (re-)download of the model weights and configuration files, overriding the
+                cached versions if they exist.
+            use_auth_token (`str`, *optional*, defaults to `None`):
+                The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+                when running `transformers-cli login` (stored in `~/.huggingface`).
+            cache_dir (`str`, *optional*, defaults to `None`):
+                Path to a directory in which a downloaded pretrained model configuration should be cached if the
+                standard cache should not be used.
+
+        Returns:
+            `OptimizedModel`: The loaded optimized model.
+        """
         revision = None
         if len(str(model_id).split("@")) == 2:
             model_id, revision = model_id.split("@")


### PR DESCRIPTION
# What does this PR do?

Add to the documentation `save_pretrained()` and `from_pretrained()` methods of `OptimizedModel`. I added it to a "Main classes" section, not sure if it is the best way to go, as e.g. the `ORTModelFor...` classes are in the ONNX Runtime --> Inference section. Was not sure how to go as well given that we want to merge the doc from subpackages (should we have a shared "Main classes" for all subpackages?).

If we prefer to have subclass-specific documentation (the one I wrote is too short I think, compare https://huggingface.co/docs/transformers/v4.20.1/en/main_classes/model#transformers.PreTrainedModel.from_pretrained), we could do in `ORTModel`:

```python
    @classmethod
    def from_pretrained(
        cls,
        model_id: Union[str, Path],
        from_transformers: bool = False,
        force_download: bool = True,
        use_auth_token: Optional[str] = None,
        cache_dir: Optional[str] = None,
        **model_kwargs,
    ):
    """subclass specific doc, with examples, etc"""
    super().from_pretrained(model_id, from_transformers, force_download, use_auth_token, cache_dir, **model_kwargs)
```

To me `ORTModel` class is a bit like a `PreTrainedModel`, `TFPreTrainedModel` or `FlaxPreTrainedModel`, and all of those have their own `from_pretrained()`, but it looks to be mostly duplicate code.

For example, following https://github.com/huggingface/optimum/pull/271, `sess_options` would be a keyword argument specific to `ORTModel`. We could use `@add_end_docstrings` to avoid repeating the doc, probably.

Partially fixes https://github.com/huggingface/optimum/issues/272


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

