### PR TITLE
BaseConfig update for transformers>=4.22.0

### DIFF
--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #  Copyright 2021 The HuggingFace Team. All rights reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,8 +96,10 @@ class BaseConfig(PretrainedConfig):
     def get_configuration_file(cls, configuration_files: List[str]) -> str:
         """
         Get the configuration file to use for this version of transformers.
+
         Args:
             configuration_files (`List[str]`): The list of available configuration files.
+
         Returns:
             `str`: The configuration file to use.
         """
@@ -109,6 +112,7 @@ class BaseConfig(PretrainedConfig):
                 configuration_files_map[v] = file_name
         available_versions = sorted(configuration_files_map.keys())
 
+        # Defaults to FULL_CONFIGURATION_FILE and then try to look at some newer versions.
         configuration_file = cls.CONFIG_NAME
         optimum_version = version.parse(__version__)
         for v in available_versions:

--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -37,7 +37,7 @@ _transformers_version_is_below_threshold = (
 ) < _transformers_version_threshold
 
 if _transformers_version_is_below_threshold:
-    from huggingface_hub import hf_hub_download
+    from transformers.utils import cached_path, hf_bucket_url
 else:
     from transformers.dynamic_module_utils import custom_object_save
     from transformers.utils import cached_file, download_url, extract_commit_hash, is_remote_url
@@ -235,16 +235,23 @@ class BaseConfig(PretrainedConfig):
             try:
                 # TODO: remove once transformers release version is way above 4.22.
                 if _transformers_version_is_below_threshold:
-                    resolved_config_file = hf_hub_download(
-                        repo_id=pretrained_model_name_or_path,
+                    config_file = hf_bucket_url(
+                        pretrained_model_name_or_path,
                         filename=configuration_file,
                         revision=revision,
+                        subfolder=subfolder if len(subfolder) > 0 else None,
+                        mirror=None,
+                    )
+                    # Load from URL or cache if already cached
+                    resolved_config_file = cached_path(
+                        config_file,
                         cache_dir=cache_dir,
                         force_download=force_download,
-                        resume_download=resume_download,
                         proxies=proxies,
-                        use_auth_token=use_auth_token,
+                        resume_download=resume_download,
                         local_files_only=local_files_only,
+                        use_auth_token=use_auth_token,
+                        user_agent=user_agent,
                     )
                 else:
                     # Load from local folder or from cache or download from model Hub and cache

--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -139,6 +139,7 @@ class BaseConfig(PretrainedConfig):
 
         Returns:
             `Tuple[Dict, Dict]`: The dictionary(ies) that will be used to instantiate the configuration object.
+
         """
         original_kwargs = copy.deepcopy(kwargs)
         # Get config dict associated with the base config file

--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -217,6 +217,7 @@ class BaseConfig(PretrainedConfig):
             # Special case when pretrained_model_name_or_path is a local file
             resolved_config_file = pretrained_model_name_or_path
             is_local = True
+        # TODO: remove once transformers release version is way above 4.22.
         elif _transformers_version_is_below_threshold and os.path.isdir(pretrained_model_name_or_path):
             configuration_file = kwargs.pop("_configuration_file", cls.CONFIG_NAME)
             resolved_config_file = os.path.join(pretrained_model_name_or_path, configuration_file)

--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -124,37 +124,6 @@ class BaseConfig(PretrainedConfig):
 
         return configuration_file
 
-    # Adapted from transformers.configuration_utils.PretrainedConfig.get_config_dict
-    @classmethod
-    def get_config_dict(
-        cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        From a `pretrained_model_name_or_path`, resolve to a dictionary of parameters, to be used for instantiating a
-        [`PretrainedConfig`] using `from_dict`.
-
-        Parameters:
-            pretrained_model_name_or_path (`str` or `os.PathLike`):
-                The identifier of the pre-trained checkpoint from which we want the dictionary of parameters.
-
-        Returns:
-            `Tuple[Dict, Dict]`: The dictionary(ies) that will be used to instantiate the configuration object.
-        """
-        original_kwargs = copy.deepcopy(kwargs)
-        # Get config dict associated with the base config file
-        config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
-        if "_commit_hash" in config_dict:
-            original_kwargs["_commit_hash"] = config_dict["_commit_hash"]
-
-        # That config file may point us toward another config file to use.
-        if "configuration_files" in config_dict:
-            configuration_file = cls.get_configuration_file(config_dict["configuration_files"])
-            config_dict, kwargs = cls._get_config_dict(
-                pretrained_model_name_or_path, _configuration_file=configuration_file, **original_kwargs
-            )
-
-        return config_dict, kwargs
-
     # Adapted from transformers.configuration_utils.PretrainedConfig._get_config_dict
     @classmethod
     def _get_config_dict(

--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -24,12 +24,7 @@ from packaging import version
 from transformers import PretrainedConfig
 from transformers import __version__ as transformers_version
 from transformers.dynamic_module_utils import custom_object_save
-from transformers.utils import (
-    cached_file,
-    download_url,
-    extract_commit_hash,
-    is_remote_url,
-)
+from transformers.utils import cached_file, download_url, extract_commit_hash, is_remote_url
 
 from huggingface_hub import hf_hub_download
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.20.1",
+    "transformers[sentencepiece]>=4.22.0",
     "torch>=1.9",
     "packaging",
     "numpy",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.22.0",
+    "transformers[sentencepiece]>=4.20.1",
     "torch>=1.9",
     "packaging",
     "numpy",

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -76,7 +76,7 @@ class ConfigPushToHubTester(unittest.TestCase):
             )
 
             new_config = FakeConfig.from_pretrained(f"{USER}/optimum-test-base-config")
-            for k, v in config.__dict__.items():
+            for k, v in config.to_dict().items():
                 if k != "optimum_version" and k != "transformers_version":
                     self.assertEqual(v, getattr(new_config, k))
 
@@ -92,6 +92,6 @@ class ConfigPushToHubTester(unittest.TestCase):
             )
 
             new_config = FakeConfig.from_pretrained("valid_org/optimum-test-base-config-org")
-            for k, v in config.__dict__.items():
+            for k, v in config.to_dict().items():
                 if k != "optimum_version" and k != "transformers_version":
                     self.assertEqual(v, getattr(new_config, k))


### PR DESCRIPTION
# What does this PR do?

This PR updates the `BaseConfig` class to synchronize with the updates performed on the `transformers.PretrainedConfig`, and fixes the issue induced by the `transformers` 4.22 release, breaking the current `BaseConfig.push_to_hub` method.