### PR TITLE
Dissociate PyTorch / ONNX Runtime benchmark scripts

### DIFF
--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -2,7 +2,6 @@ import copy
 import os
 
 from datasets import load_metric
-from transformers.onnx import FeaturesManager
 
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 

--- a/optimum/pytorch/runs/__init__.py
+++ b/optimum/pytorch/runs/__init__.py
@@ -3,7 +3,7 @@ from transformers import pipeline as _transformers_pipeline
 from transformers.onnx import FeaturesManager
 from transformers.onnx.utils import get_preprocessor
 
-from ..runs_base import Run, TimeBenchmark, get_autoclass_name, task_processing_map
+from ...runs_base import Run, TimeBenchmark, get_autoclass_name, task_processing_map
 
 
 class PyTorchRun(Run):

--- a/optimum/pytorch/runs/__init__.py
+++ b/optimum/pytorch/runs/__init__.py
@@ -1,0 +1,107 @@
+from datasets import load_metric
+from transformers import pipeline as _transformers_pipeline
+from transformers.onnx import FeaturesManager
+from transformers.onnx.utils import get_preprocessor
+
+from ..runs_base import Run, TimeBenchmark, get_autoclass_name, task_processing_map
+
+
+class PyTorchRun(Run):
+    def __init__(self, run_config):
+        run_config = super().__init__(run_config)
+
+        self.preprocessor = get_preprocessor(run_config["model_name_or_path"])
+
+        self.batch_sizes = run_config["batch_sizes"]
+        self.input_lengths = run_config["input_lengths"]
+
+        self.time_benchmark_args = run_config["time_benchmark_args"]
+
+        # pytorch benchmark
+        model_class = FeaturesManager.get_model_class_for_feature(get_autoclass_name(self.task))
+        self.torch_model = model_class.from_pretrained(run_config["model_name_or_path"])
+
+        processing_class = task_processing_map[self.task]
+        self.processor = processing_class(
+            dataset_path=run_config["dataset"]["path"],
+            dataset_name=run_config["dataset"]["name"],
+            calibration_split=run_config["dataset"]["calibration_split"],
+            eval_split=run_config["dataset"]["eval_split"],
+            preprocessor=self.preprocessor,
+            data_keys=run_config["dataset"]["data_keys"],
+            ref_keys=run_config["dataset"]["ref_keys"],
+            task_args=run_config["task_args"],
+            static_quantization=self.static_quantization,
+            num_calibration_samples=run_config["calibration"]["num_calibration_samples"]
+            if self.static_quantization
+            else None,
+            config=self.torch_model.config,
+            max_eval_samples=run_config["max_eval_samples"],
+        )
+
+        self.metric_names = run_config["metrics"]
+
+        self.load_datasets()
+
+        self.return_body[
+            "model_type"
+        ] = self.torch_model.config.model_type  # return_body is initialized in parent class
+
+    def _launch_time(self, trial):
+        batch_size = trial.suggest_categorical("batch_size", self.batch_sizes)
+        input_length = trial.suggest_categorical("input_length", self.input_lengths)
+
+        model_input_names = set(self.preprocessor.model_input_names)
+
+        print("Running PyTorch time benchmark.")
+        time_benchmark = TimeBenchmark(
+            self.torch_model,
+            input_length=input_length,
+            batch_size=batch_size,
+            model_input_names=model_input_names,
+            warmup_runs=self.time_benchmark_args["warmup_runs"],
+            duration=self.time_benchmark_args["duration"],
+        )
+        time_metrics = time_benchmark.execute()
+
+        time_evaluation = {
+            "batch_size": batch_size,
+            "input_length": input_length,
+        }
+        time_evaluation.update(time_metrics)
+
+        self.return_body["evaluation"]["time"].append(time_evaluation)
+
+        return 0, 0
+
+    def launch_eval(self):
+        try:
+            kwargs = self.processor.get_pipeline_kwargs()
+
+            # transformers pipelines are smart enought to detect whether the tokenizer or feature_extractor is needed
+            ort_pipeline = _transformers_pipeline(
+                task=self.task,
+                model=self.torch_model,
+                tokenizer=self.preprocessor,
+                feature_extractor=self.preprocessor,
+                **kwargs,
+            )
+
+            eval_dataset = self.get_eval_dataset()
+
+            # may be better to avoid to get labels twice
+            print("Running inference...")
+            all_labels, all_preds = self.processor.run_inference(eval_dataset, ort_pipeline)
+
+            print("Computing metrics...")
+            for metric_name in self.metric_names:
+                metric = load_metric(metric_name)
+                metrics_dict = self.processor.get_metrics(predictions=all_preds, references=all_labels, metric=metric)
+                self.return_body["evaluation"]["others"].update(metrics_dict)
+
+            return self.return_body
+        finally:
+            self.finalize()
+
+    def finalize(self):
+        pass

