### PR TITLE
Support specific device id for ORTModel

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -149,8 +149,6 @@ class ORTModel(OptimizedModel):
         Returns:
             `ORTModel`: the model placed on the requested device.
         """
-        print("IN THIS to!!!!!!")
-
         provider_options = {}
         if isinstance(device, torch.device):
             self.device = device
@@ -169,8 +167,6 @@ class ORTModel(OptimizedModel):
             )
 
         provider = get_provider_for_device(self.device)
-        print("provider here:", provider)
-        print("provider_options here:", provider_options)
         self.model.set_providers([provider], provider_options=[provider_options])
         self.providers = self.model.get_providers()
 
@@ -254,6 +250,9 @@ class ORTModel(OptimizedModel):
             possible providers. Defaults to `CPUExecutionProvider`.
         session_options (`onnxruntime.SessionOptions`, *optional*),:
             ONNX Runtime session options to use for loading the model. Defaults to `None`.
+        provider_options (`Dict`, **optional**):
+            Provider option dictionaries corresponding to the provider used. See available options
+            for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
 
         Returns:
             `ORTModel`: The loaded ORTModel model.

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -142,18 +142,18 @@ class ORTModel(OptimizedModel):
         """Get the relevant torch.device from the passed device, and if relevant the provider options (e.g. to set the GPU id)."""
         provider_options = {}
         if isinstance(device, torch.device):
-            self.device = device
             if device.type == "cuda" and device.index:
                 provider_options["device_id"] = device.index
+            device = device
         elif isinstance(device, str):
-            self.device = torch.device(device)
             if device.startswith("cuda") and device[-1].isdigit():
                 provider_options["device_id"] = int(device[-1])
+            device = torch.device(device)
         elif isinstance(device, int) and device < 0:
-            self.device = torch.device("cpu")
+            device = torch.device("cpu")
         elif isinstance(device, int) and device >= 0:
-            self.device = torch.device(f"cuda:{device}")
             provider_options["device_id"] = device
+            device = torch.device(f"cuda:{device}")
         else:
             raise ValueError(
                 f"Asked to set the model on the device {device}, but a torch.device, string or int was expected."

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -40,6 +40,7 @@ from .utils import (
     _is_gpu_available,
     get_device_for_provider,
     get_provider_for_device,
+    parse_device,
 )
 
 
@@ -486,7 +487,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         Returns:
             `ORTModel`: the model placed on the requested device.
         """
-        device, provider_options = self._parse_device(device)
+        device, provider_options = parse_device(device)
 
         provider = get_provider_for_device(device)
         self.encoder._device = device

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from enum import Enum
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 import torch
 from transformers.onnx import OnnxConfig, OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from enum import Enum
+from typing import Dict, Tuple
 
 import torch
 from transformers.onnx import OnnxConfig, OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast
