### PR TITLE
Use more extra quantization options of ONNX Runtime

### DIFF
--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -337,6 +337,9 @@ class ORTQuantizer(OptimumQuantizer):
                 "ActivationSymmetric": quantization_config.activations_symmetric,
                 "EnableSubgraph": False,
                 "ForceSymmetric": quantization_config.activations_symmetric and quantization_config.weights_symmetric,
+                "AddQDQPairToWeight": quantization_config.qdq_add_pair_to_weight,
+                "DedicatedQDQPair": quantization_config.qdq_dedicated_pair,
+                "QDQOpTypePerChannelSupportToAxis": quantization_config.qdq_op_type_per_channel_support_to_axis,
             },
         )
 


### PR DESCRIPTION
Pass `AddQDQPairToWeight`, `DedicatedQDQPair`, `QDQOpTypePerChannelSupportToAxis` to `QDQQuantizer` or `ONNXQuantizer`, as those configuration attributes are available in `QuantizationConfig` but were not passed up to now.

This is useful if we later aim at using `TensorrtExecutionProvider` with a static quantized model.