### PR TITLE
Add option to save benchmark results

### DIFF
--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -1,5 +1,9 @@
 import copy
+import json
 import os
+import shutil
+import time
+from typing import Dict, Optional, Union
 
 from datasets import load_metric
 from transformers import pipeline as _transformers_pipeline
@@ -10,7 +14,7 @@ from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 from ...pipelines import pipeline as _optimum_pipeline
 from ...runs_base import Run, TimeBenchmark, get_autoclass_name, task_processing_map
 from .. import ORTQuantizer
-from ..configuration import QuantizationConfig
+from ..configuration import ORTConfig, QuantizationConfig
 from ..modeling_ort import ORTModel
 from ..preprocessors import QuantizationPreprocessor
 from .calibrator import OnnxRuntimeCalibrator
@@ -39,6 +43,8 @@ class OnnxRuntimeRun(Run):
             opset=run_config["framework_args"]["opset"],
         )
 
+        self.ort_config = ORTConfig(opset=quantizer.opset, quantization=qconfig)
+
         self.preprocessor = copy.deepcopy(quantizer.preprocessor)
 
         self.batch_sizes = run_config["batch_sizes"]
@@ -46,8 +52,8 @@ class OnnxRuntimeRun(Run):
 
         self.time_benchmark_args = run_config["time_benchmark_args"]
 
-        self.model_path = "model.onnx"
-        self.quantized_model_path = "quantized_model.onnx"
+        self.model_path = os.path.join(self.run_dir_path, "model.onnx")
+        self.quantized_model_path = os.path.join(self.run_dir_path, "quantized_model.onnx")
 
         processing_class = task_processing_map[self.task]
         self.processor = processing_class(
@@ -149,7 +155,9 @@ class OnnxRuntimeRun(Run):
 
         return 0, 0
 
-    def launch_eval(self):
+    def launch_eval(
+        self, save: bool = False, save_directory: Union[str, os.PathLike] = None, run_name: Optional[str] = None
+    ):
         kwargs = self.processor.get_pipeline_kwargs()
 
         # transformers pipelines are smart enought to detect whether the tokenizer or feature_extractor is needed
@@ -189,8 +197,27 @@ class OnnxRuntimeRun(Run):
             self.return_body["evaluation"]["others"]["baseline"].update(baseline_metrics_dict)
             self.return_body["evaluation"]["others"]["optimized"].update(optimized_metrics_dict)
 
-    def finalize(self):
-        if os.path.isfile(self.quantized_model_path):
-            os.remove(self.quantized_model_path)
-        if os.path.isfile(self.model_path):
-            os.remove(self.model_path)
+        if save:
+            self.save(save_directory, run_name)
+
+    def save(self, save_directory: Union[str, os.PathLike], run_name: str):
+        if save_directory is None:
+            raise ValueError("A valid `save_directory` needs to be provided to save a run.")
+
+        subdir = time.strftime("%Y%m%d-h%Hm%Ms%S")
+        subdir += ("_" + run_name) if run_name is not None else ""
+        save_directory = os.path.join(save_directory, subdir)
+
+        if not os.path.exists(save_directory):
+            os.makedirs(save_directory)
+
+        # save ORTConfig
+        self.ort_config.save_pretrained(save_directory)
+
+        # save non-quantized and quantized models
+        shutil.move(self.model_path, os.path.join(save_directory, "model.onnx"))
+        shutil.move(self.quantized_model_path, os.path.join(save_directory, "quantized_model.onnx"))
+
+        # save run config and evaluation results
+        with open(os.path.join(save_directory, "results.json"), "w") as f:
+            json.dump(self.return_body, f, indent=4)

--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -43,8 +43,6 @@ class OnnxRuntimeRun(Run):
             opset=run_config["framework_args"]["opset"],
         )
 
-        self.ort_config = ORTConfig(opset=quantizer.opset, quantization=qconfig)
-
         self.preprocessor = copy.deepcopy(quantizer.preprocessor)
 
         self.batch_sizes = run_config["batch_sizes"]
@@ -99,6 +97,8 @@ class OnnxRuntimeRun(Run):
             quantization_config=qconfig,
             preprocessor=quantization_preprocessor,
         )
+
+        self.ort_config = ORTConfig(opset=quantizer.opset, quantization=qconfig)
 
         # onnxruntime benchmark
         ort_session = ORTModel.load_model(self.quantized_model_path)

