### PR TITLE
Remove extra "habana-deepspeed"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ EXTRAS_REQUIRE = {
     "intel": "optimum-intel",
     "graphcore": "optimum-graphcore",
     "habana": "optimum-habana",
-    "habana-deepspeed": "optimum-habana[deepspeed]",
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
     "quality": QUALITY_REQUIRE,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The extra "habana-deepspeed" has to be removed because `optimum-habana[deepspeed]` makes uploading `optimum-habana` on PyPI impossible since it does not accept direct dependencies specified as URLs like Habana Deepspeed. See https://github.com/huggingface/optimum-habana/pull/96.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

