### PR TITLE
Replace dataset's load_metric by evaluate load

### DIFF
--- a/examples/onnxruntime/optimization/question-answering/run_qa.py
+++ b/examples/onnxruntime/optimization/question-answering/run_qa.py
@@ -29,11 +29,12 @@ from typing import Optional
 
 import datasets
 import transformers
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import AutoTokenizer, EvalPrediction, HfArgumentParser, PreTrainedTokenizer, TrainingArguments
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from optimum.onnxruntime import ORTModelForQuestionAnswering, ORTOptimizer
 from optimum.onnxruntime.configuration import OptimizationConfig, ORTConfig
 from optimum.onnxruntime.model import ORTModel
@@ -430,7 +431,7 @@ def main():
             references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
             return EvalPrediction(predictions=formatted_predictions, label_ids=references)
 
-        metric = load_metric("squad_v2" if data_args.version_2_with_negative else "squad")
+        metric = load("squad_v2" if data_args.version_2_with_negative else "squad")
 
         def compute_metrics(p: EvalPrediction):
             return metric.compute(predictions=p.predictions, references=p.label_ids)

--- a/examples/onnxruntime/optimization/text-classification/run_glue.py
+++ b/examples/onnxruntime/optimization/text-classification/run_glue.py
@@ -29,7 +29,7 @@ from typing import Optional
 import datasets
 import numpy as np
 import transformers
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -41,6 +41,7 @@ from transformers import (
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from optimum.onnxruntime import ORTModelForSequenceClassification, ORTOptimizer
 from optimum.onnxruntime.configuration import OptimizationConfig, ORTConfig
 from optimum.onnxruntime.model import ORTModel
@@ -339,9 +340,9 @@ def main():
 
         # Get the metric function
         if data_args.task_name is not None:
-            metric = load_metric("glue", data_args.task_name)
+            metric = load("glue", data_args.task_name)
         else:
-            metric = load_metric("accuracy")
+            metric = load("accuracy")
 
         # You can define your custom compute_metrics function. It takes an `EvalPrediction` object (a namedtuple with a
         # predictions and label_ids field) and has to return a dictionary string to float.

--- a/examples/onnxruntime/optimization/token-classification/run_ner.py
+++ b/examples/onnxruntime/optimization/token-classification/run_ner.py
@@ -30,11 +30,12 @@ from typing import Optional
 import datasets
 import numpy as np
 import transformers
-from datasets import ClassLabel, load_dataset, load_metric
+from datasets import ClassLabel, load_dataset
 from transformers import AutoTokenizer, HfArgumentParser, PreTrainedTokenizer, TrainingArguments
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from optimum.onnxruntime import ORTModelForTokenClassification, ORTOptimizer
 from optimum.onnxruntime.configuration import OptimizationConfig, ORTConfig
 from optimum.onnxruntime.model import ORTModel
@@ -410,7 +411,7 @@ def main():
             return tokenized_inputs
 
         # Metrics
-        metric = load_metric("seqeval")
+        metric = load("seqeval")
 
         def compute_metrics(p):
             predictions, labels = p

--- a/examples/onnxruntime/quantization/image-classification/run_image_classification.py
+++ b/examples/onnxruntime/quantization/image-classification/run_image_classification.py
@@ -29,12 +29,13 @@ import datasets
 import numpy as np
 import torch
 import transformers
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from torchvision.transforms import CenterCrop, Compose, Normalize, Resize, ToTensor
 from transformers import AutoFeatureExtractor, EvalPrediction, HfArgumentParser, TrainingArguments
 from transformers.onnx import FeaturesManager
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 from optimum.onnxruntime import ORTQuantizer
 from optimum.onnxruntime.configuration import AutoCalibrationConfig, QuantizationConfig
@@ -265,7 +266,7 @@ def main():
         ]
         return example_batch
 
-    metric = load_metric("accuracy")
+    metric = load("accuracy")
 
     # You can define your custom compute_metrics function. It takes an `EvalPrediction` object (a namedtuple with a
     # predictions and label_ids field) and has to return a dictionary string to float.

--- a/examples/onnxruntime/quantization/question-answering/run_qa.py
+++ b/examples/onnxruntime/quantization/question-answering/run_qa.py
@@ -29,12 +29,13 @@ from typing import Optional
 
 import datasets
 import transformers
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import AutoTokenizer, EvalPrediction, HfArgumentParser, PreTrainedTokenizer, TrainingArguments
 from transformers.onnx import FeaturesManager
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 from optimum.onnxruntime import ORTQuantizer
 from optimum.onnxruntime.configuration import AutoCalibrationConfig, QuantizationConfig
@@ -500,7 +501,7 @@ def main():
         references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
         return EvalPrediction(predictions=formatted_predictions, label_ids=references)
 
-    metric = load_metric("squad_v2" if data_args.version_2_with_negative else "squad")
+    metric = load("squad_v2" if data_args.version_2_with_negative else "squad")
 
     def compute_metrics(p: EvalPrediction):
         return metric.compute(predictions=p.predictions, references=p.label_ids)

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -29,7 +29,7 @@ from typing import Optional
 import datasets
 import numpy as np
 import transformers
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -42,6 +42,7 @@ from transformers.onnx import FeaturesManager
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 from optimum.onnxruntime import ORTQuantizer
 from optimum.onnxruntime.configuration import AutoCalibrationConfig, QuantizationConfig
