### PR TITLE
Add support of big-bird in config for ORTOptimizer 

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -60,6 +60,7 @@ class ORTConfigManager:
     _conf = {
         "bert": ("num_attention_heads", "hidden_size", "bert"),
         "albert": ("num_attention_heads", "hidden_size", "bert"),
+        "big_bird": ("num_attention_heads", "hidden_size", "bert"),
         "camembert": ("num_attention_heads", "hidden_size", "bert"),
         "codegen": ("n_head", "n_embd", "gpt2"),
         "distilbert": ("n_heads", "dim", "bert"),

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -26,6 +26,7 @@ from transformers import (
     AutoTokenizer,
     BartForSequenceClassification,
     BertForSequenceClassification,
+    BigBirdForSequenceClassification,
     DistilBertForSequenceClassification,
     ElectraForSequenceClassification,
     GPT2ForSequenceClassification,
@@ -69,6 +70,7 @@ class ORTOptimizerTest(unittest.TestCase):
         (RobertaForSequenceClassification, "hf-internal-testing/tiny-random-roberta"),
         (ElectraForSequenceClassification, "hf-internal-testing/tiny-random-electra"),
         (XLMRobertaForSequenceClassification, "hf-internal-testing/tiny-xlm-roberta"),
+        (BigBirdForSequenceClassification, "hf-internal-testing/tiny-random-big_bird"),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)


### PR DESCRIPTION
# What does this PR do?
This small PR adds config for big-bird based models to be used in ORTOptimizer.