--- a/optimum/runs_base.py
+++ b/optimum/runs_base.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import subprocess
 from contextlib import contextmanager
@@ -57,7 +58,8 @@ class Run:
         Args:
             run_config (dict): Parameters to use for the run. See [`~utils.runs.RunConfig`] for the expected keys.
         """
-        RunConfig(**run_config)  # validate the data (useful if used as standalone)
+        run_config = RunConfig(**run_config)  # validate the data (useful if used as standalone)
+        run_config = dataclasses.asdict(run_config)
 
         self.task = run_config["task"]
 
@@ -103,11 +105,13 @@ class Run:
             },
             "evaluation": {
                 "time": [],
-                "others": {"baseline": {}, "optimized": {}},
+                "others": {},
             },
             "max_eval_samples": run_config["max_eval_samples"],
             "time_benchmark_args": run_config["time_benchmark_args"],
         }
+
+        return run_config
 
     def launch(self):
         """Launch inference to compare metrics between the original and optimized model.
@@ -138,7 +142,7 @@ class Run:
 
     def launch_eval(self):
         """
-        Run evaluation on the original and optimized model.
+        Run evaluation on the model.
 
         Populate the `["evaluation"]["others"]` subdictionary of the run.
         """
@@ -166,7 +170,7 @@ class Run:
         """
         Get evaluation dataset.  The dataset needs to be loaded first with [`~optimum.runs_base.Run.load_datasets`].
 
-         Returns:
+        Returns:
             `datasets.Dataset`: Evaluation dataset.
         """
         if not hasattr(self, "_eval_dataset"):

--- a/optimum/runs_base.py
+++ b/optimum/runs_base.py
@@ -130,6 +130,13 @@ class Run:
 
         return self.return_body
 