--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -201,15 +201,7 @@ class OnnxRuntimeRun(Run):
             self.save(save_directory, run_name)
 
     def save(self, save_directory: Union[str, os.PathLike], run_name: str):
-        if save_directory is None:
-            raise ValueError("A valid `save_directory` needs to be provided to save a run.")
-
-        subdir = time.strftime("%Y%m%d-h%Hm%Ms%S")
-        subdir += ("_" + run_name) if run_name is not None else ""
-        save_directory = os.path.join(save_directory, subdir)
-
-        if not os.path.exists(save_directory):
-            os.makedirs(save_directory)
+        save_directory = super().save(save_directory, run_name)
 
         # save ORTConfig
         self.ort_config.save_pretrained(save_directory)

--- a/optimum/runs_base.py
+++ b/optimum/runs_base.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from contextlib import contextmanager
-from time import perf_counter_ns
 from typing import Optional, Set, Union
 
 import numpy as np
@@ -185,7 +185,19 @@ class Run:
             run_name (`str`, *optional*, defaults to `None`):
                 Optional name of the run, to include as a suffix in the saved directory name.
         """
-        raise NotImplementedError()
+        if save_directory is None:
+            raise ValueError("A valid `save_directory` needs to be provided to save a run.")
+
+        subdir = time.strftime("%Y%m%d-h%Hm%Ms%S")
+        subdir += ("_" + run_name) if run_name is not None else ""
+        save_directory = os.path.join(save_directory, subdir)
+
+        if not os.path.exists(save_directory):
+            os.makedirs(save_directory)
+
+        print(f"Saving run in {save_directory}.")
+
+        return save_directory
 
     def load_datasets(self):
         """Load evaluation dataset, and if needed, calibration dataset for static quantization."""
@@ -252,9 +264,9 @@ class TimeBenchmark:
 
     @contextmanager
     def track(self):
-        start = perf_counter_ns()
+        start = time.perf_counter_ns()
         yield
-        end = perf_counter_ns()
+        end = time.perf_counter_ns()
 
         # Append the time to the buffer
         self.latencies.append(end - start)

--- a/tests/benchmark/test_run_base.py
+++ b/tests/benchmark/test_run_base.py
@@ -1,0 +1,48 @@
+import dataclasses
+import os
+import tempfile
+import unittest
+
+from optimum.onnxruntime.runs import OnnxRuntimeRun
+from optimum.utils.runs import RunConfig
+
+
+class TestRunBase(unittest.TestCase):
+    def test_save(self):
+        run_config = {
+            "model_name_or_path": "fxmarty/resnet-tiny-beans",
+            "dataset": {
+                "path": "beans",
+                "eval_split": "validation",
+                "data_keys": {"primary": "image"},
+                "ref_keys": ["labels"],
+            },
+            "metrics": ["accuracy"],
+            "task": "image-classification",
+            "quantization_approach": "dynamic",
+            "framework": "onnxruntime",
+            "framework_args": {"opset": 12},
+            "operators_to_quantize": ["Add", "MatMul"],
+            "time_benchmark_args": {"duration": 0, "warmup_runs": 0},
+            "max_eval_samples": 100,
+        }
+
+        cfg = RunConfig(**run_config)
+        cfg = dataclasses.asdict(cfg)
+
+        eval_run = OnnxRuntimeRun(cfg)
+
+        save_directory = tempfile.mkdtemp()
+
+        subdirs = set(next(os.walk(save_directory))[1])  # get non-recursive subdirectories
+        _ = eval_run.launch(save=True, save_directory=save_directory)
+        subdirs_after = set(next(os.walk(save_directory))[1])
+
+        self.assertEqual(len(subdirs_after - subdirs), 1)
+        result_dir = list(subdirs_after - subdirs)[0]
+
+        result_path = os.path.join(save_directory, result_dir)
+
+        self.assertTrue(os.path.isfile(os.path.join(result_path, "quantized_model.onnx")))
+        self.assertTrue(os.path.isfile(os.path.join(result_path, "results.json")))
+        self.assertTrue(os.path.isfile(os.path.join(result_path, "ort_config.json")))


### PR DESCRIPTION
This PR adds an option in the benchmark scripts to save the run configuration, the model obtained, and the evaluation results.

## Before submitting
- [x] Did you write any new necessary tests?
