### PR TITLE
docs: correct `sacrebleu` ref

### DIFF
--- a/examples/onnxruntime/training/translation/run_translation.py
+++ b/examples/onnxruntime/training/translation/run_translation.py
@@ -116,14 +116,14 @@ class DataTrainingArguments:
     validation_file: Optional[str] = field(
         default=None,
         metadata={
-            "help": "An optional input evaluation data file to evaluate the metrics (sacreblue) on "
+            "help": "An optional input evaluation data file to evaluate the metrics (sacrebleu) on "
             "a jsonlines file."
         },
     )
     test_file: Optional[str] = field(
         default=None,
         metadata={
-            "help": "An optional input test data file to evaluate the metrics (sacreblue) on " "a jsonlines file."
+            "help": "An optional input test data file to evaluate the metrics (sacrebleu) on " "a jsonlines file."
         },
     )
     overwrite_cache: bool = field(


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What does this PR do?

`sacreblue` -> `sacrebleu`

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

