### PR TITLE
Add the possibility to use an authentication token when loading the calibration dataset

### DIFF
--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -388,6 +388,7 @@ class ORTQuantizer(ABC):
         preprocess_function: Optional[Callable] = None,
         preprocess_batch: bool = True,
         seed: int = 2016,
+        use_auth_token: bool = False,
     ) -> Dataset:
         """
         Create the calibration `datasets.Dataset` to use for the post-training static quantization calibration step
@@ -404,10 +405,13 @@ class ORTQuantizer(ABC):
                 Which split of the dataset to use to perform the calibration step.
             preprocess_function (`Callable`, *optional*):
                 Processing function to apply to each example after loading dataset.
-            preprocess_batch (`int`, defaults to `True`):
+            preprocess_batch (`bool`, defaults to `True`):
                 Whether the `preprocess_function` should be batched.
             seed (`int`, defaults to 2016):
                 The random seed to use when shuffling the calibration dataset.
+            use_auth_token (`bool`, defaults to `False`):
+                Whether to use the token generated when running `transformers-cli login` (necessary for some datasets "
+                "like ImageNet).
         Returns:
             The calibration `datasets.Dataset` to use for the post-training static quantization calibration
             step.
@@ -418,7 +422,12 @@ class ORTQuantizer(ABC):
                 "provided."
             )
 
-        calib_dataset = load_dataset(dataset_name, name=dataset_config_name, split=dataset_split)
+        calib_dataset = load_dataset(
+            dataset_name,
+            name=dataset_config_name,
+            split=dataset_split,
+            use_auth_token=use_auth_token,
+        )
 
         if num_samples is not None:
             num_samples = min(num_samples, len(calib_dataset))


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR enables to use an authentication token to load the calibration dataset. This is necessary because some datasets (e.g. ImageNet) cannot be downloaded from the Hugging Face Hub without such token.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

