### PR TITLE
Add Model loading from subfolders similar to transformers

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -40,6 +40,9 @@ FROM_PRETRAINED_START_DOCSTRING = r"""
             standard cache should not be used.
         local_files_only(`bool`, *optional*, defaults to `False`):
             Whether or not to only look at local files (i.e., do not try to download the model).
+        subfolder (`str`, *optional*, defaults to `""`):
+            In case the relevant files are located inside a subfolder of the model repo either locally or on huggingface.co, you can
+            specify the folder name here.
 """
 
 
@@ -183,6 +186,7 @@ class OptimizedModel(ABC):
         revision: Optional[Union[str, None]] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
+        subfolder: Optional[str] = "",
         **kwargs,
     ):
         """Overwrite this method in subclass to define how to load your model from pretrained"""
@@ -197,6 +201,7 @@ class OptimizedModel(ABC):
         force_download: bool = False,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
+        subfolder: Optional[str] = "",
         **model_kwargs,
     ):
         """
@@ -207,7 +212,9 @@ class OptimizedModel(ABC):
         if len(str(model_id).split("@")) == 2:
             model_id, revision = model_id.split("@")
 
-        if os.path.isdir(model_id) and CONFIG_NAME in os.listdir(model_id):
+        if os.path.isdir(os.path.join(model_id, subfolder)) and CONFIG_NAME in os.listdir(
+            os.path.join(model_id, subfolder)
+        ):
             config = AutoConfig.from_pretrained(os.path.join(model_id, CONFIG_NAME))
         else:
             try:
@@ -217,6 +224,7 @@ class OptimizedModel(ABC):
                     cache_dir=cache_dir,
                     force_download=force_download,
                     use_auth_token=use_auth_token,
+                    subfolder=subfolder,
                 )
             except requests.exceptions.RequestException:
                 logger.warning("config.json NOT FOUND in HuggingFace Hub")
@@ -232,6 +240,7 @@ class OptimizedModel(ABC):
                 cache_dir=cache_dir,
                 force_download=force_download,
                 use_auth_token=use_auth_token,
+                subfolder=subfolder,
                 **model_kwargs,
             )
         else:
@@ -241,6 +250,7 @@ class OptimizedModel(ABC):
                 cache_dir=cache_dir,
                 force_download=force_download,
                 use_auth_token=use_auth_token,
+                subfolder=subfolder,
                 **model_kwargs,
             )
 
@@ -252,6 +262,7 @@ class OptimizedModel(ABC):
         revision: Optional[Union[str, None]] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
+        subfolder: Optional[str] = "",
         **kwargs,
     ):
         """Overwrite this method in subclass to define how to load your model from vanilla transformers model"""

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -228,13 +228,17 @@ class OptimizedModel(ABC):
                 )
             except OSError:
                 # if config not found in subfolder, search for it at the top level
-                config = AutoConfig.from_pretrained(
-                    pretrained_model_name_or_path=model_id,
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    use_auth_token=use_auth_token,
-                )
+                if subfolder != "":
+                    config = AutoConfig.from_pretrained(
+                        pretrained_model_name_or_path=model_id,
+                        revision=revision,
+                        cache_dir=cache_dir,
+                        force_download=force_download,
+                        use_auth_token=use_auth_token,
+                    )
+                    logger.info(
+                        f"config.json not found in the specified subfolder {subfolder}. Using the top level config.json."
+                    )
             except requests.exceptions.RequestException:
                 logger.warning("config.json NOT FOUND in HuggingFace Hub")
                 config = None

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -226,6 +226,15 @@ class OptimizedModel(ABC):
                     use_auth_token=use_auth_token,
                     subfolder=subfolder,
                 )
+            except OSError:
+                # if config not found in subfolder, search for it at the top level
+                config = AutoConfig.from_pretrained(
+                    pretrained_model_name_or_path=model_id,
+                    revision=revision,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    use_auth_token=use_auth_token,
+                )
             except requests.exceptions.RequestException:
                 logger.warning("config.json NOT FOUND in HuggingFace Hub")
                 config = None

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -365,6 +365,8 @@ class ORTModel(OptimizedModel):
         save_dir.mkdir(parents=True, exist_ok=True)
         kwargs["model_save_dir"] = save_dir
 
+        config = kwargs.get("config", {})
+
         # reads pipeline task from ORTModelForXXX class if available else tries to extract from hub
         if cls.export_feature is not None:
             task = cls.export_feature
@@ -380,7 +382,7 @@ class ORTModel(OptimizedModel):
 
         framework = FeaturesManager.determine_framework(os.path.join(model_id, subfolder))
         model_class = FeaturesManager.get_model_class_for_feature(task, framework)
-        model = model_class.from_pretrained(model_id, subfolder=subfolder, cache_dir=cache_dir)
+        model = model_class.from_pretrained(model_id, subfolder=subfolder, config=config, cache_dir=cache_dir)
 
         _, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=task)
         onnx_config = model_onnx_config(model.config)
@@ -393,7 +395,7 @@ class ORTModel(OptimizedModel):
             opset=onnx_config.default_onnx_opset,
             output=save_dir.joinpath(ONNX_WEIGHTS_NAME),
         )
-        kwargs["config"] = model.config
+
         # 3. load normal model
         return cls._from_pretrained(save_dir.as_posix(), **kwargs)
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -376,7 +376,6 @@ class ORTModel(OptimizedModel):
                 task = "default"
         # 2. convert to temp dir
         # FIXME: transformers.onnx conversion doesn't support private models
-        # FIXME: load preprocessor from subfolder
         preprocessor = get_preprocessor(model_id)
 
         framework = FeaturesManager.determine_framework(os.path.join(model_id, subfolder))

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -438,13 +438,14 @@ class ORTModelForConditionalGeneration(ORTModel):
         save_dir = Path(save_dir).joinpath(model_id, subfolder)
         save_dir.mkdir(parents=True, exist_ok=True)
         kwargs["model_save_dir"] = save_dir
+        config = kwargs.get("config", {})
         use_cache = kwargs.get("use_cache", True)
 
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         framework = FeaturesManager.determine_framework(os.path.join(model_id, subfolder))
         model_class = FeaturesManager.get_model_class_for_feature(cls.export_feature, framework)
-        model = model_class.from_pretrained(model_id, subfolder=subfolder, cache_dir=cache_dir)
+        model = model_class.from_pretrained(model_id, subfolder=subfolder, config=config, cache_dir=cache_dir)
 
         _, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=cls.export_feature)
         onnx_config = model_onnx_config(model.config)

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -304,6 +304,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         encoder_file_name: Optional[str] = None,
         decoder_file_name: Optional[str] = None,
         decoder_with_past_file_name: Optional[str] = None,
+        subfolder: Optional[str] = "",
         **kwargs,
     ):
         """
