### PR TITLE
Add node exclusion for benchmark suite

### DIFF
--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -76,9 +76,14 @@ class OnnxRuntimeRun(Run):
         if self.static_quantization:
             calibration_dataset = self.get_calibration_dataset()
             calibrator = OnnxRuntimeCalibrator(
-                calibration_dataset, quantizer, self.model_path, qconfig, calibration_params=run_config["calibration"]
+                calibration_dataset,
+                quantizer,
+                self.model_path,
+                qconfig,
+                calibration_params=run_config["calibration"],
+                node_exclusion=run_config["node_exclusion"],
             )
-            ranges = calibrator.calibrate()
+            ranges, quantization_preprocessor = calibrator.calibrate()
 
         # Export the quantized model
         quantizer.export(

--- a/optimum/onnxruntime/runs/calibrator.py
+++ b/optimum/onnxruntime/runs/calibrator.py
@@ -1,10 +1,12 @@
-from typing import Dict
+from typing import Dict, List
 
 from datasets import Dataset
 
 from ...runs_base import Calibrator
 from .. import ORTQuantizer
 from ..configuration import AutoCalibrationConfig, QuantizationConfig
+from ..preprocessors import QuantizationPreprocessor
+from ..preprocessors.passes import ExcludeGeLUNodes, ExcludeLayerNormNodes, ExcludeNodeAfter, ExcludeNodeFollowedBy
 
 
 class OnnxRuntimeCalibrator(Calibrator):
@@ -15,6 +17,7 @@ class OnnxRuntimeCalibrator(Calibrator):
         model_path: str,
         qconfig: QuantizationConfig,
         calibration_params: Dict,
+        node_exclusion: List[str],
     ):
         super().__init__(
             calibration_dataset=calibration_dataset,
@@ -22,12 +25,32 @@ class OnnxRuntimeCalibrator(Calibrator):
             model_path=model_path,
             qconfig=qconfig,
             calibration_params=calibration_params,
+            node_exclusion=node_exclusion,
         )
 
         # Remove the unnecessary columns of the calibration dataset before the calibration step
         self.calibration_dataset = self.quantizer.clean_calibration_dataset(calibration_dataset)
 
     def calibrate(self):
+        # Create the calibration preprocessor excluding nodes
+        quantization_preprocessor = QuantizationPreprocessor()
+
+        if "layernorm" in self.node_exclusion:
+            # Exclude the nodes constituting LayerNorm
+            quantization_preprocessor.register_pass(ExcludeLayerNormNodes())
+        if "gelu" in self.node_exclusion:
+            # Exclude the nodes constituting GELU
+            quantization_preprocessor.register_pass(ExcludeGeLUNodes())
+        if "residual" in self.node_exclusion:
+            # Exclude the residual connection Add nodes
+            quantization_preprocessor.register_pass(ExcludeNodeAfter("Add", "Add"))
+        if "gather" in self.node_exclusion:
+            # Exclude the Add nodes following the Gather operator
+            quantization_preprocessor.register_pass(ExcludeNodeAfter("Gather", "Add"))
+        if "softmax" in self.node_exclusion:
+            # Exclude the Add nodes followed by the Softmax operator
+            quantization_preprocessor.register_pass(ExcludeNodeFollowedBy("Add", "Softmax"))
+
         # Create the calibration configuration given the selected calibration method
         if self.calibration_params["method"] == "entropy":
             calibration_config = AutoCalibrationConfig.entropy(self.calibration_dataset)
@@ -64,4 +87,4 @@ class OnnxRuntimeCalibrator(Calibrator):
             )
         ranges = self.quantizer.compute_ranges()
 
-        return ranges
+        return ranges, quantization_preprocessor

--- a/optimum/runs_base.py
+++ b/optimum/runs_base.py
@@ -34,12 +34,15 @@ def get_autoclass_name(task):
 
 
 class Calibrator:
-    def __init__(self, calibration_dataset: Dataset, quantizer, model_path, qconfig, calibration_params):
+    def __init__(
+        self, calibration_dataset: Dataset, quantizer, model_path, qconfig, calibration_params, node_exclusion
+    ):
         self.calibration_dataset = calibration_dataset
         self.quantizer = quantizer
         self.model_path = model_path
         self.qconfig = qconfig
         self.calibration_params = calibration_params
+        self.node_exclusion = node_exclusion
 
     def calibrate(self):
         raise NotImplementedError()

--- a/optimum/utils/preprocessing/image_classification.py
+++ b/optimum/utils/preprocessing/image_classification.py
@@ -70,7 +70,7 @@ class ImageClassificationProcessing(DatasetProcessing):
             )
 
             columns_to_remove = raw_datasets.column_names[self.calibration_split]
-            columns_to_remove = [name for name in columns_to_remove if name not in self.tokenizer.model_input_names]
+            columns_to_remove = [name for name in columns_to_remove if name not in self.preprocessor.model_input_names]
             calibration_dataset = calibration_dataset.remove_columns(columns_to_remove)
 
             datasets_dict["calibration"] = calibration_dataset

--- a/optimum/utils/runs.py
+++ b/optimum/utils/runs.py
@@ -187,8 +187,10 @@ class _RunDefaults:
         },
     )
     node_exclusion: Optional[List[str]] = field(
-        default_factory=lambda: [],
-        metadata={"description": "Specific nodes to exclude from being quantized (default: `[]`)."},
+        default_factory=lambda: ["layernorm", "gelu", "residual", "gather", "softmax"],
+        metadata={
+            "description": "Specific nodes to exclude from being quantized (default: `['layernorm', 'gelu', 'residual', 'gather', 'softmax']`)."
+        },
     )
     per_channel: Optional[bool] = field(
         default=False, metadata={"description": "Whether to quantize per channel (default: `False`)."}


### PR DESCRIPTION
Up to now we did not support node exclusion for the benchmark suite. Here's a first rough support, but I expect it to be extended, typically if we do some kind of sensitivity analysis (be it here public or in autoquantize).

