### PR TITLE
Add Pegasus to ORTConfigManager

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -72,6 +72,7 @@ class ORTConfigManager:
         "gpt_neo": ("num_heads", "hidden_size", "gpt2"),
         "mt5": ("num_heads", "d_model", "bart"),
         "marian": ("encoder_attention_heads", "d_model", "bart"),
+        "pegasus": ("encoder_attention_heads", "d_model", "bart"),
         "roberta": ("num_attention_heads", "hidden_size", "bert"),
         "xlm-roberta": ("num_attention_heads", "hidden_size", "bert"),
     }

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -78,6 +78,8 @@ class ORTOptimizerTest(unittest.TestCase):
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-marian", False),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-marian", True),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-onnx-mt5", False),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-pegasus", False),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-pegasus", True),
     )
 
     @parameterized.expand(SUPPORTED_SEQ2SEQ_ARCHITECTURES_WITH_MODEL_ID)


### PR DESCRIPTION
Add `Pegasus` to ORTConfigManager.

It follows this Pegasus implementation in the `transformers` library https://github.com/huggingface/transformers/pull/18973

The merge would be possible only when a new release of `transformers` include the `Pegasus ONNXConfig`.

@JingyaHuang @regisss 