@@ -348,15 +349,17 @@ class ORTModelForConditionalGeneration(ORTModel):
         decoder_with_past_file_name = decoder_with_past_file_name or ONNX_DECODER_WITH_PAST_NAME
 
         # Load model from a local directory
-        if os.path.isdir(model_id):
-            decoder_with_past_path = os.path.join(model_id, decoder_with_past_file_name) if use_cache else None
+        if os.path.isdir(os.path.join(model_id, subfolder)):
+            decoder_with_past_path = (
+                os.path.join(model_id, subfolder, decoder_with_past_file_name) if use_cache else None
+            )
             model = cls.load_model(
-                encoder_path=os.path.join(model_id, encoder_file_name),
-                decoder_path=os.path.join(model_id, decoder_file_name),
+                encoder_path=os.path.join(model_id, subfolder, encoder_file_name),
+                decoder_path=os.path.join(model_id, subfolder, decoder_file_name),
                 decoder_with_past_path=decoder_with_past_path,
                 **kwargs,
             )
-            kwargs["model_save_dir"] = Path(model_id)
+            kwargs["model_save_dir"] = Path(model_id).joinpath(subfolder)
             kwargs["last_encoder_name"] = encoder_file_name
             kwargs["last_decoder_name"] = decoder_file_name
             kwargs["last_decoder_with_past_name"] = decoder_with_past_file_name
