### PR TITLE
Fix bug where the PR doc is actually the main doc

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,9 +15,14 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
-      REPO_OWNER: ${{ github.event.repository.owner.name }}
+      REPO_OWNER: ${{ github.event.repository_owner }}
+      REPO_OWNER_2: ${{ github.repository_owner }}
 
     steps:
+      -name: Echos
+        run: |
+          echo "$REPO_OWNER and $REPO_OWNER_2"
+
       - uses: actions/checkout@v2
         with:
           repository: 'huggingface/doc-builder'

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,16 +15,9 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
-      REPO_OWNER: ${{ github.repository }}
-      REPO_OWNER_2: ${{ github.event.pull_request.head.repo.clone_url }}
-      REPO_OWNER_3: ${{ github.event.pull_request.head.repo.owner.login }}
+      PR_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
     steps:
-      - name: Echos
-        run: |
-          echo "$REPO_OWNER and $REPO_OWNER_2 and $REPO_OWNER_3"
-          echo $EVENT_CONTEXT
-
       - uses: actions/checkout@v2
         with:
           repository: 'huggingface/doc-builder'
@@ -87,7 +80,7 @@ jobs:
       - name: Make Optimum documentation
         run: |
           cd optimum
-          make doc BUILD_DIR=optimum-doc-build VERSION=pr_$PR_NUMBER COMMIT_SHA_OPTIMUM=$COMMIT_SHA OPTIMUM_REPO_OWNER=$REPO_OWNER
+          make doc BUILD_DIR=optimum-doc-build VERSION=pr_$PR_NUMBER COMMIT_SHA_OPTIMUM=$COMMIT_SHA CLONE_URL=$PR_CLONE_URL
           cd ..
 
       - name: Combine subpackage documentation

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,6 +15,7 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
+      REPO_OWNER: ${{ github.event.repository.owner.name }}
 
     steps:
       - uses: actions/checkout@v2
@@ -79,7 +80,7 @@ jobs:
       - name: Make Optimum documentation
         run: |
           cd optimum
-          make doc BUILD_DIR=optimum-doc-build VERSION=pr_$PR_NUMBER
+          make doc BUILD_DIR=optimum-doc-build VERSION=pr_$PR_NUMBER COMMIT_SHA_OPTIMUM=$COMMIT_SHA OPTIMUM_REPO_OWNER=$REPO_OWNER
           cd ..
 
       - name: Combine subpackage documentation

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,12 +15,12 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
-      REPO_OWNER: ${{ github.event.org }}
+      REPO_OWNER: ${{ github.event.pull_request.org }}
       REPO_OWNER_2: ${{ github.repository_owner }}
-      REPO_OWNER_3: ${{ github.event.org.login }}
-      REPO_OWNER_4: ${{ github.event.repo }}
-      REPO_OWNER_5: ${{ github.event.repo.name }}
-      REPO_OWNER_6: ${{ github.event.repo.owner }}
+      REPO_OWNER_3: ${{ github.event.pull_request.org.login }}
+      REPO_OWNER_4: ${{ github.event.rpull_request.epo }}
+      REPO_OWNER_5: ${{ github.event.pull_request.repo.name }}
+      REPO_OWNER_6: ${{ github.event.pull_request.repo.owner }}
 
     steps:
       - name: Echos

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,9 +15,9 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
-      REPO_OWNER: ${{ github.event.repository }}
+      REPO_OWNER: ${{ github.repository }}
       REPO_OWNER_2: ${{ github.repository_owner }}
-      REPO_OWNER_3: ${{ github.event.organization }}
+      REPO_OWNER_3: ${{ github.organization }}
       REPO_OWNER_4: ${{ github.event.pull_request.owner }}
       REPO_OWNER_5: ${{ github.event.pull_request.repo }}
       REPO_OWNER_6: ${{ github.event.pull_request.repo.owner }}
