### PR TITLE
Add support of xlm-roberta in config for ORTOptimizer

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -70,6 +70,7 @@ class ORTConfigManager:
         "bart": ("encoder_attention_heads", "d_model", "bart"),
         "gpt2": ("n_head", "n_embd", "gpt2"),
         "gpt_neo": ("num_heads", "hidden_size", "gpt2"),
+        "xlm-roberta": ("num_attention_heads", "hidden_size", "bert"),
     }
 
     @classmethod

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -30,6 +30,7 @@ from transformers import (
     ElectraForSequenceClassification,
     GPT2ForSequenceClassification,
     RobertaForSequenceClassification,
+    XLMRobertaForSequenceClassification,
 )
 
 import onnx
@@ -67,6 +68,7 @@ class ORTOptimizerTest(unittest.TestCase):
         (GPT2ForSequenceClassification, "hf-internal-testing/tiny-random-gpt2"),
         (RobertaForSequenceClassification, "hf-internal-testing/tiny-random-roberta"),
         (ElectraForSequenceClassification, "hf-internal-testing/tiny-random-electra"),
+        (XLMRobertaForSequenceClassification, "hf-internal-testing/tiny-random-xlm-roberta")
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -68,7 +68,7 @@ class ORTOptimizerTest(unittest.TestCase):
         (GPT2ForSequenceClassification, "hf-internal-testing/tiny-random-gpt2"),
         (RobertaForSequenceClassification, "hf-internal-testing/tiny-random-roberta"),
         (ElectraForSequenceClassification, "hf-internal-testing/tiny-random-electra"),
-        (XLMRobertaForSequenceClassification, "hf-internal-testing/tiny-random-xlm-roberta")
+        (XLMRobertaForSequenceClassification, "hf-internal-testing/tiny-xlm-roberta"),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)


### PR DESCRIPTION
# What does this PR do?

This PR adds config for xlm-roberta based models to be used in ORTOptimizer.
(This is a duplicate PR of #312 due to the restructuring of the test)

Fixes #322

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

