### PR TITLE
Fix ORT training args log level bug

### DIFF
--- a/examples/onnxruntime/training/docker/run.sh
+++ b/examples/onnxruntime/training/docker/run.sh
@@ -12,7 +12,8 @@ GPU_DEVICES=${2:-"all"}
 # docker run -it --rm -p 80:8888 --gpus $GPU_DEVICES ort9/cu11:latest $CMD
 
 # Install dependencies
-pip install datasets accelerate evaluate transformers
+pip install git+https://github.com/huggingface/transformers
+pip install datasets accelerate evaluate
 pip install coloredlogs absl-py rouge_score seqeval scipy sacrebleu nltk sklearn parameterized sentencepiece
 pip install fairscale deepspeed mpi4py
 # pip install optuna ray sigopt wandb # Hyper parameter search

--- a/examples/onnxruntime/training/language-modeling/run_clm.py
+++ b/examples/onnxruntime/training/language-modeling/run_clm.py
@@ -51,7 +51,8 @@ import evaluate
 from optimum.onnxruntime import ORTTrainer, ORTTrainingArguments
 
 
-check_min_version("4.22.0")
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
+check_min_version("4.23.0.dev0")
 
 require_version(
     "datasets>=1.8.0", "To fix: pip install -r examples/onnxruntime/training/language-modeling/requirements.txt"

--- a/examples/onnxruntime/training/language-modeling/run_mlm.py
+++ b/examples/onnxruntime/training/language-modeling/run_mlm.py
@@ -52,7 +52,7 @@ from optimum.onnxruntime import ORTTrainer, ORTTrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.22.0")
+check_min_version("4.23.0.dev0")
 
 require_version(
     "datasets>=1.8.0", "To fix: pip install -r examples/onnxruntime/training/language-modeling/requirements.txt"

--- a/examples/onnxruntime/training/question-answering/run_qa.py
+++ b/examples/onnxruntime/training/question-answering/run_qa.py
@@ -49,7 +49,7 @@ from utils_qa import postprocess_qa_predictions
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.22.0")
+check_min_version("4.23.0.dev0")
 
 require_version(
     "datasets>=1.8.0", "To fix: pip install -r examples/onnxruntime/training/question-answering/requirements.txt"

--- a/examples/onnxruntime/training/summarization/run_summarization.py
+++ b/examples/onnxruntime/training/summarization/run_summarization.py
@@ -51,7 +51,7 @@ from optimum.onnxruntime import ORTSeq2SeqTrainer, ORTSeq2SeqTrainingArguments
 
 
 # Might have error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.22.0")
+check_min_version("4.23.0.dev0")
 
 require_version(
     "datasets>=1.8.0", "To fix: pip install -r examples/onnxruntime/training/summarization/requirements.txt"

--- a/examples/onnxruntime/training/text-classification/run_glue.py
+++ b/examples/onnxruntime/training/text-classification/run_glue.py
@@ -48,7 +48,7 @@ from optimum.onnxruntime import ORTTrainer, ORTTrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.22.0")
+check_min_version("4.23.0.dev0")
 
 require_version(
     "datasets>=1.8.0", "To fix: pip install -r examples/onnxruntime/training/text-classification/requirements.txt"

--- a/examples/onnxruntime/training/token-classification/run_ner.py
+++ b/examples/onnxruntime/training/token-classification/run_ner.py
@@ -50,7 +50,7 @@ from optimum.onnxruntime.training_args import ORTTrainingArguments
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.22.0")
+check_min_version("4.23.0.dev0")
 
 require_version(
     "datasets>=1.18.0", "To fix: pip install -r examples/onnxruntime/training/token-classification/requirements.txt"

--- a/examples/onnxruntime/training/translation/run_translation.py
+++ b/examples/onnxruntime/training/translation/run_translation.py
@@ -52,7 +52,7 @@ from optimum.onnxruntime.training_args_seq2seq import ORTSeq2SeqTrainingArgument
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.22.0")
+check_min_version("4.23.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
 

--- a/optimum/onnxruntime/training_args.py
+++ b/optimum/onnxruntime/training_args.py
@@ -73,10 +73,6 @@ class ORTTrainingArguments(TrainingArguments):
         if env_local_rank != -1 and env_local_rank != self.local_rank:
             self.local_rank = env_local_rank
 
-        # convert to int
-        self.log_level = trainer_log_levels[self.log_level]
-        self.log_level_replica = trainer_log_levels[self.log_level_replica]
-
         # expand paths, if not os.makedirs("~/bar") will make directory
         # in the current directory instead of the actual home
         #  see https://github.com/huggingface/transformers/issues/10628

--- a/tests/onnxruntime/nightly_test_trainer.py
+++ b/tests/onnxruntime/nightly_test_trainer.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import gc
+import subprocess
+import sys
 import tempfile
 import unittest
 from typing import List, Optional
@@ -672,6 +674,37 @@ class ORTTrainerIntegrationDeepSpeedTest(unittest.TestCase):
             prediction = trainer.predict(test_dataset)
             # self.assertGreaterEqual(eval_metrics["eval_accuracy"], 0.75)
             gc.collect()
+
+
+# @slow
+# @require_torc
+class ORTTrainerIntegrationDDPTest(unittest.TestCase):
+    def test_trainer_ddp_glue(self):
+
+        subprocess.run(
+            f"cp examples/onnxruntime/training/text-classification/run_glue.py ./",
+            shell=True,
+        )
+
+        subprocess.run(
+            f"{sys.executable} -m torch.distributed.launch"
+            " --nproc_per_node=1"
+            " run_glue.py"
+            " --model_name_or_path distilbert-base-uncased"
+            " --task_name mnli"
+            " --max_seq_length 128"
+            " --learning_rate 3e-6"
+            " --do_train"
+            " --output_dir /tmp/distilbert"
+            " --overwrite_output_dir"
+            " --max_steps 200"
+            " --logging_steps 20"
+            " --per_device_train_batch_size 32"
+            " --fp16 --optim adamw_ort_fused"
+            " --max_train_samples 3000",
+            shell=True,
+            check=True,
+        )
 
 
 class ORTTrainerHyperParameterIntegrationTest(unittest.TestCase):

--- a/tests/onnxruntime/nightly_test_trainer.py
+++ b/tests/onnxruntime/nightly_test_trainer.py
@@ -676,8 +676,8 @@ class ORTTrainerIntegrationDeepSpeedTest(unittest.TestCase):
             gc.collect()
 
 
-# @slow
-# @require_torc
+@slow
+@require_torch
 class ORTTrainerIntegrationDDPTest(unittest.TestCase):
     def test_trainer_ddp_glue(self):
 


### PR DESCRIPTION
# What does this PR do?

Bugged after the recent change of log level in `transformers.TrainingArgs`: https://github.com/huggingface/transformers/pull/19239

* Fix by updating `ORTTrainingArguments`.
* CI will install transformers from source to track the possible breaking changes led by transformers' updates. 
* Add test for PyTorch DDP.
* Update training example minimal transformers version.

Fixes #418 