### PR TITLE
Fix seq2seq onnx config

### DIFF
--- a/docs/source/onnxruntime/modeling_ort.mdx
+++ b/docs/source/onnxruntime/modeling_ort.mdx
@@ -79,7 +79,7 @@ from the Hub and converts it to an optimum onnxruntime model and pushes it back 
 ## Export and inference of sequence-to-sequence models
 
 Sequence-to-sequence (Seq2Seq) models, that generate a new sequence from an input, can also be used when running inference with ONNX Runtime. When Seq2Seq models are exported to the ONNX format, they are decomposed into two parts : the encoder and the "decoder" (which actually consists of the decoder with the language modeling head), that are later combined during inference.
-To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. This will results in an additional model's component to be exported : the "decoder" with pre-computed key/values as additional inputs.
+To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. This way, an additional model component will be exported: the "decoder" with pre-computed key/values as one of the inputs.
 This specific export comes from the fact that during the first pass, the decoder has no pre-computed key/values hidden-states, while during the rest of the generation past key/values will be used to speed up sequential decoding.
 Here is an example on how you can export a T5 model to the ONNX format and run inference for a translation task:
 

--- a/docs/source/onnxruntime/modeling_ort.mdx
+++ b/docs/source/onnxruntime/modeling_ort.mdx
@@ -79,7 +79,7 @@ from the Hub and converts it to an optimum onnxruntime model and pushes it back 
 ## Export and inference of sequence-to-sequence models
 
 Sequence-to-sequence (Seq2Seq) models, that generate a new sequence from an input, can also be used when running inference with ONNX Runtime. When Seq2Seq models are exported to the ONNX format, they are decomposed into two parts : the encoder and the "decoder" (which actually consists of the decoder with the language modeling head), that are later combined during inference.
-To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. This way, an additional model component will be exported: the "decoder" with pre-computed key/values as one of the inputs.
+To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. An additional model component will be exported: the "decoder" with pre-computed key/values as one of its inputs.
 This specific export comes from the fact that during the first pass, the decoder has no pre-computed key/values hidden-states, while during the rest of the generation past key/values will be used to speed up sequential decoding.
 Here is an example on how you can export a T5 model to the ONNX format and run inference for a translation task:
 

--- a/docs/source/onnxruntime/modeling_ort.mdx
+++ b/docs/source/onnxruntime/modeling_ort.mdx
@@ -79,7 +79,7 @@ from the Hub and converts it to an optimum onnxruntime model and pushes it back 
 ## Export and inference of sequence-to-sequence models
 
 Sequence-to-sequence (Seq2Seq) models, that generate a new sequence from an input, can also be used when running inference with ONNX Runtime. When Seq2Seq models are exported to the ONNX format, they are decomposed into two parts : the encoder and the "decoder" (which actually consists of the decoder with the language modeling head), that are later combined during inference.
-To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. This will results in an additional model to be exported : the "decoder" with pre-computed key/values as additional inputs.
+To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. This will results in an additional model's component to be exported : the "decoder" with pre-computed key/values as additional inputs.
 This specific export comes from the fact that during the first pass, the decoder has no pre-computed key/values hidden-states, while during the rest of the generation past key/values will be used to speed up sequential decoding.
 Here is an example on how you can export a T5 model to the ONNX format and run inference for a translation task:
 

--- a/optimum/onnx/configuration.py
+++ b/optimum/onnx/configuration.py
@@ -343,5 +343,7 @@ class DecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
     def fill_with_past_key_values_(self, inputs_or_outputs: Mapping[str, Mapping[int, str]], direction: str):
         num_pkv_per_layer = 4
         _, num_decoder_layers = self.num_layers
+        name = "past" if direction == "inputs" else "present"
+        decoder_sequence = "past_decoder_sequence" if direction == "inputs" else "past_decoder_sequence + sequence"
         for i in range(num_decoder_layers * num_pkv_per_layer):
-            inputs_or_outputs[f"past_key_values_{i}"] = {0: "batch", 2: "past_sequence + sequence"}
+            inputs_or_outputs[f"{name}_key_values_{i}"] = {0: "batch", 2: decoder_sequence}

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -506,6 +506,7 @@ class ORTDecoder:
         self._device = device
         self.input_names = {input_key.name: idx for idx, input_key in enumerate(self.session.get_inputs())}
         self.output_names = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
+        self.key_value_input_names = [key for key in self.input_names if "key_values" in key]
 
     @add_start_docstrings_to_model_forward(DECODER_INPUTS_DOCSTRING)
     def forward(
@@ -528,9 +529,8 @@ class ORTDecoder:
         if past_key_values is not None:
             # Flatten the past_key_values
             past_key_values = [past_key_value for pkv_per_layer in past_key_values for past_key_value in pkv_per_layer]
-            key_values_input_names = [key for key in self.input_names if "key_values" in key]
             # Add the past_key_values to the decoder inputs
-            for input_name, past_key_value in zip(key_values_input_names, past_key_values):
+            for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
                 onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
 
         # Run inference

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -528,10 +528,10 @@ class ORTDecoder:
         if past_key_values is not None:
             # Flatten the past_key_values
             past_key_values = [past_key_value for pkv_per_layer in past_key_values for past_key_value in pkv_per_layer]
-
+            key_values_input_names = [key for key in self.input_names if "key_values" in key]
             # Add the past_key_values to the decoder inputs
-            for i, past_key_value in enumerate(past_key_values):
-                onnx_inputs[f"past_key_values_{i}.1"] = past_key_value.cpu().detach().numpy()
+            for input_name, past_key_value in zip(key_values_input_names, past_key_values):
+                onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
 
         # Run inference
         outputs = self.session.run(None, onnx_inputs)
@@ -541,7 +541,7 @@ class ORTDecoder:
         past_key_values = tuple(
             torch.from_numpy(outputs[self.output_names[key]]).to(self._device)
             for key in self.output_names
-            if "past_key_values" in key
+            if "key_values" in key
         )
 
         # Tuple of tuple of length `n_layers`, with each tuple of length equal to the number of self-attention and


### PR DESCRIPTION
This PR allows more flexibility for ONNX Runtime inference of seq2seq models by removing assumption on the ONNX model input names