### PR TITLE
Fixes for ORT 1.13.1

### DIFF
--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -660,6 +660,7 @@ class OptimizationConfig:
     use_mask_index: bool = False
     no_attention_mask: bool = False
     disable_embed_layer_norm: bool = True
+    disable_shape_inference: bool = False
 
 
 class ORTConfig(BaseConfig):

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -643,7 +643,10 @@ class OptimizationConfig:
             Whether to not use attention masks. Only works for bert model type.
         disable_embed_layer_norm (`bool`, defaults to `True`):
             Whether to disable EmbedLayerNormalization fusion.
-            The default value is set to `True` since this fusion is incompatible with ONNX Runtime quantization
+            The default value is set to `True` since this fusion is incompatible with ONNX Runtime quantization.
+        disable_shape_inference (`bool`, defaults to `False`):
+            Whether to disable symbolic shape inference.
+            The default value is set to `False` but symbolic shape inference might cause issues sometimes.
     """
 
     optimization_level: int = 1

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -20,8 +20,10 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from datasets import Dataset, load_dataset
+from packaging.version import Version, parse
 
 import onnx
+from onnxruntime import __version__ as ort_version
 from onnxruntime.quantization import CalibrationDataReader, QuantFormat, QuantizationMode, QuantType
 from onnxruntime.quantization.onnx_quantizer import ONNXQuantizer
 from onnxruntime.quantization.qdq_quantizer import QDQQuantizer
@@ -317,31 +319,62 @@ class ORTQuantizer(OptimumQuantizer):
 
         onnx_model = onnx.load(self.onnx_model_path)
         quantizer_factory = QDQQuantizer if use_qdq else ONNXQuantizer
-        quantizer = quantizer_factory(
-            model=onnx_model,
-            static=quantization_config.is_static,
-            per_channel=quantization_config.per_channel,
-            mode=quantization_config.mode,
-            weight_qType=quantization_config.weights_dtype,
-            activation_qType=quantization_config.activations_dtype,
-            tensors_range=calibration_tensors_range,
-            reduce_range=quantization_config.reduce_range,
-            nodes_to_quantize=quantization_config.nodes_to_quantize,
-            nodes_to_exclude=quantization_config.nodes_to_exclude,
-            op_types_to_quantize=[
-                operator.value if isinstance(operator, ORTQuantizableOperator) else operator
-                for operator in quantization_config.operators_to_quantize
-            ],
-            extra_options={
-                "WeightSymmetric": quantization_config.weights_symmetric,
-                "ActivationSymmetric": quantization_config.activations_symmetric,
-                "EnableSubgraph": False,
-                "ForceSymmetric": quantization_config.activations_symmetric and quantization_config.weights_symmetric,
-                "AddQDQPairToWeight": quantization_config.qdq_add_pair_to_weight,
-                "DedicatedQDQPair": quantization_config.qdq_dedicated_pair,
-                "QDQOpTypePerChannelSupportToAxis": quantization_config.qdq_op_type_per_channel_support_to_axis,
-            },
-        )
+
+        if parse(ort_version) > Version("1.13.0"):
+            # The argument `input_qType` has been changed into `activation_qType` from ORT 1.13
+            quantizer = quantizer_factory(
+                model=onnx_model,
+                static=quantization_config.is_static,
+                per_channel=quantization_config.per_channel,
+                mode=quantization_config.mode,
+                weight_qType=quantization_config.weights_dtype,
+                activation_qType=quantization_config.activations_dtype,
+                tensors_range=calibration_tensors_range,
+                reduce_range=quantization_config.reduce_range,
+                nodes_to_quantize=quantization_config.nodes_to_quantize,
+                nodes_to_exclude=quantization_config.nodes_to_exclude,
+                op_types_to_quantize=[
+                    operator.value if isinstance(operator, ORTQuantizableOperator) else operator
+                    for operator in quantization_config.operators_to_quantize
+                ],
+                extra_options={
+                    "WeightSymmetric": quantization_config.weights_symmetric,
+                    "ActivationSymmetric": quantization_config.activations_symmetric,
+                    "EnableSubgraph": False,
+                    "ForceSymmetric": quantization_config.activations_symmetric
+                    and quantization_config.weights_symmetric,
+                    "AddQDQPairToWeight": quantization_config.qdq_add_pair_to_weight,
+                    "DedicatedQDQPair": quantization_config.qdq_dedicated_pair,
+                    "QDQOpTypePerChannelSupportToAxis": quantization_config.qdq_op_type_per_channel_support_to_axis,
+                },
+            )
+        else:
+            quantizer = quantizer_factory(
+                model=onnx_model,
+                static=quantization_config.is_static,
+                per_channel=quantization_config.per_channel,
+                mode=quantization_config.mode,
+                weight_qType=quantization_config.weights_dtype,
+                input_qType=quantization_config.activations_dtype,
+                tensors_range=calibration_tensors_range,
+                reduce_range=quantization_config.reduce_range,
+                nodes_to_quantize=quantization_config.nodes_to_quantize,
+                nodes_to_exclude=quantization_config.nodes_to_exclude,
+                op_types_to_quantize=[
+                    operator.value if isinstance(operator, ORTQuantizableOperator) else operator
+                    for operator in quantization_config.operators_to_quantize
+                ],
+                extra_options={
+                    "WeightSymmetric": quantization_config.weights_symmetric,
+                    "ActivationSymmetric": quantization_config.activations_symmetric,
+                    "EnableSubgraph": False,
+                    "ForceSymmetric": quantization_config.activations_symmetric
+                    and quantization_config.weights_symmetric,
+                    "AddQDQPairToWeight": quantization_config.qdq_add_pair_to_weight,
+                    "DedicatedQDQPair": quantization_config.qdq_dedicated_pair,
+                    "QDQOpTypePerChannelSupportToAxis": quantization_config.qdq_op_type_per_channel_support_to_axis,
+                },
+            )
 
         LOGGER.info("Quantizing model...")
         quantizer.quantize_model()

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -323,7 +323,7 @@ class ORTQuantizer(OptimumQuantizer):
             per_channel=quantization_config.per_channel,
             mode=quantization_config.mode,
             weight_qType=quantization_config.weights_dtype,
-            input_qType=quantization_config.activations_dtype,
+            activation_qType=quantization_config.activations_dtype,
             tensors_range=calibration_tensors_range,
             reduce_range=quantization_config.reduce_range,
             nodes_to_quantize=quantization_config.nodes_to_quantize,

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -320,7 +320,7 @@ class ORTQuantizer(OptimumQuantizer):
         onnx_model = onnx.load(self.onnx_model_path)
         quantizer_factory = QDQQuantizer if use_qdq else ONNXQuantizer
 
-        if parse(ort_version) > Version("1.13.0"):
+        if parse(ort_version) >= Version("1.13.0"):
             # The argument `input_qType` has been changed into `activation_qType` from ORT 1.13
             quantizer = quantizer_factory(
                 model=onnx_model,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes a couple of errors that appeared with ORT 1.13.1:
- `disable_shape_inference` is added to `OptimizationConfig` since it has been added to `FusionOptions` in ORT (see https://github.com/microsoft/onnxruntime/pull/12215),
- replace `input_qType` by `activation_qType` in `quantization.py` since this argument name has changed in ORT (see https://github.com/microsoft/onnxruntime/pull/12873).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

