### PR TITLE
Fix the way the linear modules are removed from the parent module

### DIFF
--- a/optimum/fx/optimization/transformations.py
+++ b/optimum/fx/optimization/transformations.py
@@ -296,7 +296,6 @@ class MergeLinears(ReversibleTransformation):
             mod = graph_module
             if len(names) > 1:
                 for name in names[:-1]:
-                    print(name)
                     mod = getattr(mod, name)
             delattr(mod, names[-1])
 


### PR DESCRIPTION
# What does this PR do?

- Fixes the way linears are removed from their parent module when merging.
- Fixes the way linears are inserted back to the model when umerging.