### PR TITLE
Do not force download by default in ORTModel

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -199,7 +199,6 @@ class OptimizedModel(ABC):
         Returns:
             `OptimizedModel`: The loaded optimized model.
         """
-
         revision = None
         if len(str(model_id).split("@")) == 2:
             model_id, revision = model_id.split("@")

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -193,10 +193,13 @@ class OptimizedModel(ABC):
             cache_dir (`str`, *optional*, defaults to `None`):
                 Path to a directory in which a downloaded pretrained model configuration should be cached if the
                 standard cache should not be used.
+            local_files_only(`bool`, *optional*, defaults to `False`):
+                Whether or not to only look at local files (i.e., do not try to download the model).
 
         Returns:
             `OptimizedModel`: The loaded optimized model.
         """
+
         revision = None
         if len(str(model_id).split("@")) == 2:
             model_id, revision = model_id.split("@")

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -155,7 +155,7 @@ class OptimizedModel(ABC):
         model_id: Union[str, os.PathLike],
         use_auth_token: Optional[Union[bool, str, None]] = None,
         revision: Optional[Union[str, None]] = None,
-        force_download: bool = True,
+        force_download: bool = False,
         cache_dir: Optional[str] = None,
         **kwargs,
     ):
@@ -167,7 +167,7 @@ class OptimizedModel(ABC):
         cls,
         model_id: Union[str, Path],
         from_transformers: bool = False,
-        force_download: bool = True,
+        force_download: bool = False,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
         **model_kwargs,
@@ -247,7 +247,7 @@ class OptimizedModel(ABC):
         model_id: Union[str, os.PathLike],
         use_auth_token: Optional[Union[bool, str, None]] = None,
         revision: Optional[Union[str, None]] = None,
-        force_download: bool = True,
+        force_download: bool = False,
         cache_dir: Optional[str] = None,
         **kwargs,
     ):

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -208,9 +208,12 @@ class ORTModel(OptimizedModel):
             file_name(`str`):
                 Overwrites the default model file name from `"model.onnx"` to `file_name`. This allows you to load different model files from the same
                 repository or directory.
+            local_files_only(`bool`, *optional*, defaults to `False`):
+                Whether or not to only look at local files (i.e., do not try to download the model).
             kwargs (`Dict`, *optional*):
                 kwargs will be passed to the model during initialization
         """
+        local_files_only = kwargs.pop("local_files_only", False)
         config_dict = kwargs.pop("config", {})
         model_file_name = file_name if file_name is not None else ONNX_WEIGHTS_NAME
         # load model from local directory
@@ -229,6 +232,7 @@ class ORTModel(OptimizedModel):
                 revision=revision,
                 cache_dir=cache_dir,
                 force_download=force_download,
+                local_files_only=local_files_only,
             )
             kwargs["model_save_dir"] = Path(model_cache_path).parent
             kwargs["latest_model_name"] = Path(model_cache_path).name
@@ -268,7 +272,6 @@ class ORTModel(OptimizedModel):
             kwargs (`Dict`, *optional*):
                 kwargs will be passed to the model during initialization
         """
-
         # create local save dir in cache dir
         save_dir = Path(save_dir).joinpath(model_id)
         save_dir.mkdir(parents=True, exist_ok=True)

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -299,8 +299,11 @@ class ORTModelForConditionalGeneration(ORTModel):
                 kwargs will be passed to the model during initialization.
             use_cache (`bool`, *optional*, defaults to `True`):
                 Whether or not to use the pre-computed key/values hidden-states in order to speed up sequential decoding.
+            local_files_only(`bool`, *optional*, defaults to `False`):
+                Whether or not to only look at local files (i.e., do not try to download the model).
         """
         use_cache = kwargs.pop("use_cache", True)
+        local_files_only = kwargs.pop("local_files_only", False)
         config_dict = kwargs.pop("config", {})
         config = PretrainedConfig.from_dict(config_dict)
         encoder_file_name = encoder_file_name or ONNX_ENCODER_NAME
@@ -335,6 +338,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                     revision=revision,
                     cache_dir=cache_dir,
                     force_download=force_download,
+                    local_files_only=local_files_only,
                 )
                 kwargs[f"last_{default_file_name.split('.')[0]}_name"] = Path(model_cache_path).name
             kwargs["model_save_dir"] = Path(model_cache_path).parent


### PR DESCRIPTION
We passed by default `force_download=True`, although the caching works well when passing `force_download=False`. Especially when passing `from_transformers=False`, everything works as expected as the onnx model is loaded from the cache `hub/` subfolder.

When passing `from_transformers=True`, although we cache only the PyTorch model (before [the new transformers cache system ](https://github.com/huggingface/transformers/pull/18438) in `transformers/` cache subfolder, in `hub/` subfolder in the next transformers release), the `force_download` argument is anyway ignored in `_from_transformers` so this PR has no impact there:

https://github.com/huggingface/optimum/blob/e90332463f7d2c1ae7e6feb93cfb379f92ed6231/optimum/onnxruntime/modeling_ort.py#L239-L303