### PR TITLE
Update ONNX Runtime training for ort 1.13.1 and transformers 4.23.1 

### DIFF
--- a/examples/onnxruntime/training/docker/Dockerfile-ort-nightly-cu116
+++ b/examples/onnxruntime/training/docker/Dockerfile-ort-nightly-cu116
@@ -1,5 +1,5 @@
 # Use nvidia/cuda image
-FROM nvidia/cuda:11.3.0-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
 CMD nvidia-smi
 
 # Ignore interactive questions during `docker build`
@@ -29,9 +29,9 @@ RUN pip install -U pip
 RUN pip install pygit2 pgzip
 
 # Install onnxruntime-training dependencies
-RUN pip install onnx==1.11.0 ninja
-RUN pip install torch==1.11.0+cu113 -f https://download.pytorch.org/whl/torch_stable.html
-RUN pip install --pre --no-deps --no-index onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu113.html && TORCH_CUDA_ARCH_LIST='7.0;8.0+PTX'
+RUN pip install onnx==1.12.0 ninja
+RUN pip install torch==1.12.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install --pre --no-deps --no-index onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu116.html && TORCH_CUDA_ARCH_LIST='7.0;8.0+PTX'
 RUN pip install torch-ort
 RUN pip install --upgrade protobuf==3.20.1
 # RUN python -m torch_ort.configure

--- a/examples/onnxruntime/training/docker/Dockerfile-ort1.13.1-cu116
+++ b/examples/onnxruntime/training/docker/Dockerfile-ort1.13.1-cu116
@@ -1,0 +1,41 @@
+# Use nvidia/cuda image
+FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
+CMD nvidia-smi
+
+# Ignore interactive questions during `docker build`
+ENV DEBIAN_FRONTEND noninteractive
+
+# Bash shell
+RUN chsh -s /bin/bash
+SHELL ["/bin/bash", "-c"]
+
+# Temporary fix until NVDIA finish the update of its docker images
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+# Install and update tools to minimize security vulnerabilities
+RUN apt-get update
+RUN apt-get install -y software-properties-common wget apt-utils patchelf git libprotobuf-dev protobuf-compiler cmake \
+    bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 mercurial subversion libopenmpi-dev && \
+    apt-get clean
+RUN unattended-upgrade
+RUN apt-get autoremove -y
+
+# Install Pythyon (3.8 as default)
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN apt-get install -y python3-pip
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN pip install -U pip
+RUN pip install pygit2 pgzip
+
+# Install onnxruntime-training dependencies
+RUN pip install onnx==1.12.0 ninja
+RUN pip install torch==1.12.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install onnxruntime-training==1.13.1+cu116 -f https://download.onnxruntime.ai/onnxruntime_stable_cu113.html
+RUN pip install torch-ort
+RUN pip install --upgrade protobuf==3.20.1
+# RUN python -m torch_ort.configure
+
+WORKDIR .
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
# What does this PR do?

* Update dockerfiles for `onnxruntime-training==1.13.1` and `ort-nightly`.
* Update `ORTTrainer` to be compatible with transformers 4.23.1
* Update training examples to be compatible with transformers 4.23.1