@@ -26,6 +26,7 @@ jobs:
       - name: Echos
         run: |
           echo "$REPO_OWNER and $REPO_OWNER_2 and $REPO_OWNER_3 and $REPO_OWNER_4 and $REPO_OWNER_5 and $REPO_OWNER_6"
+          echo $EVENT_CONTEXT
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Echos
         run: |
-          echo "$REPO_OWNER and $REPO_OWNER_2"
+          echo "$REPO_OWNER and $REPO_OWNER_2 and $REPO_OWNER_3 and $REPO_OWNER_4 and $REPO_OWNER_5 and $REPO_OWNER_6"
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -19,7 +19,7 @@ jobs:
       REPO_OWNER_2: ${{ github.repository_owner }}
 
     steps:
-      -name: Echos
+      - name: Echos
         run: |
           echo "$REPO_OWNER and $REPO_OWNER_2"
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -16,16 +16,13 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
       REPO_OWNER: ${{ github.repository }}
-      REPO_OWNER_2: ${{ github.repository_owner }}
-      REPO_OWNER_3: ${{ github.organization }}
-      REPO_OWNER_4: ${{ github.event.pull_request.owner }}
-      REPO_OWNER_5: ${{ github.event.pull_request.repo }}
-      REPO_OWNER_6: ${{ github.event.pull_request.repo.owner }}
+      REPO_OWNER_2: ${{ github.event.pull_request.head.repo.clone_url }}
+      REPO_OWNER_3: ${{ github.event.pull_request.head.repo.owner.login }}
 
     steps:
       - name: Echos
         run: |
-          echo "$REPO_OWNER and $REPO_OWNER_2 and $REPO_OWNER_3 and $REPO_OWNER_4 and $REPO_OWNER_5 and $REPO_OWNER_6"
+          echo "$REPO_OWNER and $REPO_OWNER_2 and $REPO_OWNER_3"
           echo $EVENT_CONTEXT
 
       - uses: actions/checkout@v2

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,8 +15,12 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
-      REPO_OWNER: ${{ github.event.repository_owner }}
+      REPO_OWNER: ${{ github.event.org }}
       REPO_OWNER_2: ${{ github.repository_owner }}
+      REPO_OWNER_3: ${{ github.event.org.login }}
+      REPO_OWNER_4: ${{ github.event.repo }}
+      REPO_OWNER_5: ${{ github.event.repo.name }}
+      REPO_OWNER_6: ${{ github.event.repo.owner }}
 
     steps:
       - name: Echos

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,11 +15,11 @@ jobs:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
       EVENT_CONTEXT: ${{ toJSON(github.event) }}
-      REPO_OWNER: ${{ github.event.pull_request.org }}
+      REPO_OWNER: ${{ github.event.repository }}
       REPO_OWNER_2: ${{ github.repository_owner }}
