### PR TITLE
fix(optimization): handle empty file suffix

### DIFF
--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -93,7 +93,7 @@ class ORTOptimizer:
         self,
         optimization_config: OptimizationConfig,
         save_dir: Union[str, os.PathLike],
-        file_suffix: str = "optimized",
+        file_suffix: Optional[str] = "optimized",
         use_external_data_format: bool = False,
     ):
         """
@@ -144,7 +144,8 @@ class ORTOptimizer:
                 # keep_io_types to keep inputs/outputs as float32
                 optimizer.convert_float_to_float16(keep_io_types=True)
 
-            output_path = save_dir.joinpath(f"{model_path.stem}_{file_suffix}").with_suffix(model_path.suffix)
+            suffix = f"_{file_suffix}" if file_suffix else ""
+            output_path = save_dir.joinpath(f"{model_path.stem}{suffix}").with_suffix(model_path.suffix)
             optimizer.save_model_to_file(output_path.as_posix(), use_external_data_format)
 
         LOGGER.info(f"Optimized model saved at: {save_dir} (external data format: " f"{use_external_data_format})")

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -286,6 +286,8 @@ class ORTQuantizer(OptimumQuantizer):
             The path of the resulting quantized model.
         """
         use_qdq = quantization_config.is_static and quantization_config.format == QuantFormat.QDQ
+        save_dir = Path(save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
 
         if not quantization_config.is_static:
             if quantization_config.mode != QuantizationMode.IntegerOps:
@@ -341,7 +343,6 @@ class ORTQuantizer(OptimumQuantizer):
         LOGGER.info("Quantizing model...")
         quantizer.quantize_model()
 
-        os.makedirs(save_dir, exist_ok=True)
         suffix = f"_{file_suffix}" if file_suffix else ""
         quantized_model_path = Path(save_dir).joinpath(f"{self.onnx_model_path.stem}{suffix}").with_suffix(".onnx")
         LOGGER.info(f"Saving quantized model at: {save_dir} (external data format: " f"{use_external_data_format})")

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -286,8 +286,6 @@ class ORTQuantizer(OptimumQuantizer):
             The path of the resulting quantized model.
         """
         use_qdq = quantization_config.is_static and quantization_config.format == QuantFormat.QDQ
-        os.makedirs(save_dir, exist_ok=True)
-        quantized_model_path = Path(save_dir).joinpath(f"{self.onnx_model_path.stem}_{file_suffix}.onnx")
 
         if not quantization_config.is_static:
             if quantization_config.mode != QuantizationMode.IntegerOps:
@@ -343,6 +341,9 @@ class ORTQuantizer(OptimumQuantizer):
         LOGGER.info("Quantizing model...")
         quantizer.quantize_model()
 
+        os.makedirs(save_dir, exist_ok=True)
+        suffix = f"_{file_suffix}" if file_suffix else ""
+        quantized_model_path = Path(save_dir).joinpath(f"{self.onnx_model_path.stem}{suffix}").with_suffix(".onnx")
         LOGGER.info(f"Saving quantized model at: {save_dir} (external data format: " f"{use_external_data_format})")
         quantizer.model.save_model_to_file(quantized_model_path, use_external_data_format)
 

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -344,7 +344,7 @@ class ORTQuantizer(OptimumQuantizer):
         quantizer.quantize_model()
 
         suffix = f"_{file_suffix}" if file_suffix else ""
-        quantized_model_path = Path(save_dir).joinpath(f"{self.onnx_model_path.stem}{suffix}").with_suffix(".onnx")
+        quantized_model_path = save_dir.joinpath(f"{self.onnx_model_path.stem}{suffix}").with_suffix(".onnx")
         LOGGER.info(f"Saving quantized model at: {save_dir} (external data format: " f"{use_external_data_format})")
         quantizer.model.save_model_to_file(quantized_model_path, use_external_data_format)
 


### PR DESCRIPTION
# What does this PR do?
Fixes #364 

## Problem : 
Optimize or quantize a model but the user does not want a suffix so the user tries to use :

`file_suffix=None` => RuntimeError (for optimization)
`file_suffix=""` => saved file name is like `encoder_model_.onnx`

## Solution : 
Little logic to handle optional or empty file_suffix

## Doc : 
The doc was already saying the parameter could be optional (even if not with the current code)