### PR TITLE
support passing in user specified provider to from_pretrained

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -157,6 +157,7 @@ class OptimizedModel(ABC):
         revision: Optional[Union[str, None]] = None,
         force_download: bool = True,
         cache_dir: Optional[str] = None,
+        provider: Optional[str] = None,
         **kwargs,
     ):
         """Overwrite this method in subclass to define how to load your model from pretrained"""
@@ -170,6 +171,7 @@ class OptimizedModel(ABC):
         force_download: bool = True,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
+        provider: Optional[str] = None,
         **model_kwargs,
     ):
         revision = None
@@ -213,6 +215,7 @@ class OptimizedModel(ABC):
                 cache_dir=cache_dir,
                 force_download=force_download,
                 use_auth_token=use_auth_token,
+                provider=provider,
                 **model_kwargs,
             )
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -161,6 +161,7 @@ class ORTModel(OptimizedModel):
         force_download: bool = False,
         cache_dir: Optional[str] = None,
         file_name: Optional[str] = None,
+        provider: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -206,7 +207,7 @@ class ORTModel(OptimizedModel):
             )
             kwargs["model_save_dir"] = Path(model_cache_path).parent
             kwargs["latest_model_name"] = Path(model_cache_path).name
-            model = ORTModel.load_model(model_cache_path)
+            model = ORTModel.load_model(model_cache_path, provider=provider)
             config = PretrainedConfig.from_dict(config_dict)
         return cls(model=model, config=config, **kwargs)
 


### PR DESCRIPTION
# What does this PR do?
Allow users to pass in their own provider to the `from_pretrained` method and spike it through to the load_model call in `ORTModel`. Currently the `load_model` method supports passing in a provider but it seems like this functionality is not supported via the `from_pretrained` code path.

Fixes # (issue)
https://github.com/huggingface/optimum/issues/274

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

