### PR TITLE
OnnxRuntime tests refactor to make them faster

### DIFF
--- a/.github/workflows/test_fx.yml
+++ b/.github/workflows/test_fx.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_onnx.yml
+++ b/.github/workflows/test_onnx.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,5 +33,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        pwd
-        python -m pytest -n auto tests/onnxruntime
+        python -m pytest -n auto onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,5 +33,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        # python -m unittest discover -s onnxruntime -p 'test_*.py'
-        pytest -n 4 tests/onnxruntime
+        pytest -n auto tests/onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        python -m unittest discover -s onnxruntime -p 'test_*.py'
+        # python -m unittest discover -s onnxruntime -p 'test_*.py'
+        pytest -n 4 tests/onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        python -m pytest tests/onnxruntime
+        pwd
+        python -m pytest -n auto tests/onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[tests,onnxruntime]
-    - name: Test with unittest
+    - name: Test with pytest
       working-directory: tests
       run: |
         python -m pytest -n auto onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        python -m pytest -n auto tests/onnxruntime
+        python -m pytest tests/onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Test with pytest
       working-directory: tests
       run: |
-        python -m pytest -n auto onnxruntime
+        python -m pytest -n auto -m "not run_in_series" onnxruntime
+        python -m pytest -m "run_in_series" onnxruntime

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        pytest -n auto tests/onnxruntime
+        python -m pytest -n auto tests/onnxruntime

--- a/.github/workflows/test_optimum_common.yml
+++ b/.github/workflows/test_optimum_common.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -434,7 +434,7 @@ class ORTModelForConditionalGeneration(ORTModel):
             )
 
         kwargs["config"] = model.config.__dict__
