### PR TITLE
Fix broken documentation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,5 +56,6 @@ doc: build_doc_docker_image
 	doc-builder build optimum /optimum/docs/source/ \
 		--build_dir $(BUILD_DIR) \
 		--version $(VERSION) \
+		--version_tag_suffix "" \
 		--html \
 		--clean

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -5,7 +5,7 @@ ARG clone_url
 
 RUN apt -y update
 RUN python3 -m pip install --no-cache-dir --upgrade pip
-RUN python3 -m pip install --no-cache-dir hf-doc-builder
+RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/doc-builder.git
 
 RUN git clone $clone_url && cd optimum && git checkout $commit_sha
 RUN python3 -m pip install --no-cache-dir ./optimum[onnxruntime,benchmark,quality]

--- a/docs/README.md
+++ b/docs/README.md
@@ -372,6 +372,7 @@ doc: build_doc_docker_image
 	doc-builder build optimum.habana /optimum-habana/docs/source/ \
 		--build_dir $(BUILD_DIR) \
 		--version $(VERSION) \
+		--version_tag_suffix "" \
 		--html \
 		--clean
 ```


### PR DESCRIPTION
This should be merged after https://github.com/huggingface/doc-builder/pull/278 is accepted.

This PR fixes the broken documentation links in Optimum documentation as the structure is not `src/optimum/` but directly `optimum/` (see e.g. the broken links in https://huggingface.co/docs/optimum/main/en/onnxruntime/quantization#optimum.onnxruntime.ORTQuantizer ).
