### PR TITLE
Update ORTTrainer with transformers 4.22.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ As you can see, the process is similar in each case:
 
 ### Training
 
-Besides supporting ONNX Runtime inference, 🤗 Optimum also supports training with ONNX Runtime backend. The `ORTTrainer` class possess a similar behavior than the `Trainer` of 🤗 Transformers, but reduces the memory consumption and optimize the computation graphs during training. As a result, you will experience an acceleration and feed larger batch size to your device.
+Besides supporting ONNX Runtime inference, 🤗 Optimum also supports training with ONNX Runtime backend. The `ORTTrainer` class possesses a similar behavior to the `Trainer` of 🤗 Transformers, but reduces the memory consumption and optimizes the computation graphs during training. As a result, you will experience an acceleration and feed larger batch size to your device.
 
 Replace `Trainer` with `ORTTrainer` to leverage ONNX Runtime on fine-tuning tasks:
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ As you can see, the process is similar in each case:
 
 ### Training
 
-Besides supporting ONNX Runtime inference, 🤗 Optimum also supports ONNX Runtime training, reducing the memory and computations needed during training. This can be achieved by using the class `ORTTrainer`, which possess a similar behavior than the `Trainer` of 🤗 Transformers:
+Besides supporting ONNX Runtime inference, 🤗 Optimum also supports training with ONNX Runtime backend. The `ORTTrainer` class possess a similar behavior than the `Trainer` of 🤗 Transformers, but reduces the memory consumption and optimize the computation graphs during training. As a result, you will experience an acceleration and feed larger batch size to your device.
+
+Replace `Trainer` with `ORTTrainer` to leverage ONNX Runtime on fine-tuning tasks:
 
 ```diff
 -from transformers import Trainer
@@ -211,17 +213,14 @@ Besides supporting ONNX Runtime inference, 🤗 Optimum also supports ONNX Runti
     compute_metrics=compute_metrics,
     tokenizer=tokenizer,
     data_collator=default_data_collator,
-    feature="sequence-classification",
++    feature="sequence-classification",
 )
 
-# Step 2: Use ONNX Runtime for training and evalution!🤗
+# Step 2: Use ONNX Runtime for training!🤗
 train_result = trainer.train()
-eval_metrics = trainer.evaluate()
 ```
 
-By replacing `Trainer` by `ORTTrainer`, you will be able to leverage ONNX Runtime for fine-tuning tasks.
-
-Check out the [`examples`](https://github.com/huggingface/optimum/tree/main/examples) directory for more sophisticated usage.
+Check out the [`examples`](https://github.com/huggingface/optimum/tree/main/examples) for more sophisticated usage.
 
 Happy optimizing 🤗!
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Replace `Trainer` with `ORTTrainer` to leverage ONNX Runtime on fine-tuning task
     compute_metrics=compute_metrics,
     tokenizer=tokenizer,
     data_collator=default_data_collator,
-+    feature="sequence-classification",
++   feature="sequence-classification",
 )
 
 # Step 2: Use ONNX Runtime for training!🤗

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1403,9 +1403,6 @@ class ORTTrainer(Trainer):
                 )
                 if FSDPOption.OFFLOAD not in self.args.fsdp:
                     model.to(self.args.device)
-            # raise NotImplementedError(
-            #     "PyTorch's distrubuted data parallel features are not supported by `ORTTrainer` yet."
-            # )
         elif is_sagemaker_dp_enabled():
             raise NotImplementedError(
                 "Sagemaker's distrubuted data parallel features are not supported by `ORTTrainer` yet."

--- a/optimum/onnxruntime/trainer_seq2seq.py
+++ b/optimum/onnxruntime/trainer_seq2seq.py
@@ -107,9 +107,8 @@ class ORTSeq2SeqTrainer(ORTTrainer):
         """
 
         gen_kwargs = gen_kwargs.copy()
-        gen_kwargs["max_length"] = (
-            gen_kwargs["max_length"] if gen_kwargs.get("max_length") is not None else self.args.generation_max_length
-        )
+        if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
+            gen_kwargs["max_length"] = self.args.generation_max_length
         gen_kwargs["num_beams"] = (
             gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.args.generation_num_beams
         )
@@ -164,9 +163,8 @@ class ORTSeq2SeqTrainer(ORTTrainer):
         """
 
         gen_kwargs = gen_kwargs.copy()
-        gen_kwargs["max_length"] = (
-            gen_kwargs["max_length"] if gen_kwargs.get("max_length") is not None else self.args.generation_max_length
-        )
+        if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
+            gen_kwargs["max_length"] = self.args.generation_max_length
         gen_kwargs["num_beams"] = (
             gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.args.generation_num_beams
         )
@@ -581,9 +579,8 @@ class ORTSeq2SeqTrainer(ORTTrainer):
 
         # XXX: adapt synced_gpus for fairscale as well
         gen_kwargs = self._gen_kwargs.copy()
-        gen_kwargs["max_length"] = (
-            gen_kwargs["max_length"] if gen_kwargs.get("max_length") is not None else self.model.config.max_length
-        )
+        if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
+            gen_kwargs["max_length"] = self.model.config.max_length
         gen_kwargs["num_beams"] = (
             gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.model.config.num_beams
         )


### PR DESCRIPTION
# What does this PR do?

* Update `ORTTrainer` and `ORTSeq2SeqTrainer` with transformers 4.22.1 release.
* Enable PyTorch’s Fully Sharded Data Parallel (FSDP) training feature in the trainers.