### PR TITLE
Use evaluators in the benchmark scripts

### DIFF
--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -2,9 +2,9 @@ import copy
 import os
 from pathlib import Path
 
-from transformers import AutoTokenizer
 from transformers import pipeline as _transformers_pipeline
 from transformers.onnx import FeaturesManager
+from transformers.onnx.utils import get_preprocessor
 
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 
@@ -42,10 +42,9 @@ class OnnxRuntimeRun(Run):
         trfs_model = FeaturesManager.get_model_from_feature(
             onnx_model.export_feature, run_config["model_name_or_path"]
         )
-        tokenizer = AutoTokenizer.from_pretrained(run_config["model_name_or_path"])
         quantizer = ORTQuantizer.from_pretrained(onnx_model)
 
-        self.preprocessor = copy.deepcopy(tokenizer)
+        self.preprocessor = get_preprocessor(run_config["model_name_or_path"])
 
         self.batch_sizes = run_config["batch_sizes"]
         self.input_lengths = run_config["input_lengths"]

--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -1,11 +1,14 @@
 import copy
 import os
+from pathlib import Path
 
+from transformers import AutoTokenizer
 from transformers import pipeline as _transformers_pipeline
 from transformers.onnx import FeaturesManager
 
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 
+from ...pipelines import SUPPORTED_TASKS
 from ...pipelines import pipeline as _optimum_pipeline
 from ...runs_base import Run, TimeBenchmark, get_autoclass_name, task_processing_map
 from .. import ORTQuantizer

--- a/optimum/runs_base.py
+++ b/optimum/runs_base.py
@@ -146,7 +146,7 @@ class Run:
 
     def load_datasets(self):
         """Load evaluation dataset, and if needed, calibration dataset for static quantization."""
-        datasets_dict = self.processor.load_datasets()
+        datasets_dict = self.task_processor.load_datasets()
 
         self._eval_dataset = datasets_dict["eval"]
         if self.static_quantization:
@@ -166,7 +166,7 @@ class Run:
         """
         Get evaluation dataset.  The dataset needs to be loaded first with [`~optimum.runs_base.Run.load_datasets`].
 
-         Returns:
+        Returns:
             `datasets.Dataset`: Evaluation dataset.
         """
         if not hasattr(self, "_eval_dataset"):

--- a/optimum/utils/preprocessing/image_classification.py
+++ b/optimum/utils/preprocessing/image_classification.py
@@ -29,8 +29,6 @@ class ImageClassificationProcessing(DatasetProcessing):
         # Downloading and loading a dataset from the hub.
         raw_datasets = load_dataset(path=self.dataset_path, name=self.dataset_name)
 
