### PR TITLE
Add possibility to pass `provider_options` to `ORTModel.from_pretrained()`

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -160,6 +160,7 @@ class ORTModel(OptimizedModel):
         path: Union[str, Path],
         provider: Optional[str] = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
+        provider_options: Optional[Dict] = None,
         **kwargs
     ):
         """
@@ -171,8 +172,11 @@ class ORTModel(OptimizedModel):
             provider (`str`, *optional*):
                 ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/
                 for possible providers. Defaults to `CPUExecutionProvider`.
-            session_options (`onnxruntime.SessionOptions`, *optional*),:
+            session_options (`onnxruntime.SessionOptions`, *optional*):
                 ONNX Runtime session options to use for loading the model. Defaults to `None`.
+            provider_options (`Dict`, **optional**):
+                Provider option dictionaries corresponding to the provider used. See available options
+                for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
         available_providers = ort.get_available_providers()
         if provider not in available_providers:
@@ -180,7 +184,10 @@ class ORTModel(OptimizedModel):
                 f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
             )
 
-        return ort.InferenceSession(path, providers=[provider], sess_options=session_options)
+        # `providers` list must of be of the same length as `provider_options` list
+        return ort.InferenceSession(
+            path, providers=[provider], sess_options=session_options, provider_options=[provider_options]
+        )
 
     def _save_pretrained(self, save_directory: Union[str, Path], file_name: Optional[str] = None, **kwargs):
         """
@@ -210,6 +217,7 @@ class ORTModel(OptimizedModel):
         cache_dir: Optional[str] = None,
         provider: Optional[str] = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
+        provider_options: Optional[Dict] = None,
         *args,
         **kwargs
     ):
@@ -231,6 +239,7 @@ class ORTModel(OptimizedModel):
             cache_dir,
             provider=provider,
             session_options=session_options,
+            provider_options=provider_options,
             *args,
             **kwargs,
         )

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -186,7 +186,10 @@ class ORTModel(OptimizedModel):
 
         # `providers` list must of be of the same length as `provider_options` list
         return ort.InferenceSession(
-            path, providers=[provider], sess_options=session_options, provider_options=[provider_options]
+            path,
+            providers=[provider],
+            sess_options=session_options,
+            provider_options=None if provider_options is None else [provider_options],
         )
 
     def _save_pretrained(self, save_directory: Union[str, Path], file_name: Optional[str] = None, **kwargs):

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -225,10 +225,16 @@ class ORTModelForConditionalGeneration(ORTModel):
             )
 
         encoder_session = onnxruntime.InferenceSession(
-            str(encoder_path), providers=[provider], sess_options=session_options, provider_options=[provider_options]
+            str(encoder_path),
+            providers=[provider],
+            sess_options=session_options,
+            provider_options=None if provider_options is None else [provider_options],
         )
         decoder_session = onnxruntime.InferenceSession(
-            str(decoder_path), providers=[provider], sess_options=session_options, provider_options=[provider_options]
+            str(decoder_path),
+            providers=[provider],
+            sess_options=session_options,
+            provider_options=None if provider_options is None else [provider_options],
         )
 
         decoder_with_past_session = None
@@ -239,7 +245,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 str(decoder_with_past_path),
                 providers=[provider],
                 sess_options=session_options,
-                provider_options=[provider_options],
+                provider_options=None if provider_options is None else [provider_options],
             )
 
         return encoder_session, decoder_session, decoder_with_past_session

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -194,6 +194,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         decoder_with_past_path: Union[str, Path] = None,
         provider: str = "CPUExecutionProvider",
         session_options: Optional[onnxruntime.SessionOptions] = None,