@@ -166,6 +167,21 @@ def get_provider_for_device(device: torch.device) -> str:
     Gets the ONNX Runtime provider associated with the PyTorch device (CPU/CUDA).
     """
     return "CUDAExecutionProvider" if device.type.lower() == "cuda" else "CPUExecutionProvider"
+
+
+def parse_device(device: Union[torch.device, str, int]) -> Tuple[torch.device, Dict]:
+    """Get the relevant torch.device from the passed device, and if relevant the provider options (e.g. to set the GPU id)."""
+
+    if device == -1:
+        device = torch.device("cpu")
+    else:
+        device = torch._C._nn._parse_to(device)[0]
+
+    provider_options = {}
+    if device.type == "cuda" and device.index:
+        provider_options["device_id"] = device.index
+
+    return device, provider_options
 
 
 class ORTQuantizableOperator(Enum):

--- a/tests/benchmark/test_transformers_optimum_examples_parity.py
+++ b/tests/benchmark/test_transformers_optimum_examples_parity.py
@@ -271,6 +271,9 @@ class TestParity(unittest.TestCase):
             optimum_results["exact_match"], benchmark_results["evaluation"]["others"]["optimized"]["exact_match"]
         )
 
+    @unittest.skip(
+        "failing related to shuffle issue https://github.com/huggingface/datasets/issues/5145 , skip for now"
+    )
     def test_image_classification_parity(self):
         # dummy test until this question is solved
         # https://discuss.huggingface.co/t/why-use-val-transforms-function-in-image-classification-example-instead-of-feature-extractor/19976

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -254,6 +254,20 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
 
     @require_torch_gpu
+    def test_model_on_gpu_id(self):
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID)
+        model.to(torch.device("cuda:1"))
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model.to(1)
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model.to("cuda:1")
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+
+    @require_torch_gpu
     def test_passing_provider_options_seq2seq(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, provider="CUDAExecutionProvider")
         self.assertEqual(
@@ -315,6 +329,32 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertEqual(model.decoder.session.get_providers()[0], "CUDAExecutionProvider")
         self.assertEqual(model.decoder_with_past.session.get_providers()[0], "CUDAExecutionProvider")
         self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+    @require_torch_gpu
+    def test_seq2seq_model_on_gpu_id(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model.to(torch.device("cuda:1"))
+        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(
+            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1
+        )
+
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model.to(1)
+        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(
+            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1
+        )
+
+        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model.to("cuda:1")
+        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(
+            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1
+        )
 
     # test string device input for to()
     @require_torch_gpu

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -34,7 +34,7 @@ from transformers import (
     set_seed,
 )
 from transformers.onnx.utils import get_preprocessor
-from transformers.testing_utils import require_torch_gpu
+from transformers.testing_utils import get_gpu_count, require_torch_gpu
 
 import onnxruntime
 import requests
@@ -253,19 +253,19 @@ class ORTModelIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
 
-    @unittest.skip("should be run on a multi-gpu machine")
+    @unittest.skipIf(get_gpu_count() <= 0, "this test requires multi-gpu")
     def test_model_on_gpu_id(self):
         model = ORTModel.from_pretrained(self.ONNX_MODEL_ID)
         model.to(torch.device("cuda:1"))
-        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
 
-        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID)
         model.to(1)
-        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
 
-        model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
+        model = ORTModel.from_pretrained(self.ONNX_MODEL_ID)
         model.to("cuda:1")
-        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
 
     @require_torch_gpu
     def test_passing_provider_options_seq2seq(self):
@@ -330,30 +330,30 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertEqual(model.decoder_with_past.session.get_providers()[0], "CUDAExecutionProvider")
         self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
 
-    @unittest.skip("should be run on a multi-gpu machine")
+    @unittest.skipIf(get_gpu_count() <= 0, "this test requires multi-gpu")
     def test_seq2seq_model_on_gpu_id(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
         model.to(torch.device("cuda:1"))
-        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
-        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
+        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
         self.assertEqual(
-            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1
+            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1"
         )
 
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
         model.to(1)
-        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
-        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
+        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
         self.assertEqual(
-            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1
+            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1"
         )
 
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
         model.to("cuda:1")
-        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
-        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1)
+        self.assertEqual(model.encoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
+        self.assertEqual(model.decoder.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1")
         self.assertEqual(
-            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], 1
+            model.decoder_with_past.session.get_provider_options()["CUDAExecutionProvider"]["device_id"], "1"
         )
 
     # test string device input for to()

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -253,7 +253,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
 
-    @require_torch_gpu
+    @unittest.skip("should be run on a multi-gpu machine")
     def test_model_on_gpu_id(self):
         model = ORTModel.from_pretrained(self.ONNX_MODEL_ID)
         model.to(torch.device("cuda:1"))
@@ -330,7 +330,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertEqual(model.decoder_with_past.session.get_providers()[0], "CUDAExecutionProvider")
         self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
 
-    @require_torch_gpu
+    @unittest.skip("should be run on a multi-gpu machine")
     def test_seq2seq_model_on_gpu_id(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
         model.to(torch.device("cuda:1"))

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -253,7 +253,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(model.model.get_provider_options()["CUDAExecutionProvider"]["do_copy_in_default_stream"], "0")
 
-    @unittest.skipIf(get_gpu_count() <= 0, "this test requires multi-gpu")
+    @unittest.skipIf(get_gpu_count() <= 1, "this test requires multi-gpu")
     def test_model_on_gpu_id(self):
         model = ORTModel.from_pretrained(self.ONNX_MODEL_ID)
         model.to(torch.device("cuda:1"))
@@ -330,7 +330,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertEqual(model.decoder_with_past.session.get_providers()[0], "CUDAExecutionProvider")
         self.assertListEqual(model.providers, ["CUDAExecutionProvider", "CPUExecutionProvider"])
 
-    @unittest.skipIf(get_gpu_count() <= 0, "this test requires multi-gpu")
+    @unittest.skipIf(get_gpu_count() <= 1, "this test requires multi-gpu")
     def test_seq2seq_model_on_gpu_id(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
         model.to(torch.device("cuda:1"))


### PR DESCRIPTION
# What does this PR do?

Support to pass a specific device id (e.g. as an int) for ORTModel, as transformers does for pipelines.

For example, `model.to(1)` will use the GPU with id 1.

Fixes #426 

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? ==> yes but disabled by default