+    def launch_time(self):
+        try:
+            self.study.optimize(self._launch_time)
+            return self.return_body
+        finally:
+            self.finalize()
+
     def _launch_time(self, trial):
         """Optuna objective function to measure latency/throughput.
 

--- a/tests/benchmark/test_transformers_optimum_examples_parity.py
+++ b/tests/benchmark/test_transformers_optimum_examples_parity.py
@@ -9,7 +9,7 @@ import unittest
 import transformers
 
 from optimum.onnxruntime.runs import OnnxRuntimeRun
-from optimum.utils.runs import RunConfig
+from optimum.pytorch.runs import PyTorchRun
 
 
 class TestParity(unittest.TestCase):
@@ -85,29 +85,38 @@ class TestParity(unittest.TestCase):
                 "ref_keys": ["label"],
             },
             "metrics": ["accuracy"],
+            "framework": "pytorch",
+            "max_eval_samples": n_samples,
+        }
+        run_instance = PyTorchRun(run_config)
+        benchmark_results = run_instance.launch_eval()
+
+        self.assertEqual(transformers_results["eval_accuracy"], benchmark_results["evaluation"]["others"]["accuracy"])
+
+        run_config = {
+            "task": "text-classification",
+            "task_args": {"is_regression": False},
+            "model_name_or_path": model_name,
+            "dataset": {
+                "path": "glue",
+                "name": "sst2",
+                "eval_split": "validation",
+                "data_keys": {"primary": "sentence"},
+                "ref_keys": ["label"],
+            },
+            "metrics": ["accuracy"],
             "quantization_approach": "dynamic",
             "operators_to_quantize": ["Add", "MatMul"],
             "node_exclusion": [],
             "per_channel": False,
             "framework": "onnxruntime",
             "framework_args": {"optimization_level": 1, "opset": 15},
-            "batch_sizes": [8],
-            "input_lengths": [128],
             "max_eval_samples": n_samples,
-            "time_benchmark_args": {"warmup_runs": 0, "duration": 0},
         }
-        run_config = RunConfig(**run_config)
-        run_config = dataclasses.asdict(run_config)
-
         run_instance = OnnxRuntimeRun(run_config)
-        benchmark_results = run_instance.launch()
+        benchmark_results = run_instance.launch_eval()
 
-        self.assertEqual(
-            transformers_results["eval_accuracy"], benchmark_results["evaluation"]["others"]["baseline"]["accuracy"]
-        )
-        self.assertEqual(
-            optimum_results["accuracy"], benchmark_results["evaluation"]["others"]["optimized"]["accuracy"]
-        )
+        self.assertEqual(optimum_results["accuracy"], benchmark_results["evaluation"]["others"]["accuracy"])
 
     def test_token_classification_parity(self):
         model_name = "hf-internal-testing/tiny-bert-for-token-classification"
@@ -162,32 +171,38 @@ class TestParity(unittest.TestCase):
                 "ref_keys": ["ner_tags"],
             },
             "metrics": ["seqeval"],
+            "framework": "pytorch",
+            "max_eval_samples": n_samples,
+        }
+        run_instance = PyTorchRun(run_config)
+        benchmark_results = run_instance.launch_eval()
+
+        self.assertEqual(transformers_results["eval_accuracy"], benchmark_results["evaluation"]["others"]["accuracy"])
+        self.assertEqual(transformers_results["eval_f1"], benchmark_results["evaluation"]["others"]["f1"])
+
+        run_config = {
+            "task": "token-classification",
+            "model_name_or_path": model_name,
+            "dataset": {
+                "path": "conll2003",
+                "eval_split": "validation",
+                "data_keys": {"primary": "tokens"},
+                "ref_keys": ["ner_tags"],
+            },
+            "metrics": ["seqeval"],
             "quantization_approach": "dynamic",
             "operators_to_quantize": ["Add", "MatMul"],
             "node_exclusion": [],
             "per_channel": False,
             "framework": "onnxruntime",
             "framework_args": {"optimization_level": 1, "opset": 11},
-            "batch_sizes": [8],
-            "input_lengths": [128],
             "max_eval_samples": n_samples,
-            "time_benchmark_args": {"warmup_runs": 0, "duration": 0},
         }
-        run_config = RunConfig(**run_config)
-        run_config = dataclasses.asdict(run_config)
-
         run_instance = OnnxRuntimeRun(run_config)
-        benchmark_results = run_instance.launch()
+        benchmark_results = run_instance.launch_eval()
 
-        self.assertEqual(
-            transformers_results["eval_accuracy"], benchmark_results["evaluation"]["others"]["baseline"]["accuracy"]
-        )
-        self.assertEqual(transformers_results["eval_f1"], benchmark_results["evaluation"]["others"]["baseline"]["f1"])
-
-        self.assertEqual(
-            optimum_results["accuracy"], benchmark_results["evaluation"]["others"]["optimized"]["accuracy"]
-        )
-        self.assertEqual(optimum_results["f1"], benchmark_results["evaluation"]["others"]["optimized"]["f1"])
+        self.assertEqual(optimum_results["accuracy"], benchmark_results["evaluation"]["others"]["accuracy"])
+        self.assertEqual(optimum_results["f1"], benchmark_results["evaluation"]["others"]["f1"])
 
     def test_question_answering_parity(self):
         model_name = "mrm8488/bert-tiny-finetuned-squadv2"
@@ -243,33 +258,41 @@ class TestParity(unittest.TestCase):
                 "ref_keys": ["answers"],
             },
             "metrics": ["squad"],
+            "framework": "pytorch",
+            "max_eval_samples": n_samples,
+        }
+        run_instance = PyTorchRun(run_config)
+        benchmark_results = run_instance.launch_eval()
+
+        self.assertEqual(transformers_results["eval_f1"], benchmark_results["evaluation"]["others"]["f1"])
+        self.assertEqual(
+            transformers_results["eval_exact_match"],
+            benchmark_results["evaluation"]["others"]["exact_match"],
+        )
+
+        run_config = {
+            "task": "question-answering",
+            "model_name_or_path": model_name,
+            "dataset": {
+                "path": "squad",
+                "eval_split": "validation",
+                "data_keys": {"question": "question", "context": "context"},
+                "ref_keys": ["answers"],
+            },
+            "metrics": ["squad"],
             "quantization_approach": "dynamic",
             "operators_to_quantize": ["Add", "MatMul"],
             "node_exclusion": [],
             "per_channel": False,
             "framework": "onnxruntime",
             "framework_args": {"optimization_level": 1, "opset": 15},
-            "batch_sizes": [8],
-            "input_lengths": [128],
             "max_eval_samples": n_samples,
-            "time_benchmark_args": {"warmup_runs": 0, "duration": 0},
         }
-        run_config = RunConfig(**run_config)
-        run_config = dataclasses.asdict(run_config)
-
         run_instance = OnnxRuntimeRun(run_config)
-        benchmark_results = run_instance.launch()
+        benchmark_results = run_instance.launch_eval()
 
-        self.assertEqual(transformers_results["eval_f1"], benchmark_results["evaluation"]["others"]["baseline"]["f1"])
-        self.assertEqual(
-            transformers_results["eval_exact_match"],
-            benchmark_results["evaluation"]["others"]["baseline"]["exact_match"],
-        )
-
-        self.assertEqual(optimum_results["f1"], benchmark_results["evaluation"]["others"]["optimized"]["f1"])
-        self.assertEqual(
-            optimum_results["exact_match"], benchmark_results["evaluation"]["others"]["optimized"]["exact_match"]
-        )
+        self.assertEqual(optimum_results["f1"], benchmark_results["evaluation"]["others"]["f1"])
+        self.assertEqual(optimum_results["exact_match"], benchmark_results["evaluation"]["others"]["exact_match"])
 
     def test_image_classification_parity(self):
         # wait to have an answer on


### PR DESCRIPTION
# What does this PR do?

* Dissociate the metrics / time evaluation between PyTorch and ONNX Runtime.
* Add a method to perform only perf metrics evaluation, or only time evaluation if we are not interested in both.

**Motivation:** The current design in `main` is to run both evals in the same method, and it results e.g. for autoquantize in repeated evals with PyTorch when we try different quantization hyperparameters (only the eval for ONNX Runtime changes).

Below just design questions I am wondering about.

### **Is it worth "advertising" in the doc these scripts in a tutorial section? Having this included in Optimum?**

At the end of the day, I think the goal is not only to have a seamless tool to compare vanilla PyTorch to a target backend, but to compare several backends / optimization strategies as well, for example INC, OpenVino, ONNX Runtime.

This is something that does not exist in transformers, there are only the `run_etc.py` example scripts. So I wonder if actually (except for autoquantize where it's the motivation) adding an additional layer of abstraction taking care of data loading, pre-processing, quantization, possible optimizations, inference & evaluation with pipelines is desirable or not ; and most of all if it's desirable to have it in the Optimum repository. It feels like a very different direction compared to the examples in transformers.

I feel the risk of this approach is to abstract too much the logic at the risk of loosing features provided by the backend. Still, for what I am doing it is pretty useful to have these scripts at hand, compare models / evals changing only a config file.

As we promised to improve the documentation for end of July I spent a little time on this to set clear the design if it is to be extended in the future to other backends, so let me know @mfuntowicz  & team if you think having these `Run...` classes as an additional abstraction is useful or not.

Doc to come in a next PR if approved.