### PR TITLE
Fix CPU device parameter

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1310,7 +1310,7 @@ class ORTTrainer(Trainer):
         else:
             if not (self.args.fp16 and self.args.deepspeed):
                 # Taking CPU to export the model
-                self.model.to("cpu")
+                self.model.to(torch.device("cpu"))
             model = unwrap_model(self.model)
 
         model_type, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=self.feature)


### PR DESCRIPTION
# What does this PR do?

Fixes a crash in Trainer using CPU.

This parameter is expected to be of type `torch.device` not `str`.

Otherwise this crashes with:
```
../../.mamba/envs/score/lib/python3.7/site-packages/optimum/onnxruntime/trainer.py:1315: in _export
    self.model.to("cpu")
../../.mamba/envs/score/lib/python3.7/site-packages/optimum/onnxruntime/modeling_ort.py:122: in to
    provider = get_provider_for_device(self.device)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

device = 'cpu'

    def get_provider_for_device(device: torch.device) -> str:
        """
        Gets the ONNX Runtime provider associated with the PyTorch device (CPU/CUDA).
        """
>       return "CUDAExecutionProvider" if device.type.lower() == "cuda" else "CPUExecutionProvider"
E       AttributeError: 'str' object has no attribute 'type'

../../.mamba/envs/score/lib/python3.7/site-packages/optimum/onnxruntime/utils.py:165: AttributeError
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

