### PR TITLE
Update train docker to onnxruntime-training 1.12.0

### DIFF
--- a/.github/workflows/test_onnxruntime_train.yml
+++ b/.github/workflows/test_onnxruntime_train.yml
@@ -1,9 +1,15 @@
 name: ONNX Runtime / Test ORTTrainer
 
+# on:
+#   workflow_dispatch:
+#   schedule:
+#     - cron: 0 7 * * * #every day at 7 am
+
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: 0 7 * * * #every day at 7 am
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   start-runner:
@@ -54,14 +60,14 @@ jobs:
       - name: Build Image
         working-directory: examples/onnxruntime/training/docker
         run: |
-            docker build -f Dockerfile-ort1.11.1-cu113 -t ort11/cu11 .
+            docker build -f Dockerfile-ort1.12.0-cu113 -t ort12/cu113 .
       - name: Run Test
         run: |
             docker run --rm -p 80:8888 \
               --gpus all \
               -v $PWD:/workspace \
               --workdir=/workspace \
-              ort11/cu11:latest /bin/bash examples/onnxruntime/training/docker/run.sh
+              ort12/cu113:latest /bin/bash examples/onnxruntime/training/docker/run.sh
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/examples/onnxruntime/training/docker/Dockerfile-ort1.12.0-cu113
+++ b/examples/onnxruntime/training/docker/Dockerfile-ort1.12.0-cu113
@@ -28,11 +28,11 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN pip install --upgrade pip
 
 # Install onnxruntime-training dependencies
-RUN pip install onnx==1.11.0 ninja
-RUN pip install torch==1.11.0+cu113 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install onnx==1.12.0 ninja
+RUN pip install torch==1.12.0+cu113 -f https://download.pytorch.org/whl/torch_stable.html
 RUN pip install onnxruntime-training==1.12.0+cu113 -f https://download.onnxruntime.ai/onnxruntime_stable_cu113.html
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+# RUN python -m torch_ort.configure
 
 WORKDIR .
 

--- a/examples/onnxruntime/training/docker/Dockerfile-ort1.12.0-cu115
+++ b/examples/onnxruntime/training/docker/Dockerfile-ort1.12.0-cu115
@@ -1,0 +1,39 @@
+# Use nvidia/cuda image
+FROM nvidia/cuda:11.5.0-cudnn8-devel-ubuntu20.04
+CMD nvidia-smi
+
+# Ignore interactive questions during `docker build`
+ENV DEBIAN_FRONTEND noninteractive
+
+# Bash shell
+RUN chsh -s /bin/bash
+SHELL ["/bin/bash", "-c"]
+
+# Temporary fix until NVDIA finish the update of its docker images
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+# Install and update tools to minimize security vulnerabilities
+RUN apt-get update
+RUN apt-get install -y software-properties-common wget apt-utils patchelf git libprotobuf-dev protobuf-compiler cmake \
+    bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 mercurial subversion libopenmpi-dev && \
+    apt-get clean
+RUN unattended-upgrade
+RUN apt-get autoremove -y
+
+# Install Pythyon (3.8 as default)
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN apt-get install -y python3-pip
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN pip install --upgrade pip
+
+# Install onnxruntime-training dependencies
+RUN pip install onnx==1.11.0 ninja
+RUN pip install torch==1.11.0+cu115 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install onnxruntime-training==1.12.0+cu115 -f https://download.onnxruntime.ai/onnxruntime_stable_cu115.html
+RUN pip install torch-ort
+# RUN python -m torch_ort.configure
+
+WORKDIR .
+
+CMD ["/bin/bash"]

--- a/examples/onnxruntime/training/docker/run.sh
+++ b/examples/onnxruntime/training/docker/run.sh
@@ -14,8 +14,10 @@ GPU_DEVICES=${2:-"all"}
 # Install dependencies
 pip install -U pip
 pip install pygit2 pgzip
-pip install transformers datasets accelerate
-pip install coloredlogs absl-py rouge_score seqeval scipy sacrebleu nltk sklearn parameterized
+# Install transformers from source as there was a bug on the 4.21.0 release: https://github.com/huggingface/transformers/issues/18350
+pip install git+https://github.com/huggingface/transformers
+pip install datasets accelerate #transformers
+pip install coloredlogs absl-py rouge_score seqeval scipy sacrebleu nltk sklearn parameterized sentencepiece
 pip install fairscale deepspeed mpi4py
 pip install --upgrade protobuf==3.20.1
 # pip install optuna ray sigopt wandb # Hyper parameter search

--- a/tests/onnxruntime/nightly_test_trainer.py
+++ b/tests/onnxruntime/nightly_test_trainer.py
@@ -40,7 +40,7 @@ from transformers.testing_utils import (
     require_ray,
     require_sigopt,
     require_torch,
-    require_torch_bf16,
+    require_torch_bf16_gpu,
     require_torch_gpu,
     require_wandb,
     slow,
@@ -517,7 +517,7 @@ class ORTTrainerIntegrationTest(unittest.TestCase):
 
     @unittest.skip("Skip BF6 test.")
     @slow
-    @require_torch_bf16
+    @require_torch_bf16_gpu
     @parameterized.expand(_get_models_to_test(_MODELS_TO_TEST, _TASKS_DATASETS_CONFIGS), skip_on_empty=True)
     def test_trainer_bf16(self, test_name, model_name, feature, data_metric_config):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
# What does this PR do?

* Update `torch==1.12.0 onnx==1.12.0` in ort-1.12.0-cu113
* Create ort-1.12.0-cu115 dockerfile
* Update run.sh (currently a bug of fairescale in transformers 4.21.0)