@@ -371,6 +374,7 @@ class ORTModelForConditionalGeneration(ORTModel):
             for file_name, default_file_name in zip(model_file_names, default_file_names):
                 model_cache_path = hf_hub_download(
                     repo_id=model_id,
+                    subfolder=subfolder,
                     filename=file_name,
                     use_auth_token=use_auth_token,
                     revision=revision,
@@ -397,6 +401,7 @@ class ORTModelForConditionalGeneration(ORTModel):
     def _from_transformers(
         cls,
         model_id: str,
+        subfolder: Optional[str] = "",
         save_dir: Union[str, Path] = default_cache_path,
         use_auth_token: Optional[Union[bool, str, None]] = None,
         revision: Optional[Union[str, None]] = None,
@@ -430,12 +435,17 @@ class ORTModelForConditionalGeneration(ORTModel):
                 kwargs will be passed to the model during initialization.
         """
         # Create local save dir in cache dir
-        save_dir = Path(save_dir).joinpath(model_id)
+        save_dir = Path(save_dir).joinpath(model_id, subfolder)
         save_dir.mkdir(parents=True, exist_ok=True)
         kwargs["model_save_dir"] = save_dir
         use_cache = kwargs.get("use_cache", True)
+
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = FeaturesManager.get_model_from_feature(cls.export_feature, model_id)
+
+        framework = FeaturesManager.determine_framework(os.path.join(model_id, subfolder))
+        model_class = FeaturesManager.get_model_class_for_feature(cls.export_feature, framework)
+        model = model_class.from_pretrained(model_id, subfolder=subfolder, cache_dir=cache_dir)
+
         _, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model, feature=cls.export_feature)
         onnx_config = model_onnx_config(model.config)
         onnx_opset = onnx_config.default_onnx_opset

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -107,6 +107,17 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertIsInstance(model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
         self.assertIsInstance(model.config, PretrainedConfig)
 
+    def test_load_model_from_hub_subfolder(self):
+        model = ORTModel.from_pretrained(
+            "fxmarty/tiny-bert-sst2-distilled-subfolder", subfolder="my_subfolder", from_transformers=True
+        )
+        self.assertIsInstance(model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
+        self.assertIsInstance(model.config, PretrainedConfig)
+
+        model = ORTModel.from_pretrained("fxmarty/tiny-bert-sst2-distilled-onnx-subfolder", subfolder="my_subfolder")
+        self.assertIsInstance(model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
+        self.assertIsInstance(model.config, PretrainedConfig)
+
     def test_load_model_from_cache(self):
         _ = ORTModel.from_pretrained(self.TINY_ONNX_MODEL_ID)  # caching
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -108,7 +108,8 @@ class ORTModelIntegrationTest(unittest.TestCase):
         self.assertIsInstance(model.config, PretrainedConfig)
 
     def test_load_model_from_hub_subfolder(self):
-        model = ORTModel.from_pretrained(
+        # does not pass with ORTModel as it does not have export_feature attribute
+        model = ORTModelForSequenceClassification.from_pretrained(
             "fxmarty/tiny-bert-sst2-distilled-subfolder", subfolder="my_subfolder", from_transformers=True
         )
         self.assertIsInstance(model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
@@ -116,6 +117,21 @@ class ORTModelIntegrationTest(unittest.TestCase):
 
         model = ORTModel.from_pretrained("fxmarty/tiny-bert-sst2-distilled-onnx-subfolder", subfolder="my_subfolder")
         self.assertIsInstance(model.model, onnxruntime.capi.onnxruntime_inference_collection.InferenceSession)
+        self.assertIsInstance(model.config, PretrainedConfig)
+
+    def test_load_seq2seq_model_from_hub_subfolder(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained(
+            "fxmarty/tiny-mbart-subfolder", subfolder="my_folder", from_transformers=True
+        )
+        self.assertIsInstance(model.encoder, ORTEncoder)
+        self.assertIsInstance(model.decoder, ORTDecoder)
+        self.assertIsInstance(model.decoder_with_past, ORTDecoder)
+        self.assertIsInstance(model.config, PretrainedConfig)
+
+        model = ORTModelForSeq2SeqLM.from_pretrained("fxmarty/tiny-mbart-onnx-subfolder", subfolder="my_folder")
+        self.assertIsInstance(model.encoder, ORTEncoder)
+        self.assertIsInstance(model.decoder, ORTDecoder)
+        self.assertIsInstance(model.decoder_with_past, ORTDecoder)
         self.assertIsInstance(model.config, PretrainedConfig)
 
     def test_load_model_from_cache(self):


### PR DESCRIPTION
# What does this PR do?

Allow to pass the argument `subfolder` to `ORTModel.from_pretrained()` in a similar fashion to transformers `PreTrainedModel`. It allows to host several models (e.g. optimized) in the same model repository.

The preprocessor is expected to be loaded from the parent directory.

Fixes #308

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