+        provider_options: Optional[Dict] = None,
         **kwargs
     ):
         """
@@ -213,6 +214,9 @@ class ORTModelForConditionalGeneration(ORTModel):
                 for possible providers. Defaults to `CPUExecutionProvider`.
             session_options (`onnxruntime.SessionOptions`, *optional*),:
                 ONNX Runtime session options to use for loading the model. Defaults to `None`.
+            provider_options (`Dict`, **optional**):
+                Provider option dictionaries corresponding to the provider used. See available options
+                for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
         available_providers = onnxruntime.get_available_providers()
         if provider not in available_providers:
@@ -221,10 +225,10 @@ class ORTModelForConditionalGeneration(ORTModel):
             )
 
         encoder_session = onnxruntime.InferenceSession(
-            str(encoder_path), providers=[provider], sess_options=session_options
+            str(encoder_path), providers=[provider], sess_options=session_options, provider_options=[provider_options]
         )
         decoder_session = onnxruntime.InferenceSession(
-            str(decoder_path), providers=[provider], sess_options=session_options
+            str(decoder_path), providers=[provider], sess_options=session_options, provider_options=[provider_options]
         )
 
         decoder_with_past_session = None
@@ -232,7 +236,10 @@ class ORTModelForConditionalGeneration(ORTModel):
         # will be enabled
         if decoder_with_past_path is not None:
             decoder_with_past_session = onnxruntime.InferenceSession(
-                str(decoder_with_past_path), providers=[provider], sess_options=session_options
+                str(decoder_with_past_path),
+                providers=[provider],
+                sess_options=session_options,
+                provider_options=[provider_options],
             )
 
         return encoder_session, decoder_session, decoder_with_past_session

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -240,19 +240,40 @@ class ORTModelIntegrationTest(unittest.TestCase):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, session_options=options)
         self.assertEqual(model.encoder.session.get_session_options().intra_op_num_threads, 3)
         self.assertEqual(model.decoder.session.get_session_options().intra_op_num_threads, 3)
-    
+
+    @require_torch_gpu
     def test_passing_provider_options(self):
         model = ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider="CUDAExecutionProvider")
-        session_provider_options = model.model.get_provider_options()
-        self.assertEqual(session_provider_options["CUDAExecutionProvider"]["do_copy_in_default_stream"], "1")
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "1")
 
-        """
-        provider_options = {"do_copy_in_default_stream": 0}
-        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider="CUDAExecutionProvider")
-        session_provider_options = model.model.get_provider_options()
-        self.assertEqual(session_provider_options["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
-        """
-    #def test_passing_provider_options_seq2seq(self):
+        model = ORTModel.from_pretrained(
+            self.ONNX_MODEL_ID,
+            provider="CUDAExecutionProvider",
+            provider_options={"do_copy_in_default_stream": 0},
+        )
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
+
+    @require_torch_gpu
+    def test_passing_provider_options_seq2seq(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, provider="CUDAExecutionProvider")
+        self.assertEqual(
+            model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "1"
+        )
+        self.assertEqual(
+            model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "1"
+        )
+
+        model = ORTModelForSeq2SeqLM.from_pretrained(
+            self.ONNX_SEQ2SEQ_MODEL_ID,
+            provider="CUDAExecutionProvider",
+            provider_options={"do_copy_in_default_stream": 0},
+        )
+        self.assertEqual(
+            model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0"
+        )
+        self.assertEqual(
+            model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0"
+        )
 
     def test_seq2seq_model_on_cpu(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -240,6 +240,19 @@ class ORTModelIntegrationTest(unittest.TestCase):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, session_options=options)
         self.assertEqual(model.encoder.session.get_session_options().intra_op_num_threads, 3)
         self.assertEqual(model.decoder.session.get_session_options().intra_op_num_threads, 3)
+    
+    def test_passing_provider_options(self):
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider="CUDAExecutionProvider")
+        session_provider_options = model.model.get_provider_options()
+        self.assertEqual(session_provider_options["CUDAExecutionProvider"]["do_copy_in_default_stream"], "1")
+
+        """
+        provider_options = {"do_copy_in_default_stream": 0}
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID, provider="CUDAExecutionProvider")
+        session_provider_options = model.model.get_provider_options()
+        self.assertEqual(session_provider_options["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
+        """
+    #def test_passing_provider_options_seq2seq(self):
 
     def test_seq2seq_model_on_cpu(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)


### PR DESCRIPTION
`InferenceSession` init can take the `provider_options` argument, that may set some custom parameters depending on the execution provider: see https://onnxruntime.ai/docs/api/python/api_summary.html#inferencesession & https://onnxruntime.ai/docs/api/c/group___global.html .

This is useful for example when using `TensorrtExecutionProvider`, we need to pass `{"trt_int8_enable": True}` to enable TensorRT INT8 precision, otherwise getting the error `Internal Error (Int8 precision has been set for a layer or layer output, but int8 is not configured in the builder)`.

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