-      REPO_OWNER_3: ${{ github.event.pull_request.org.login }}
-      REPO_OWNER_4: ${{ github.event.rpull_request.epo }}
-      REPO_OWNER_5: ${{ github.event.pull_request.repo.name }}
+      REPO_OWNER_3: ${{ github.event.organization }}
+      REPO_OWNER_4: ${{ github.event.pull_request.owner }}
+      REPO_OWNER_5: ${{ github.event.pull_request.repo }}
       REPO_OWNER_6: ${{ github.event.pull_request.repo.owner }}
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ pypi_upload: build_dist
 	python -m twine upload dist/*
 
 build_doc_docker_image:
-	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_OPTIMUM) --build-arg clone_url=$(CLONE_URL)  ./docs
+	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_OPTIMUM) --build-arg clone_url=$(CLONE_URL) ./docs
 
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ pypi_upload: build_dist
 	python -m twine upload dist/*
 
 build_doc_docker_image:
-	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_OPTIMUM) --build-arg repo_owner=$(OPTIMUM_REPO_OWNER)  ./docs
+	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_OPTIMUM) --build-arg clone_url=$(CLONE_URL)  ./docs
 
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ pypi_upload: build_dist
 	python -m twine upload dist/*
 
 build_doc_docker_image:
-	docker build -t doc_maker ./docs
+	docker build -t doc_maker --build-arg commit_sha=$(COMMIT_SHA_OPTIMUM) --build-arg repo_owner=$(OPTIMUM_REPO_OWNER)  ./docs
 
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,6 +2,7 @@ FROM nikolaik/python-nodejs:python3.8-nodejs18
 
 ARG commit_sha
 ARG repo_owner
+ENV repo_owner=$repo_owner
 
 RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,5 +7,7 @@ RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir hf-doc-builder
 
+RUN echo HERE
+RUN echo $repo_owner
 RUN git clone "https://github.com/$repo_owner/optimum.git" && cd optimum && git checkout $commit_sha
 RUN python3 -m pip install --no-cache-dir ./optimum[onnxruntime,benchmark,quality]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,8 +1,11 @@
 FROM nikolaik/python-nodejs:python3.8-nodejs18
 
+ARG commit_sha
+ARG repo_owner
+
 RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir hf-doc-builder
 
-RUN git clone https://github.com/huggingface/optimum.git
+RUN git clone https://github.com/$repo_owner/optimum.git && cd optimum && git checkout $commit_sha
 RUN python3 -m pip install --no-cache-dir ./optimum[onnxruntime,benchmark,quality]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,11 +2,10 @@ FROM nikolaik/python-nodejs:python3.8-nodejs18
 
 ARG commit_sha
 ARG repo_owner
-ENV repo_owner=$repo_owner
 
 RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir hf-doc-builder
 
-RUN git clone https://github.com/$repo_owner/optimum.git && cd optimum && git checkout $commit_sha
+RUN git clone "https://github.com/$repo_owner/optimum.git" && cd optimum && git checkout $commit_sha
 RUN python3 -m pip install --no-cache-dir ./optimum[onnxruntime,benchmark,quality]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,7 +7,5 @@ RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir hf-doc-builder
 
-RUN echo HERE
-RUN echo $clone_url
 RUN git clone $clone_url && cd optimum && git checkout $commit_sha
 RUN python3 -m pip install --no-cache-dir ./optimum[onnxruntime,benchmark,quality]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,13 +1,13 @@
 FROM nikolaik/python-nodejs:python3.8-nodejs18
 
 ARG commit_sha
-ARG repo_owner
+ARG clone_url
 
 RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir hf-doc-builder
 
 RUN echo HERE
-RUN echo $repo_owner
-RUN git clone "https://github.com/$repo_owner/optimum.git" && cd optimum && git checkout $commit_sha
+RUN echo $clone_url
+RUN git clone $clone_url && cd optimum && git checkout $commit_sha
 RUN python3 -m pip install --no-cache-dir ./optimum[onnxruntime,benchmark,quality]

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -72,5 +72,3 @@ For the acclerator-specific features, you can install them by appending `#egg=op
 ```bash
 python -m pip install git+https://github.com/huggingface/optimum.git#egg=optimum[onnxruntime]
 ```
-
-Test

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -72,3 +72,5 @@ For the acclerator-specific features, you can install them by appending `#egg=op
 ```bash
 python -m pip install git+https://github.com/huggingface/optimum.git#egg=optimum[onnxruntime]
 ```
+
+Test


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In the Docker image associated to the container building the doc, the repo is cloned but it points by default to the main branch. Thus, the doc generated for each PR is actually the doc of the main branch. This is fixed by checking out the commit associated to the PR when cloning the repo in the Dockerfile. See [here](https://github.com/huggingface/optimum-habana/pull/78) for more explanations.

If the PR comes from a fork, it also clone the right repo in the Docker container. This must also be done for Optimum Graphcore/Habana/Intel.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