-        max_eval_samples = 100  # TODO remove this
-
         normalize = Normalize(mean=self.preprocessor.image_mean, std=self.preprocessor.image_std)
         transforms = Compose(
             [
@@ -50,8 +48,8 @@ class ImageClassificationProcessing(DatasetProcessing):
             return examples
 
         eval_dataset = raw_datasets[self.eval_split]
-        if max_eval_samples is not None:
-            eval_dataset = eval_dataset.shuffle(seed=42).select(range(max_eval_samples))
+        if self.max_eval_samples is not None:
+            eval_dataset = eval_dataset.shuffle(seed=42).select(range(self.max_eval_samples))
         eval_dataset = eval_dataset.align_labels_with_mapping(self.config.label2id, self.ref_keys[0])
 
         datasets_dict = {"eval": eval_dataset}
@@ -80,20 +78,18 @@ class ImageClassificationProcessing(DatasetProcessing):
         return datasets_dict
 
     def run_evaluation(self, eval_dataset: Dataset, pipeline: ImageClassificationPipeline, metrics: List[str]):
-        combined_metrics = combine(metrics)
+        all_metrics = combine(metrics)
 
         task_evaluator = evaluator("image-classification")
 
         results = task_evaluator.compute(
             model_or_pipeline=pipeline,
             data=eval_dataset,
-            metric=combined_metrics,
+            metric=all_metrics,
             input_column=self.data_keys["primary"],
             label_column=self.ref_keys[0],
+            label_mapping=self.config.label2id,
         )
-
-        results.pop("latency", None)
-        results.pop("throughput", None)
 
         return results
 

--- a/optimum/utils/preprocessing/image_classification.py
+++ b/optimum/utils/preprocessing/image_classification.py
@@ -6,6 +6,8 @@ from datasets import Dataset, load_dataset
 from torchvision.transforms import CenterCrop, Compose, Normalize, Resize, ToTensor
 from transformers import FeatureExtractionMixin, ImageClassificationPipeline
 
+from evaluate import Metric, combine, evaluator
+
 from .base import DatasetProcessing
 
 
@@ -97,6 +99,8 @@ class ImageClassificationProcessing(DatasetProcessing):
             label_column=self.ref_keys[0],
             label_mapping=self.config.label2id,
         )
+
+        return results
 
     def get_metrics(self, predictions: List, references: List, metric: Metric):
         metrics_res = metric.compute(predictions=predictions, references=references)

--- a/optimum/utils/preprocessing/question_answering.py
+++ b/optimum/utils/preprocessing/question_answering.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 from datasets import Dataset, load_dataset
 from transformers import PreTrainedTokenizerBase, QuestionAnsweringPipeline
 
-from evaluate import combine, evaluator
+from evaluate import combine, evaluator, load
 
 from .base import DatasetProcessing
 
@@ -84,21 +84,21 @@ class QuestionAnsweringProcessing(DatasetProcessing):
         return datasets_dict
 
     def run_evaluation(self, eval_dataset: Dataset, pipeline: QuestionAnsweringPipeline, metrics: List[str]):
-        combined_metrics = combine(metrics)
+        if len(metrics) == 1:
+            all_metrics = load(metrics[0])
+        else:
+            all_metrics = combine(metrics)
 
         task_evaluator = evaluator("question-answering")
 
         results = task_evaluator.compute(
             model_or_pipeline=pipeline,
             data=eval_dataset,
-            metric=combined_metrics,
+            metric=all_metrics,
             question_column=self.data_keys["question"],
             context_column=self.data_keys["context"],
             label_column=self.ref_keys[0],
         )
-
-        results.pop("latency", None)
-        results.pop("throughput", None)
 
         return results
 

--- a/optimum/utils/preprocessing/token_classification.py
+++ b/optimum/utils/preprocessing/token_classification.py
@@ -1,8 +1,10 @@
 from functools import partial
 from typing import Dict, List, Optional
 
-from datasets import ClassLabel, Dataset, Metric, load_dataset
+from datasets import ClassLabel, Dataset, load_dataset
 from transformers import PreTrainedTokenizerBase, TokenClassificationPipeline
+
+from evaluate import combine, evaluator
 
 from .base import DatasetProcessing
 
@@ -92,53 +94,24 @@ class TokenClassificationProcessing(DatasetProcessing):
 
         return datasets_dict
 
-    def run_inference(self, eval_dataset: Dataset, pipeline: TokenClassificationPipeline):
-        all_labels = [[self.label_list[l] for l in label if l != -100] for label in eval_dataset[self.ref_keys[0]]]
-        all_preds = []
-        for i, data in enumerate(eval_dataset):
-            inputs = " ".join(data[self.data_keys["primary"]])
-            res = pipeline(inputs)
+    def run_evaluation(self, eval_dataset: Dataset, pipeline: TokenClassificationPipeline, metrics: List[str]):
+        combined_metrics = combine(metrics)
 
-            # BatchEncoding.word_ids may be wrong as we joined words with " ", so let's populate it ourselves
-            token_to_word_id = []
-            for j, word in enumerate(data[self.data_keys["primary"]]):
-                preprocessed_inputs = pipeline.preprocess(word)
-                n_tokens = len([k for k in preprocessed_inputs.word_ids(0) if k != None])  # exclude None
-                token_to_word_id.extend([j] * n_tokens)
+        task_evaluator = evaluator("token-classification")
 
-            # the pipeline may give as output labeled tokens that are part of the same word, keep track
-            # of the indexing to match the true labels on words
-            index_tokens_word_start = []
+        results = task_evaluator.compute(
+            model_or_pipeline=pipeline,
+            data=eval_dataset,
+            metric=combined_metrics,
+            input_column=self.data_keys["primary"],
+            label_column=self.ref_keys[0],
+            join_by=" ",
+        )
 
-            for j, word_index in enumerate(token_to_word_id):
-                if j == 0:
-                    index_tokens_word_start.append(j)
-                elif word_index != token_to_word_id[j - 1]:
-                    index_tokens_word_start.append(j)
+        results.pop("latency", None)
+        results.pop("throughput", None)
 
-            # keep only predictions that correspond to the beginning of a word
-            preds = [res[index]["entity"] for index in index_tokens_word_start]
-
-            assert len(preds) == len(all_labels[i])
-            all_preds.append(preds)
-
-        return all_labels, all_preds
-
-    def get_metrics(self, predictions: List, references: List, metric: Metric):
-        metrics_res = metric.compute(predictions=predictions, references=references)
-
-        if metric.name == "seqeval":
-            metrics_res = {
-                "precision": metrics_res["overall_precision"],
-                "recall": metrics_res["overall_recall"],
-                "f1": metrics_res["overall_f1"],
-                "accuracy": metrics_res["overall_accuracy"],
-            }
-        # `metric.compute` may return a dict or a number
-        elif not isinstance(metrics_res, dict):
-            metrics_res = {metric.name: metrics_res}
-
-        return metrics_res
+        return results
 
     def get_pipeline_kwargs(self):
         res = {

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ TESTS_REQUIRE = ["pytest", "requests", "parameterized", "pytest-xdist", "Pillow"
 
 QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.5.4"]
 
+BENCHMARK_REQUIRE = ["optuna", "tqdm", "sklearn", "seqeval", "torchvision", "evaluate"]
+
 EXTRAS_REQUIRE = {
     "onnxruntime": [
         "onnx",
@@ -45,7 +47,7 @@ EXTRAS_REQUIRE = {
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
     "quality": QUALITY_REQUIRE,
-    "benchmark": ["optuna", "tqdm", "sklearn", "seqeval", "torchvision"],
+    "benchmark": BENCHMARK_REQUIRE,
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ TESTS_REQUIRE = ["pytest", "requests", "parameterized", "pytest-xdist", "Pillow"
 
 QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.5.4"]
 
-BENCHMARK_REQUIRE = ["optuna", "tqdm", "sklearn", "seqeval", "torchvision", "evaluate"]
+BENCHMARK_REQUIRE = ["optuna", "tqdm", "sklearn", "seqeval", "torchvision", "evaluate>=0.2.0"]
 
 EXTRAS_REQUIRE = {
     "onnxruntime": [

--- a/tests/benchmark/test_transformers_optimum_examples_parity.py
+++ b/tests/benchmark/test_transformers_optimum_examples_parity.py
@@ -278,7 +278,7 @@ class TestParity(unittest.TestCase):
         # dummy test until this question is solved
         # https://discuss.huggingface.co/t/why-use-val-transforms-function-in-image-classification-example-instead-of-feature-extractor/19976
         model_name = "fxmarty/resnet-tiny-beans"
-        n_samples = 100
+        n_samples = 120
 
         run_config = {
             "task": "image-classification",
@@ -307,7 +307,8 @@ class TestParity(unittest.TestCase):
         run_instance = OnnxRuntimeRun(run_config)
         benchmark_results = run_instance.launch()
 
-        self.assertEqual(benchmark_results["evaluation"]["others"]["baseline"]["accuracy"], 0.71)
+        print(benchmark_results)
+        self.assertEqual(benchmark_results["evaluation"]["others"]["baseline"]["accuracy"], 84 / 120)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

This is part of an effort on my end to simplify the benchmark scripts. As much of the logic of the evaluation using pipelines was moved to subclasses of Evaluator in evaluate, we make use of them following the 0.2.0 release, see https://huggingface.co/docs/evaluate/package_reference/evaluator_classes

In a following PR, we could make use of them in the example scripts as well.

PRs will follow after this one to:
* Have an option after a benchmark to save the model with config and results.
* Dissociate backends (do not run pytorch and onnxruntime at the same time).
* Have a tutorial in the documentation on how to use the benchmark scripts.
* Ideally, I would like to support at some points other backends than ONNX Runtime. This would involve building pipeline wrappers just like for `ORTModel`.

## Before submitting
- [x] Did you write any new necessary tests?

