### PR TITLE
fix activation dtype

### DIFF
--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -586,7 +586,7 @@ class AutoQuantizationConfig:
             is_static=is_static,
             format=format,
             mode=mode,
-            activations_dtype=QuantType.QInt8,
+            activations_dtype=QuantType.QUInt8,
             activations_symmetric=True,  # TRT only supports symmetric
             weights_dtype=QuantType.QInt8,
             weights_symmetric=True,  # TRT only supports symmetric


### PR DESCRIPTION
# What does this PR do?
Fix the activation type for quantizing for tensorrt

Fixes
```bash
ValueError: Invalid combination of use_static_quantization = False and activations_dtype = QuantType.QInt8. OnnxRuntime dynamic quantization requires activations_dtype = QuantType.QUInt8
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

