### PR TITLE
Use PretrainedConfig child classes for ORTModel config attribute

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -208,12 +208,11 @@ class OptimizedModel(ABC):
             model_id, revision = model_id.split("@")
 
         if os.path.isdir(model_id) and CONFIG_NAME in os.listdir(model_id):
-            config_file = os.path.join(model_id, CONFIG_NAME)
+            config = AutoConfig.from_pretrained(os.path.join(model_id, CONFIG_NAME))
         else:
             try:
-                config_file = hf_hub_download(
-                    repo_id=model_id,
-                    filename=CONFIG_NAME,
+                config = AutoConfig.from_pretrained(
+                    pretrained_model_name_or_path=model_id,
                     revision=revision,
                     cache_dir=cache_dir,
                     force_download=force_download,
@@ -221,11 +220,9 @@ class OptimizedModel(ABC):
                 )
             except requests.exceptions.RequestException:
                 logger.warning("config.json NOT FOUND in HuggingFace Hub")
-                config_file = None
+                config = None
 
-        if config_file is not None:
-            with open(config_file, "r", encoding="utf-8") as f:
-                config = json.load(f)
+        if config is not None:
             model_kwargs.update({"config": config})
 
         if from_transformers:

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -107,7 +107,7 @@ class ORTModel(OptimizedModel):
     base_model_prefix = "onnx_model"
     auto_model_class = AutoModel
 
-    def __init__(self, model: ort.InferenceSession = None, config=None, **kwargs):
+    def __init__(self, model: ort.InferenceSession = None, config: PretrainedConfig = None, **kwargs):
         self.model = model
         self.config = config
         self.model_save_dir = kwargs.get("model_save_dir", None)
@@ -298,11 +298,10 @@ class ORTModel(OptimizedModel):
                 kwargs will be passed to the model during initialization
         """
         local_files_only = kwargs.pop("local_files_only", False)
-        config_dict = kwargs.pop("config", {})
+        config = kwargs.pop("config", {})
         model_file_name = file_name if file_name is not None else ONNX_WEIGHTS_NAME
         # load model from local directory
         if os.path.isdir(model_id):
-            config = PretrainedConfig.from_dict(config_dict)
             model = ORTModel.load_model(os.path.join(model_id, model_file_name), **kwargs)
             kwargs["model_save_dir"] = Path(model_id)
             kwargs["latest_model_name"] = model_file_name
@@ -321,7 +320,6 @@ class ORTModel(OptimizedModel):
             kwargs["model_save_dir"] = Path(model_cache_path).parent
             kwargs["latest_model_name"] = Path(model_cache_path).name
             model = ORTModel.load_model(model_cache_path, **kwargs)
-            config = PretrainedConfig.from_dict(config_dict)
 
         return cls(model=model, config=config, **kwargs)
 
@@ -386,7 +384,7 @@ class ORTModel(OptimizedModel):
             opset=onnx_config.default_onnx_opset,
             output=save_dir.joinpath(ONNX_WEIGHTS_NAME),
         )
-        kwargs["config"] = model.config.__dict__
+        kwargs["config"] = model.config
         # 3. load normal model
         return cls._from_pretrained(save_dir.as_posix(), **kwargs)
 

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -20,7 +20,7 @@ from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Set, Tuple, 
 
 import torch
 import transformers
-from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer, PretrainedConfig
+from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, default_cache_path
 from transformers.generation_utils import GenerationMixin
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
@@ -342,8 +342,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         """
         use_cache = kwargs.pop("use_cache", True)
         local_files_only = kwargs.pop("local_files_only", False)
-        config_dict = kwargs.pop("config", {})
-        config = PretrainedConfig.from_dict(config_dict)
+        config = kwargs.pop("config", {})
         encoder_file_name = encoder_file_name or ONNX_ENCODER_NAME
         decoder_file_name = decoder_file_name or ONNX_DECODER_NAME
         decoder_with_past_file_name = decoder_with_past_file_name or ONNX_DECODER_WITH_PAST_NAME
@@ -477,7 +476,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 output=save_dir.joinpath(ONNX_DECODER_WITH_PAST_NAME),
             )
 
-        kwargs["config"] = model.config.__dict__
+        kwargs["config"] = model.config
         return cls._from_pretrained(save_dir, **kwargs)
 
     def to(self, device: Union[torch.device, str, int]):


### PR DESCRIPTION
# What does this PR do?

Currently, ORTModel `config` attribute was loading the config key/items from a vanilla dict using `PretrainedConfig.from_dict()`. With this PR, we rather load the config with `AutoConfig.from_pretrained()` that allows to instanciate child classes from `PretrainedConfig`, e.g. `DistilBertConfig`, `XLMRobertaConfig`, etc.

The current way may have been intended, is it the case @philschmid ? Do you think this change is OK? With the current code, the key `model_type` was not saved in the `config.json` when using `save_pretrained`.

Fixes #402