@@ -355,9 +356,9 @@ def main():
 
     # Get the metric function
     if data_args.task_name is not None:
-        metric = load_metric("glue", data_args.task_name)
+        metric = load("glue", data_args.task_name)
     else:
-        metric = load_metric("accuracy")
+        metric = load("accuracy")
 
     # You can define your custom compute_metrics function. It takes an `EvalPrediction` object (a namedtuple with a
     # predictions and label_ids field) and has to return a dictionary string to float.
@@ -454,7 +455,7 @@ def main():
         # Exclude the nodes constituting GELU
         quantization_preprocessor.register_pass(ExcludeGeLUNodes())
         # Exclude the residual connection Add nodes
-        quantization_preprocessor.register_pass(ExcludeNodeAfter("Add", "Add"))
+        # quantization_preprocessor.register_pass(ExcludeNodeAfter("Add", "Add"))
         # Exclude the Add nodes following the Gather operator
         quantization_preprocessor.register_pass(ExcludeNodeAfter("Gather", "Add"))
         # Exclude the Add nodes followed by the Softmax operator

--- a/examples/onnxruntime/quantization/text-classification/run_glue.py
+++ b/examples/onnxruntime/quantization/text-classification/run_glue.py
@@ -455,7 +455,7 @@ def main():
         # Exclude the nodes constituting GELU
         quantization_preprocessor.register_pass(ExcludeGeLUNodes())
         # Exclude the residual connection Add nodes
-        # quantization_preprocessor.register_pass(ExcludeNodeAfter("Add", "Add"))
+        quantization_preprocessor.register_pass(ExcludeNodeAfter("Add", "Add"))
         # Exclude the Add nodes following the Gather operator
         quantization_preprocessor.register_pass(ExcludeNodeAfter("Gather", "Add"))
         # Exclude the Add nodes followed by the Softmax operator

--- a/examples/onnxruntime/quantization/token-classification/run_ner.py
+++ b/examples/onnxruntime/quantization/token-classification/run_ner.py
@@ -31,12 +31,13 @@ from typing import Optional
 import datasets
 import numpy as np
 import transformers
-from datasets import ClassLabel, load_dataset, load_metric
+from datasets import ClassLabel, load_dataset
 from transformers import AutoTokenizer, HfArgumentParser, PretrainedConfig, PreTrainedTokenizer, TrainingArguments
 from transformers.onnx import FeaturesManager
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
+from evaluate import load
 from onnxruntime.quantization import QuantFormat, QuantizationMode, QuantType
 from optimum.onnxruntime import ORTQuantizer
 from optimum.onnxruntime.configuration import AutoCalibrationConfig, QuantizationConfig
@@ -413,7 +414,7 @@ def main():
         return tokenized_inputs
 
     # Metrics
-    metric = load_metric("seqeval")
+    metric = load("seqeval")
 
     def compute_metrics(p):
         predictions, labels = p

--- a/tests/onnxruntime/nightly_test_trainer.py
+++ b/tests/onnxruntime/nightly_test_trainer.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock, patch
 
 import nltk
 import numpy as np
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AutoModelForSeq2SeqLM,
     AutoModelForSequenceClassification,
@@ -55,6 +55,8 @@ from transformers.trainer_utils import (
 )
 from transformers.training_args import OptimizerNames
 from transformers.utils import is_apex_available, is_bitsandbytes_available
+
+from evaluate import load
 
 
 if is_torch_available():
@@ -192,7 +194,7 @@ def load_and_prepare_glue(model_name, data_metric_config, max_seq_length, paddin
 
     # Prepare dataset
     dataset = load_dataset(*data_metric_config["dataset"])
-    metric = load_metric(*data_metric_config["metric"])
+    metric = load(*data_metric_config["metric"])
 
     max_seq_length = min(max_seq_length, tokenizer.model_max_length)
 
@@ -234,7 +236,7 @@ def load_and_prepare_ner(model_name, data_metric_config, max_seq_length, padding
 
     # Load dataset and metric
     dataset = load_dataset(*data_metric_config["dataset"])
-    metric = load_metric(*data_metric_config["metric"])
+    metric = load(*data_metric_config["metric"])
     label_all_tokens = True
     task = "ner"
     label_list = dataset["train"].features[f"{task}_tags"].feature.names
@@ -326,7 +328,7 @@ def load_and_prepare_xsum(model_name, data_metric_config, padding="max_length", 
 
     # Load dataset and metric
     dataset = load_dataset(*data_metric_config["dataset"])
-    metric = load_metric(*data_metric_config["metric"])
+    metric = load(*data_metric_config["metric"])
 
     if model_name in ["t5-small", "t5-base", "t5-large", "t5-3b", "t5-11b"]:
         prefix = "summarize: "


### PR DESCRIPTION
# What does this PR do?

`datasets.load_metric` is deprecated, replace it everywhere with `evaluate.load`.

Fixes #350 
