### PR TITLE
Raise warning in examples for classification tasks where the model's label mapping can not automatically match with the dataset labels

### DIFF
--- a/examples/onnxruntime/optimization/text-classification/run_glue.py
+++ b/examples/onnxruntime/optimization/text-classification/run_glue.py
@@ -149,7 +149,13 @@ class OptimizationArguments:
     optimization_level: Optional[int] = field(
         default=1,
         metadata={
-            "help": "Optimization level performed by ONNX Runtime of the loaded graph."
+            "help": "Optimization level performed         except Exception as e:
+            logger.warning(
+                f"\nModel label mapping: {optimizer.model.config.label2id}"
+                f"\nDataset label features: {eval_dataset.features['label']}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
+            )by ONNX Runtime of the loaded graph."
             "0 will disable all optimizations."
             "1 will enable basic optimizations."
             "2 will enable basic and extended optimizations, including complex node fusions applied to the nodes "
@@ -369,9 +375,17 @@ def main():
         eval_dataset = raw_datasets[validation_split]
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
-        if optimizer.config.label2id:
+
+        try:
             eval_dataset = eval_dataset.align_labels_with_mapping(
-                label2id=optimizer.config.label2id, label_column="label"
+                label2id=model.config.label2id, label_column="label"
+            )
+        except Exception as e:
+            logger.warning(
+                f"\nModel label mapping: {optimizer.model.config.label2id}"
+                f"\nDataset label features: {eval_dataset.features['label']}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
             )
 
         eval_dataset = eval_dataset.map(

--- a/examples/onnxruntime/optimization/text-classification/run_glue.py
+++ b/examples/onnxruntime/optimization/text-classification/run_glue.py
@@ -35,7 +35,6 @@ from transformers import (
     AutoTokenizer,
     EvalPrediction,
     HfArgumentParser,
-    PretrainedConfig,
     PreTrainedTokenizer,
     TrainingArguments,
 )
@@ -149,13 +148,7 @@ class OptimizationArguments:
     optimization_level: Optional[int] = field(
         default=1,
         metadata={
-            "help": "Optimization level performed         except Exception as e:
-            logger.warning(
-                f"\nModel label mapping: {optimizer.model.config.label2id}"
-                f"\nDataset label features: {eval_dataset.features['label']}"
-                f"\nCould not guarantee the model label mapping and the dataset labels match."
-                f" Evaluation results may suffer from a wrong matching."
-            )by ONNX Runtime of the loaded graph."
+            "help": "Optimization level performed by ONNX Runtime of the loaded graph."
             "0 will disable all optimizations."
             "1 will enable basic optimizations."
             "2 will enable basic and extended optimizations, including complex node fusions applied to the nodes "
@@ -377,12 +370,10 @@ def main():
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
         try:
-            eval_dataset = eval_dataset.align_labels_with_mapping(
-                label2id=model.config.label2id, label_column="label"
-            )
+            eval_dataset = eval_dataset.align_labels_with_mapping(label2id=model.config.label2id, label_column="label")
         except Exception as e:
             logger.warning(
-                f"\nModel label mapping: {optimizer.model.config.label2id}"
+                f"\nModel label mapping: {model.config.label2id}"
                 f"\nDataset label features: {eval_dataset.features['label']}"
                 f"\nCould not guarantee the model label mapping and the dataset labels match."
                 f" Evaluation results may suffer from a wrong matching."

--- a/examples/onnxruntime/optimization/token-classification/run_ner.py
+++ b/examples/onnxruntime/optimization/token-classification/run_ner.py
@@ -329,11 +329,18 @@ def main():
             if data_args.max_eval_samples is not None:
                 eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
-            label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
-            if label2id:
+            try:
                 eval_dataset = eval_dataset.align_labels_with_mapping(
-                    label2id=label2id, label_column=label_column_name
+                    label2id=optimizer.model.config.label2id, label_column=label_column_name
                 )
+            except Exception as e:
+                logger.warning(
+                    f"\nModel label mapping: {optimizer.model.config.label2id}"
+                    f"\nDataset label features: {eval_dataset.features['label']}"
+                    f"\nCould not guarantee the model label mapping and the dataset labels match."
+                    f" Evaluation results may suffer from a wrong matching."
+                )
+
             features = eval_dataset.features
         else:
             features = raw_datasets["train"].features

--- a/examples/onnxruntime/optimization/token-classification/run_ner.py
+++ b/examples/onnxruntime/optimization/token-classification/run_ner.py
@@ -31,7 +31,7 @@ import datasets
 import numpy as np
 import transformers
 from datasets import ClassLabel, load_dataset, load_metric
-from transformers import AutoTokenizer, HfArgumentParser, PretrainedConfig, PreTrainedTokenizer, TrainingArguments
+from transformers import AutoTokenizer, HfArgumentParser, PreTrainedTokenizer, TrainingArguments
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
@@ -331,12 +331,12 @@ def main():
 
             try:
                 eval_dataset = eval_dataset.align_labels_with_mapping(
-                    label2id=optimizer.model.config.label2id, label_column=label_column_name
+                    label2id=model.config.label2id, label_column=label_column_name
                 )
             except Exception as e:
                 logger.warning(
-                    f"\nModel label mapping: {optimizer.model.config.label2id}"
-                    f"\nDataset label features: {eval_dataset.features['label']}"
+                    f"\nModel label mapping: {model.config.label2id}"
+                    f"\nDataset label features: {eval_dataset.features[label_column_name]}"
                     f"\nCould not guarantee the model label mapping and the dataset labels match."
                     f" Evaluation results may suffer from a wrong matching."
                 )

--- a/examples/onnxruntime/quantization/image-classification/run_image_classification.py
+++ b/examples/onnxruntime/quantization/image-classification/run_image_classification.py
@@ -225,7 +225,7 @@ def main():
     # or specify a Dataset from the hub (the dataset will be downloaded automatically from the datasets Hub).
     if data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
-        dataset = load_dataset(data_args.dataset_name, task="image-classification")
+        dataset = load_dataset(data_args.dataset_name)
     else:
         data_files = {}
         if data_args.train_dir is not None:
@@ -240,6 +240,10 @@ def main():
         )
         # See more about loading custom images at
         # https://huggingface.co/docs/datasets/v2.0.0/en/image_process#imagefolder.
+
+    labels_column = (
+        "labels" if "labels" in dataset["validation"].column_names else dataset["validation"].column_names[1]
+    )
 
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_args.model_name_or_path)
 
@@ -298,7 +302,9 @@ def main():
     if apply_static_quantization:
         calibration_dataset = dataset["train"]
         if optim_args.num_calibration_samples is not None:
-            calibration_dataset = calibration_dataset.select(range(optim_args.num_calibration_samples))
+            calibration_dataset = calibration_dataset.shuffle(seed=training_args.seed).select(
+                range(optim_args.num_calibration_samples)
+            )
 
         # all images are loaded in memory, which could prove expensive if num_calibration_samples is large
         calibration_dataset = calibration_dataset.map(
@@ -369,16 +375,16 @@ def main():
 
         eval_dataset = dataset["validation"]
         if data_args.max_eval_samples is not None:
-            eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
+            eval_dataset = eval_dataset.shuffle(seed=training_args.seed).select(range(data_args.max_eval_samples))
 
         try:
             eval_dataset = eval_dataset.align_labels_with_mapping(
-                label2id=model.config.label2id, label_column="labels"
+                label2id=model.config.label2id, label_column=labels_column
             )
         except Exception as e:
             logger.warning(
                 f"\nModel label mapping: {quantizer.model.config.label2id}"
-                f"\nDataset label features: {eval_dataset.features['labels']}"
+                f"\nDataset label features: {eval_dataset.features[labels_column]}"
                 f"\nCould not guarantee the model label mapping and the dataset labels match."
                 f" Evaluation results may suffer from a wrong matching."
             )
@@ -390,7 +396,7 @@ def main():
             Path(training_args.output_dir) / "model_quantized.onnx",
             execution_provider=optim_args.execution_provider,
             compute_metrics=compute_metrics,
-            label_names=["labels"],
+            label_names=[labels_column],
         )
         outputs = ort_model.evaluation_loop(eval_dataset)
         # Save metrics

--- a/examples/onnxruntime/quantization/image-classification/run_image_classification.py
+++ b/examples/onnxruntime/quantization/image-classification/run_image_classification.py
@@ -366,14 +366,23 @@ def main():
     # Evaluation
     if training_args.do_eval:
         logger.info("*** Evaluate ***")
+
         eval_dataset = dataset["validation"]
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
-        if model.config.label2id:
+        try:
             eval_dataset = eval_dataset.align_labels_with_mapping(
                 label2id=model.config.label2id, label_column="labels"
             )
+        except Exception as e:
+            logger.warning(
+                f"\nModel label mapping: {quantizer.model.config.label2id}"
+                f"\nDataset label features: {eval_dataset.features['labels']}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
+            )
+
         # Set the validation transforms
         eval_dataset = eval_dataset.with_transform(preprocess_function)
 

--- a/examples/onnxruntime/quantization/image-classification/run_image_classification.py
+++ b/examples/onnxruntime/quantization/image-classification/run_image_classification.py
@@ -383,7 +383,7 @@ def main():
             )
         except Exception as e:
             logger.warning(
-                f"\nModel label mapping: {quantizer.model.config.label2id}"
+                f"\nModel label mapping: {model.config.label2id}"
                 f"\nDataset label features: {eval_dataset.features[labels_column]}"
                 f"\nCould not guarantee the model label mapping and the dataset labels match."
                 f" Evaluation results may suffer from a wrong matching."

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -484,7 +484,7 @@ def main():
             )
         except Exception as e:
             logger.warning(
-                f"\nModel label mapping: {quantizer.model.config.label2id}"
+                f"\nModel label mapping: {onnx_model.config.label2id}"
                 f"\nDataset label features: {eval_dataset.features['label']}"
                 f"\nCould not guarantee the model label mapping and the dataset labels match."
                 f" Evaluation results may suffer from a wrong matching."

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -477,8 +477,18 @@ def main():
         eval_dataset = preprocessed_datasets["validation_matched" if data_args.task_name == "mnli" else "validation"]
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
-        if model.config.label2id:
-            eval_dataset = eval_dataset.align_labels_with_mapping(label2id=model.config.label2id, label_column="label")
+
+        try:
+            eval_dataset = eval_dataset.align_labels_with_mapping(
+                label2id=model.config.label2id, label_column="label"
+            )
+        except Exception as e:
+            logger.warning(
+                f"\nModel label mapping: {quantizer.model.config.label2id}"
+                f"\nDataset label features: {eval_dataset.features['label']}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
+            )
 
         ort_model = ORTModel(
             Path(training_args.output_dir) / "model_quantized.onnx",

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -479,9 +479,7 @@ def main():
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
         try:
-            eval_dataset = eval_dataset.align_labels_with_mapping(
-                label2id=model.config.label2id, label_column="label"
-            )
+            eval_dataset = eval_dataset.align_labels_with_mapping(label2id=model.config.label2id, label_column="label")
         except Exception as e:
             logger.warning(
                 f"\nModel label mapping: {onnx_model.config.label2id}"

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -331,8 +331,8 @@ def main():
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
+        label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path)
         try:
-            label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
             eval_dataset = eval_dataset.align_labels_with_mapping(
                 label2id=label2id,
                 label_column=label_column_name,

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -334,7 +334,7 @@ def main():
         try:
             label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
             eval_dataset = eval_dataset.align_labels_with_mapping(
-                label2id=PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id,
+                label2id=label2id,
                 label_column=label_column_name,
             )
         except Exception as e:

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -331,7 +331,7 @@ def main():
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
-        label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path)
+        label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
         try:
             eval_dataset = eval_dataset.align_labels_with_mapping(
                 label2id=label2id,

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -331,9 +331,19 @@ def main():
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
 
-        label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
-        if label2id:
-            eval_dataset = eval_dataset.align_labels_with_mapping(label2id=label2id, label_column=label_column_name)
+        try:
+            label2id = PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id
+            eval_dataset = eval_dataset.align_labels_with_mapping(
+                label2id=PretrainedConfig.from_pretrained(model_args.model_name_or_path).label2id,
+                label_column=label_column_name,
+            )
+        except Exception as e:
+            logger.warning(
+                f"\nModel label mapping: {label2id}"
+                f"\nDataset label features: {eval_dataset.features[label_column_name]}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
+            )
         features = eval_dataset.features
     else:
         features = raw_datasets["train"].features

--- a/optimum/utils/preprocessing/image_classification.py
+++ b/optimum/utils/preprocessing/image_classification.py
@@ -50,7 +50,16 @@ class ImageClassificationProcessing(DatasetProcessing):
         eval_dataset = raw_datasets[self.eval_split]
         if max_eval_samples is not None:
             eval_dataset = eval_dataset.shuffle(seed=42).select(range(max_eval_samples))
-        eval_dataset = eval_dataset.align_labels_with_mapping(self.config.label2id, self.ref_keys[0])
+
+        try:
+            eval_dataset = eval_dataset.align_labels_with_mapping(self.config.label2id, self.ref_keys[0])
+        except Exception as e:
+            print(
+                f"\nModel label mapping: {self.config.label2id}"
+                f"\nDataset label features: {eval_dataset.features[self.ref_keys[0]]}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
+            )
 
         datasets_dict = {"eval": eval_dataset}
 

--- a/optimum/utils/preprocessing/token_classification.py
+++ b/optimum/utils/preprocessing/token_classification.py
@@ -39,9 +39,18 @@ class TokenClassificationProcessing(DatasetProcessing):
         eval_dataset = raw_datasets[self.eval_split]
         if self.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(self.max_eval_samples))
-        eval_dataset = eval_dataset.align_labels_with_mapping(
-            label2id=self.config.label2id, label_column=self.ref_keys[0]
-        )
+
+        try:
+            eval_dataset = eval_dataset.align_labels_with_mapping(
+                label2id=self.config.label2id, label_column=self.ref_keys[0]
+            )
+        except Exception as e:
+            print(
+                f"\nModel label mapping: {self.config.label2id}"
+                f"\nDataset label features: {eval_dataset.features[self.ref_keys[0]]}"
+                f"\nCould not guarantee the model label mapping and the dataset labels match."
+                f" Evaluation results may suffer from a wrong matching."
+            )
 
         datasets_dict = {"eval": eval_dataset}
 


### PR DESCRIPTION
Following https://github.com/huggingface/optimum/pull/197 , as per the title. For example 

```python
cfg = AutoConfig.from_pretrained("howey/bert-base-uncased-sst2")
print(cfg)
"""prints
BertConfig {
  "_name_or_path": "howey/bert-base-uncased-sst2",
  "architectures": [
    "BertForSequenceClassification"
  ],
  "attention_probs_dropout_prob": 0.1,
  "classifier_dropout": null,
  "finetuning_task": "sst2",
  "gradient_checkpointing": false,
  "hidden_act": "gelu",
  "hidden_dropout_prob": 0.1,
  "hidden_size": 768,
  "initializer_range": 0.02,
  "intermediate_size": 3072,
  "layer_norm_eps": 1e-12,
  "max_position_embeddings": 512,
  "model_type": "bert",
  "num_attention_heads": 12,
  "num_hidden_layers": 12,
  "pad_token_id": 0,
  "position_embedding_type": "absolute",
  "problem_type": "single_label_classification",
  "transformers_version": "4.22.0.dev0",
  "type_vocab_size": 2,
  "use_cache": true,
  "vocab_size": 30522
}
"""

print(cfg.label2id)
"""prints
{'LABEL_0': 0, 'LABEL_1': 1}
"""
```

So although in the config.json there is no label2id, it's actually an attribute of the PretrainedConfig. So the previous check (e.g. `if optimizer.model.config.label2id`) was not enough to avoid the example scripts failing.

I tried all the examples this time.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