-        return cls._from_pretrained(save_dir.as_posix(), **kwargs)
+        return cls._from_pretrained(save_dir, **kwargs)
 
     def to(self, device):
         """

--- a/tests/onnxruntime/nightly_test_trainer.py
+++ b/tests/onnxruntime/nightly_test_trainer.py
@@ -70,14 +70,14 @@ nltk.download("punkt")
 
 _MODELS_TO_TEST = {
     ("bert", "bert-base-cased"),
-    ("distilbert", "distilbert-base-cased"),
-    ("roberta", "roberta-base"),
-    ("gpt2", "gpt2"),
+#     ("distilbert", "distilbert-base-cased"),
+#     ("roberta", "roberta-base"),
+#     ("gpt2", "gpt2"),
 }
 
 _SEQ2SEQ_MODELS_TO_TEST = {
     ("t5", "t5-small"),
-    ("bart", "facebook/bart-base"),
+#     ("bart", "facebook/bart-base"),
 }
 
 _TASKS_DATASETS_CONFIGS = {

--- a/tests/onnxruntime/nightly_test_trainer.py
+++ b/tests/onnxruntime/nightly_test_trainer.py
@@ -70,14 +70,14 @@ nltk.download("punkt")
 
 _MODELS_TO_TEST = {
     ("bert", "bert-base-cased"),
-#     ("distilbert", "distilbert-base-cased"),
-#     ("roberta", "roberta-base"),
-#     ("gpt2", "gpt2"),
+    ("distilbert", "distilbert-base-cased"),
+    ("roberta", "roberta-base"),
+    ("gpt2", "gpt2"),
 }
 
 _SEQ2SEQ_MODELS_TO_TEST = {
     ("t5", "t5-small"),
-#     ("bart", "facebook/bart-base"),
+    ("bart", "facebook/bart-base"),
 }
 
 _TASKS_DATASETS_CONFIGS = {

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -16,6 +16,7 @@ import gc
 import os
 import tempfile
 import unittest
+import pytest
 
 import torch
 from PIL import Image
@@ -282,6 +283,7 @@ class ORTModelForQuestionAnsweringIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         pipe = pipeline("question-answering")
         question = "Whats my name?"
@@ -371,6 +373,7 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         pipe = pipeline("text-classification")
         text = "My Name is Philipp and i live in Germany."
@@ -473,6 +476,7 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         pipe = pipeline("token-classification")
         text = "My Name is Philipp and i live in Germany."
@@ -552,6 +556,7 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         pipe = pipeline("feature-extraction")
         text = "My Name is Philipp and i live in Germany."
@@ -650,6 +655,7 @@ class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         pipe = pipeline("text-generation")
         text = "My Name is Philipp and i live"
@@ -731,6 +737,7 @@ class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         pipe = pipeline("image-classification")
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -853,6 +860,7 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
+    @pytest.mark.run_in_series
     def test_pipeline_model_is_none(self):
         # Text2text generation
         pipe = pipeline("text2text-generation")

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -200,12 +200,12 @@ class ORTModelForQuestionAnsweringIntegrationTest(unittest.TestCase):
         "bert": "hf-internal-testing/tiny-random-bert",
         # FIXME: Error: ONNX export failed: Couldn't export Python operator SymmetricQuantFunction
         # "ibert": "hf-internal-testing/tiny-random-ibert",
-        # "camembert": "etalab-ia/camembert-base-squadFR-fquad-piaf",
-        "camembert": "hf-internal-testing/tiny-random-camembert",
+        "camembert": "etalab-ia/camembert-base-squadFR-fquad-piaf",
+        # "camembert": "hf-internal-testing/tiny-random-camembert",
         "roberta": "hf-internal-testing/tiny-random-roberta",
         # TODO: used real model do to big difference in output
-        "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
-        # "xlm-roberta": "deepset/xlm-roberta-base-squad2",
+        # "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+        "xlm-roberta": "deepset/xlm-roberta-base-squad2",
         "electra": "hf-internal-testing/tiny-random-electra",
         "albert": "hf-internal-testing/tiny-random-albert",
         "bart": "hf-internal-testing/tiny-random-bart",
@@ -296,12 +296,12 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
         "bert": "hf-internal-testing/tiny-random-bert",
         # FIXME: Error: ONNX export failed: Couldn't export Python operator SymmetricQuantFunction
         # "ibert": "hf-internal-testing/tiny-random-ibert",
-        "camembert": "hf-internal-testing/tiny-random-camembert",
-        # "camembert": "cmarkea/distilcamembert-base-sentiment",
+        # "camembert": "hf-internal-testing/tiny-random-camembert",
+        "camembert": "cmarkea/distilcamembert-base-sentiment",
         "roberta": "hf-internal-testing/tiny-random-roberta",
         # TODO: used real model do to big difference in output
-        "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
-        # "xlm-roberta": "unitary/multilingual-toxic-xlm-roberta",
+        # "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+        "xlm-roberta": "unitary/multilingual-toxic-xlm-roberta",
         "electra": "hf-internal-testing/tiny-random-electra",
         "albert": "hf-internal-testing/tiny-random-albert",
         "bart": "hf-internal-testing/tiny-random-bart",
@@ -403,12 +403,12 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         "bert": "hf-internal-testing/tiny-random-bert",
         # FIXME: Error: ONNX export failed: Couldn't export Python operator SymmetricQuantFunction
         # "ibert": "hf-internal-testing/tiny-random-ibert",
-        "camembert": "hf-internal-testing/tiny-random-camembert",
-        # "camembert": "cmarkea/distilcamembert-base-ner",
+        # "camembert": "hf-internal-testing/tiny-random-camembert",
+        "camembert": "cmarkea/distilcamembert-base-ner",
         "roberta": "hf-internal-testing/tiny-random-roberta",
         # TODO: used real model do to big difference in output
-        "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
-        # "xlm-roberta": "Davlan/xlm-roberta-base-wikiann-ner",
+        # "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+        "xlm-roberta": "Davlan/xlm-roberta-base-wikiann-ner",
         "electra": "hf-internal-testing/tiny-random-electra",
         "albert": "hf-internal-testing/tiny-random-albert",
     }
@@ -489,12 +489,12 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         "bert": "hf-internal-testing/tiny-random-bert",
         # FIXME: Error: ONNX export failed: Couldn't export Python operator SymmetricQuantFunction
         # "ibert": "hf-internal-testing/tiny-random-ibert",
-        # "camembert": "cmarkea/distilcamembert-base",
-        "camembert": "hf-internal-testing/tiny-random-camembert",
+        "camembert": "cmarkea/distilcamembert-base",
+        # "camembert": "hf-internal-testing/tiny-random-camembert",
         "roberta": "hf-internal-testing/tiny-random-roberta",
         # TODO: used real model do to big difference in output
-        "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
-        # "xlm-roberta": "xlm-roberta-base",
+        # "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+        "xlm-roberta": "xlm-roberta-base",
         "electra": "hf-internal-testing/tiny-random-electra",
         "albert": "hf-internal-testing/tiny-random-albert",
     }
@@ -772,19 +772,13 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         tokenizer = get_preprocessor(model_id)
         text = "This is a sample output"
         tokens = tokenizer(text, return_tensors="pt")
+
+        # General case
         outputs = model.generate(**tokens)
         res = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertIsInstance(res[0], str)
 
-        gc.collect()
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
-    def test_generate_utils_with_input_ids(self, *args, **kwargs):
-        model_arch, model_id = args
-        model = ORTModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True)
-        tokenizer = get_preprocessor(model_id)
-        text = "This is a sample output"
-        tokens = tokenizer(text, return_tensors="pt")
+        # With input ids
         outputs = model.generate(input_ids=tokens["input_ids"])
         res = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertIsInstance(res[0], str)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -16,8 +16,8 @@ import gc
 import os
 import tempfile
 import unittest
-import pytest
 
+import pytest
 import torch
 from PIL import Image
 from transformers import (
@@ -865,19 +865,19 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         # Text2text generation
         pipe = pipeline("text2text-generation")
         text = "This is a test"
-        outputs = pipe(text)
+        outputs = pipe(text, max_length=2)
         # compare model output class
         self.assertIsInstance(outputs[0]["generated_text"], str)
 
         # Summarization
         pipe = pipeline("summarization")
-        outputs = pipe(text)
+        outputs = pipe(text, max_length=2)
         # compare model output class
         self.assertIsInstance(outputs[0]["summary_text"], str)
 
         # Translation
         pipe = pipeline("translation_en_to_de")
-        outputs = pipe(text)
+        outputs = pipe(text, max_length=2)
         # compare model output class
         self.assertIsInstance(outputs[0]["translation_text"], str)
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -865,19 +865,19 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         # Text2text generation
         pipe = pipeline("text2text-generation")
         text = "This is a test"
-        outputs = pipe(text, max_length=2)
+        outputs = pipe(text, min_length=1, max_length=2)
         # compare model output class
         self.assertIsInstance(outputs[0]["generated_text"], str)
 
         # Summarization
         pipe = pipeline("summarization")
-        outputs = pipe(text, max_length=2)
+        outputs = pipe(text, min_length=1, max_length=2)
         # compare model output class
         self.assertIsInstance(outputs[0]["summary_text"], str)
 
         # Translation
         pipe = pipeline("translation_en_to_de")
-        outputs = pipe(text, max_length=2)
+        outputs = pipe(text, min_length=1, max_length=2)
         # compare model output class
         self.assertIsInstance(outputs[0]["translation_text"], str)
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -291,18 +291,18 @@ class ORTModelForQuestionAnsweringIntegrationTest(unittest.TestCase):
 class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = {
         "distilbert": "hf-internal-testing/tiny-random-distilbert",
-        "bert": "hf-internal-testing/tiny-random-bert",
-        # FIXME: Error: ONNX export failed: Couldn't export Python operator SymmetricQuantFunction
-        # "ibert": "hf-internal-testing/tiny-random-ibert",
-        "camembert": "cmarkea/distilcamembert-base-sentiment",
-        "roberta": "hf-internal-testing/tiny-random-roberta",
-        # TODO: used real model do to big difference in output
-        # "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
-        "xlm-roberta": "unitary/multilingual-toxic-xlm-roberta",
-        "electra": "hf-internal-testing/tiny-random-electra",
-        "albert": "hf-internal-testing/tiny-random-albert",
-        "bart": "hf-internal-testing/tiny-random-bart",
-        "mbart": "hf-internal-testing/tiny-random-mbart",
+        # "bert": "hf-internal-testing/tiny-random-bert",
+        # # FIXME: Error: ONNX export failed: Couldn't export Python operator SymmetricQuantFunction
+        # # "ibert": "hf-internal-testing/tiny-random-ibert",
+        # "camembert": "cmarkea/distilcamembert-base-sentiment",
+        # "roberta": "hf-internal-testing/tiny-random-roberta",
+        # # TODO: used real model do to big difference in output
+        # # "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+        # "xlm-roberta": "unitary/multilingual-toxic-xlm-roberta",
+        # "electra": "hf-internal-testing/tiny-random-electra",
+        # "albert": "hf-internal-testing/tiny-random-albert",
+        # "bart": "hf-internal-testing/tiny-random-bart",
+        # "mbart": "hf-internal-testing/tiny-random-mbart",
     }
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import gc
 import os
 import tempfile
 import unittest
@@ -242,6 +243,8 @@ class ORTModelForQuestionAnsweringIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(onnx_outputs.start_logits, transformers_outputs.start_logits, atol=1e-4))
         self.assertTrue(torch.allclose(onnx_outputs.end_logits, transformers_outputs.end_logits, atol=1e-4))
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_ort_model(self, *args, **kwargs):
         model_arch, model_id = args
@@ -255,6 +258,8 @@ class ORTModelForQuestionAnsweringIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.device, pipe.model.device)
         self.assertGreaterEqual(outputs["score"], 0.0)
         self.assertIsInstance(outputs["answer"], str)
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         pipe = pipeline("question-answering")
@@ -281,6 +286,8 @@ class ORTModelForQuestionAnsweringIntegrationTest(unittest.TestCase):
         # compare model output class
         self.assertGreaterEqual(outputs["score"], 0.0)
         self.assertTrue(isinstance(outputs["answer"], str))
+
+        gc.collect()
 
 
 class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
@@ -329,6 +336,8 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
         # compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_ort_model(self, *args, **kwargs):
         model_arch, model_id = args
@@ -341,6 +350,8 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertGreaterEqual(outputs[0]["score"], 0.0)
         self.assertIsInstance(outputs[0]["label"], str)
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         pipe = pipeline("text-classification")
@@ -365,6 +376,8 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
         # compare model output class
         self.assertGreaterEqual(outputs[0]["score"], 0.0)
         self.assertTrue(isinstance(outputs[0]["label"], str))
+
+        gc.collect()
 
     def test_pipeline_zero_shot_classification(self):
         onnx_model = ORTModelForSequenceClassification.from_pretrained(
@@ -428,6 +441,8 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         # compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_ort_model(self, *args, **kwargs):
         model_arch, model_id = args
@@ -440,6 +455,8 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.device, onnx_model.device)
         # TODO: shouldn't it be all instead of any?
         self.assertTrue(any(item["score"] > 0.0 for item in outputs))
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         pipe = pipeline("token-classification")
@@ -462,6 +479,8 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.model.device.type.lower(), "cuda")
         # compare model output class
         self.assertTrue(any(item["score"] > 0.0 for item in outputs))
+
+        gc.collect()
 
 
 class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
@@ -504,6 +523,8 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
             torch.allclose(onnx_outputs.last_hidden_state, transformers_outputs.last_hidden_state, atol=1e-4)
         )
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_ort_model(self, *args, **kwargs):
         model_arch, model_id = args
@@ -516,6 +537,8 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         # compare model output class
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertTrue(any(any(isinstance(item, float) for item in row) for row in outputs[0]))
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         pipe = pipeline("feature-extraction")
@@ -538,6 +561,8 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.model.device.type.lower(), "cuda")
         # compare model output class
         self.assertTrue(any(any(isinstance(item, float) for item in row) for row in outputs[0]))
+
+        gc.collect()
 
 
 class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
@@ -574,6 +599,8 @@ class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
         self.assertIsInstance(res[0], str)
         self.assertTrue(len(res[0]) > len(text))
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_compare_to_transformers(self, *args, **kwargs):
         model_arch, model_id = args
@@ -596,6 +623,8 @@ class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
         # compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_ort_model(self, *args, **kwargs):
         model_arch, model_id = args
@@ -608,6 +637,8 @@ class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertIsInstance(outputs[0]["generated_text"], str)
         self.assertTrue(len(outputs[0]["generated_text"]) > len(text))
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         pipe = pipeline("text-generation")
@@ -632,6 +663,8 @@ class ORTModelForCausalLMIntegrationTest(unittest.TestCase):
         # compare model output class
         self.assertTrue(isinstance(outputs[0]["generated_text"], str))
         self.assertTrue(len(outputs[0]["generated_text"]) > len(text))
+
+        gc.collect()
 
 
 class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
@@ -669,6 +702,8 @@ class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
         # compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, trtfs_outputs.logits, atol=1e-4))
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_ort_model(self, *args, **kwargs):
         model_arch, model_id = args
@@ -681,6 +716,8 @@ class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertGreaterEqual(outputs[0]["score"], 0.0)
         self.assertTrue(isinstance(outputs[0]["label"], str))
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         pipe = pipeline("image-classification")
@@ -706,6 +743,8 @@ class ORTModelForImageClassificationIntegrationTest(unittest.TestCase):
         # compare model output class
         self.assertGreaterEqual(outputs[0]["score"], 0.0)
         self.assertTrue(isinstance(outputs[0]["label"], str))
+
+        gc.collect()
 
 
 class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
@@ -737,6 +776,8 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         res = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertIsInstance(res[0], str)
 
+        gc.collect()
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_generate_utils_with_input_ids(self, *args, **kwargs):
         model_arch, model_id = args
@@ -747,6 +788,8 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         outputs = model.generate(input_ids=tokens["input_ids"])
         res = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertIsInstance(res[0], str)
+
+        gc.collect()
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_compare_to_transformers(self, *args, **kwargs):
@@ -772,6 +815,8 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
             transformers_outputs = transformers_model(**tokens, **decoder_inputs)
         # Compare tensor outputs
         self.assertTrue(torch.allclose(onnx_outputs.logits, transformers_outputs.logits, atol=1e-4))
+
+        gc.collect()
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
     def test_pipeline_text_generation(self, *args, **kwargs):
@@ -799,6 +844,8 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         outputs = pipe(text)
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertIsInstance(outputs[0]["translation_text"], str)
+
+        gc.collect()
 
     def test_pipeline_model_is_none(self):
         # Text2text generation
@@ -845,3 +892,5 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         model_without_pkv = ORTModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True, use_cache=False)
         outputs_model_without_pkv = model_without_pkv.generate(**tokens)
         self.assertTrue(torch.equal(outputs_model_with_pkv, outputs_model_without_pkv))
+
+        gc.collect()

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -414,8 +414,8 @@ class ORTModelForSequenceClassificationIntegrationTest(unittest.TestCase):
         )
 
         # compare model output class
-        self.assertTrue(any(score > 0.0 for score in outputs["scores"]))
-        self.assertTrue(any(isinstance(label, str) for label in outputs["labels"]))
+        self.assertTrue(all(score > 0.0 for score in outputs["scores"]))
+        self.assertTrue(all(isinstance(label, str) for label in outputs["labels"]))
 
 
 class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
@@ -472,7 +472,7 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
 
         self.assertEqual(pipe.device, onnx_model.device)
         # TODO: shouldn't it be all instead of any?
-        self.assertTrue(any(item["score"] > 0.0 for item in outputs))
+        self.assertTrue(all(item["score"] > 0.0 for item in outputs))
 
         gc.collect()
 
@@ -483,7 +483,7 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         outputs = pipe(text)
 
         # compare model output class
-        self.assertTrue(any(item["score"] > 0.0 for item in outputs))
+        self.assertTrue(all(item["score"] > 0.0 for item in outputs))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @require_torch_gpu
@@ -497,7 +497,7 @@ class ORTModelForTokenClassificationIntegrationTest(unittest.TestCase):
         # check model device
         self.assertEqual(pipe.model.device.type.lower(), "cuda")
         # compare model output class
-        self.assertTrue(any(item["score"] > 0.0 for item in outputs))
+        self.assertTrue(all(item["score"] > 0.0 for item in outputs))
 
         gc.collect()
 
@@ -552,7 +552,7 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
 
         # compare model output class
         self.assertEqual(pipe.device, onnx_model.device)
-        self.assertTrue(any(any(isinstance(item, float) for item in row) for row in outputs[0]))
+        self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
 
         gc.collect()
 
@@ -563,7 +563,7 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         outputs = pipe(text)
 
         # compare model output class
-        self.assertTrue(any(any(isinstance(item, float) for item in row) for row in outputs[0]))
+        self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @require_torch_gpu
@@ -577,7 +577,7 @@ class ORTModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         # check model device
         self.assertEqual(pipe.model.device.type.lower(), "cuda")
         # compare model output class
-        self.assertTrue(any(any(isinstance(item, float) for item in row) for row in outputs[0]))
+        self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
 
         gc.collect()
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -889,7 +889,7 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         self.assertTrue(len(outputs[0]["generated_text"]) > len(text))
 
     def test_compare_with_and_without_past_key_values_model_outputs(self):
-        model_id = "t5-small"
+        model_id = MODEL_NAMES["t5"]
         tokenizer = get_preprocessor(model_id)
         text = "This is a sample output"
         tokens = tokenizer(text, return_tensors="pt")
@@ -898,5 +898,3 @@ class ORTModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         model_without_pkv = ORTModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True, use_cache=False)
         outputs_model_without_pkv = model_without_pkv.generate(**tokens)
         self.assertTrue(torch.equal(outputs_model_with_pkv, outputs_model_without_pkv))
-
-        gc.collect()

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -20,7 +20,17 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, AutoConfig
+from transformers import (
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    BartForSequenceClassification,
+    BertForSequenceClassification,
+    DistilBertForSequenceClassification,
+    ElectraForSequenceClassification,
+    GPT2ForSequenceClassification,
+    RobertaForSequenceClassification,
+)
 
 import onnx
 from onnx import load as onnx_load
@@ -49,20 +59,19 @@ class ORTConfigTest(unittest.TestCase):
 
 
 class ORTOptimizerTest(unittest.TestCase):
-    from transformers import BertForSequenceClassification, DistilBertForSequenceClassification, BartForSequenceClassification, GPT2ForSequenceClassification, RobertaForSequenceClassification, ElectraForSequenceClassification
-    SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = {
-        "bert": ("bert-base-cased", BertForSequenceClassification),
-        "distilbert": ("distilbert-base-uncased", DistilBertForSequenceClassification),
-        "bart": ("facebook/bart-base", BartForSequenceClassification),
-        "gpt2": ("gpt2", GPT2ForSequenceClassification),
-        "roberta": ("roberta-base", RobertaForSequenceClassification),
-        "electra": ("google/electra-small-discriminator", ElectraForSequenceClassification),
-    }
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID.items())
+    SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = (
+        (BertForSequenceClassification, "bert-base-cased"),
+        (DistilBertForSequenceClassification, "distilbert-base-uncased"),
+        (BartForSequenceClassification, "facebook/bart-base"),
+        (GPT2ForSequenceClassification, "gpt2"),
+        (RobertaForSequenceClassification, "roberta-base"),
+        (ElectraForSequenceClassification, "google/electra-small-discriminator"),
+    )
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)
     def test_optimize(self, *args, **kwargs):
-        model_type, t = args
-        model_name, model_cls = t
+        model_cls, model_name = args
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         model = model_cls(AutoConfig.from_pretrained(model_name))
         optimization_config = OptimizationConfig(optimization_level=2, optimize_with_onnxruntime_only=False)
@@ -70,7 +79,6 @@ class ORTOptimizerTest(unittest.TestCase):
             output_dir = Path(tmp_dir)
             model_path = output_dir.joinpath("model.onnx")
             optimized_model_path = output_dir.joinpath("model-optimized.onnx")
-            # optimizer = ORTOptimizer.from_pretrained(model_name, feature="sequence-classification")
             optimizer = ORTOptimizer(tokenizer, model, feature="sequence-classification")
             optimizer.export(
                 onnx_model_path=model_path,
@@ -89,12 +97,14 @@ class ORTOptimizerTest(unittest.TestCase):
 
     def test_optimization_details(self):
         model_name = "bert-base-cased"
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = BertForSequenceClassification(AutoConfig.from_pretrained(model_name))
         optimization_config = OptimizationConfig(optimization_level=0, optimize_with_onnxruntime_only=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir)
             model_path = output_dir.joinpath("model.onnx")
             optimized_model_path = output_dir.joinpath("model-optimized.onnx")
-            optimizer = ORTOptimizer.from_pretrained(model_name, feature="sequence-classification")
+            optimizer = ORTOptimizer(tokenizer, model, feature="sequence-classification")
             optimizer.export(
                 onnx_model_path=model_path,
                 onnx_optimized_model_output_path=optimized_model_path,
@@ -143,16 +153,15 @@ class ORTOptimizerTest(unittest.TestCase):
 
 
 class ORTDynamicQuantizationTest(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMUL = {
-        "bert-base-cased": 72,
-        "roberta-base": 72,
-        "distilbert-base-uncased": 36,
-        "facebook/bart-base": 96,
-    }
+    SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (
+        (BertForSequenceClassification, "bert-base-cased", 72),
+        (RobertaForSequenceClassification, "roberta-base", 72),
+        (DistilBertForSequenceClassification, "distilbert-base-uncased", 36),
+        (BartForSequenceClassification, "facebook/bart-base", 96),
+    )
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMUL.items())
-    def test_dynamic_quantization(self, *args, **kwargs):
-        model_name, expected_quantized_matmul = args
+    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
+    def test_dynamic_quantization(self, model_cls, model_name, expected_quantized_matmuls):
         qconfig = QuantizationConfig(
             is_static=False,
             format=QuantFormat.QOperator,
@@ -163,11 +172,13 @@ class ORTDynamicQuantizationTest(unittest.TestCase):
             reduce_range=False,
             operators_to_quantize=["MatMul"],
         )
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = model_cls(AutoConfig.from_pretrained(model_name))
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir)
             model_path = output_dir.joinpath("model.onnx")
             q8_model_path = output_dir.joinpath("model-quantized.onnx")
-            quantizer = ORTQuantizer.from_pretrained(model_name, feature="sequence-classification")
+            quantizer = ORTQuantizer(tokenizer, model, feature="sequence-classification")
             quantizer.export(
                 onnx_model_path=model_path,
                 onnx_quantized_model_output_path=q8_model_path,
@@ -179,19 +190,15 @@ class ORTDynamicQuantizationTest(unittest.TestCase):
             for initializer in quantized_model.graph.initializer:
                 if "MatMul" in initializer.name and "quantized" in initializer.name:
                     num_quantized_matmul += 1
-            self.assertEqual(expected_quantized_matmul, num_quantized_matmul)
+            self.assertEqual(expected_quantized_matmuls, num_quantized_matmul)
             gc.collect()
 
 
 class ORTStaticQuantizationTest(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMUL = {
-        "bert-base-cased": 72,
-    }
+    SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = ((BertForSequenceClassification, "bert-base-cased", 72),)
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMUL.items())
-    def test_static_quantization(self, *args, **kwargs):
-        model_name, expected_quantized_matmul = args
-
+    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
+    def test_static_quantization(self, model_cls, model_name, expected_quantized_matmuls):
         qconfig = QuantizationConfig(
             is_static=True,
             format=QuantFormat.QDQ,
@@ -203,6 +210,9 @@ class ORTStaticQuantizationTest(unittest.TestCase):
             operators_to_quantize=["MatMul"],
         )
 
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = model_cls(AutoConfig.from_pretrained(model_name))
+
         def preprocess_function(examples, tokenizer):
             return tokenizer(examples["sentence"], padding="max_length", max_length=128, truncation=True)
 
@@ -210,7 +220,7 @@ class ORTStaticQuantizationTest(unittest.TestCase):
             output_dir = Path(tmp_dir)
             model_path = output_dir.joinpath("model.onnx")
             q8_model_path = output_dir.joinpath("model-quantized.onnx")
-            quantizer = ORTQuantizer.from_pretrained(model_name, feature="sequence-classification")
+            quantizer = ORTQuantizer(tokenizer, model, feature="sequence-classification")
             calibration_dataset = quantizer.get_calibration_dataset(
                 "glue",
                 dataset_config_name="sst2",
@@ -236,7 +246,7 @@ class ORTStaticQuantizationTest(unittest.TestCase):
             for initializer in quantized_model.graph.initializer:
                 if "MatMul" in initializer.name and "quantized" in initializer.name:
                     num_quantized_matmul += 1
-            self.assertEqual(expected_quantized_matmul, num_quantized_matmul)
+            self.assertEqual(expected_quantized_matmuls, num_quantized_matmul)
             gc.collect()
 
 

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -61,17 +61,16 @@ class ORTConfigTest(unittest.TestCase):
 class ORTOptimizerTest(unittest.TestCase):
 
     SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = (
-        (BertForSequenceClassification, "bert-base-cased"),
-        (DistilBertForSequenceClassification, "distilbert-base-uncased"),
-        (BartForSequenceClassification, "facebook/bart-base"),
-        (GPT2ForSequenceClassification, "gpt2"),
-        (RobertaForSequenceClassification, "roberta-base"),
-        (ElectraForSequenceClassification, "google/electra-small-discriminator"),
+        (BertForSequenceClassification, "hf-internal-testing/tiny-random-bert"),
+        (DistilBertForSequenceClassification, "hf-internal-testing/tiny-random-distilbert"),
+        (BartForSequenceClassification, "hf-internal-testing/tiny-random-bart"),
+        (GPT2ForSequenceClassification, "hf-internal-testing/tiny-random-gpt2"),
+        (RobertaForSequenceClassification, "hf-internal-testing/tiny-random-roberta"),
+        (ElectraForSequenceClassification, "hf-internal-testing/tiny-random-electra"),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)
-    def test_optimize(self, *args, **kwargs):
-        model_cls, model_name = args
+    def test_optimize(self, model_cls, model_name):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         model = model_cls(AutoConfig.from_pretrained(model_name))
         optimization_config = OptimizationConfig(optimization_level=2, optimize_with_onnxruntime_only=False)
@@ -154,10 +153,10 @@ class ORTOptimizerTest(unittest.TestCase):
 
 class ORTDynamicQuantizationTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (
-        (BertForSequenceClassification, "bert-base-cased", 72),
-        (RobertaForSequenceClassification, "roberta-base", 72),
-        (DistilBertForSequenceClassification, "distilbert-base-uncased", 36),
-        (BartForSequenceClassification, "facebook/bart-base", 96),
+        (BertForSequenceClassification, "hf-internal-testing/tiny-random-bert", 30),
+        (RobertaForSequenceClassification, "hf-internal-testing/tiny-random-roberta", 30),
+        (DistilBertForSequenceClassification, "hf-internal-testing/tiny-random-distilbert", 30),
+        (BartForSequenceClassification, "hf-internal-testing/tiny-random-bart", 32),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
@@ -195,7 +194,9 @@ class ORTDynamicQuantizationTest(unittest.TestCase):
 
 
 class ORTStaticQuantizationTest(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = ((BertForSequenceClassification, "bert-base-cased", 72),)
+    SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (
+        (BertForSequenceClassification, "hf-internal-testing/tiny-random-bert", 30),
+    )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
     def test_static_quantization(self, model_cls, model_name, expected_quantized_matmuls):


### PR DESCRIPTION
# What does this PR do?

The goal of this PR is to make the Onnxruntime tests much faster, as they usually run for more than 1 hour. 
To do that, this PR:
- Fuses multiple tests together in `tests/test_modeling.py`:
  - `test_supported_transformers_architectures`, `test_model_call` are fused to `test_compare_to_transformers`
  - `test_default_pipeline_and_model_device` is fused to `test_pipeline_ort_model`
  - `test_generate_utils_with_input_ids` is fused to `test_generate_utils`
- Uses smaller model architectures to test, instead of big ones
