### PR TITLE
Change import structure for ORTModel

### DIFF
--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -26,8 +26,8 @@ _import_structure = {
         "AutoOptimizationConfig",
         "ORTConfig",
     ],
-    "model": ["ORTModel"],
     "modeling_ort": [
+        "ORTModel",
         "ORTModelForCausalLM",
         "ORTModelForCustomTasks",
         "ORTModelForFeatureExtraction",
@@ -57,8 +57,8 @@ _import_structure = {
 # Direct imports for type-checking
 if TYPE_CHECKING:
     from .configuration import ORTConfig
-    from .model import ORTModel
     from .modeling_ort import (
+        ORTModel,
         ORTModelForCausalLM,
         ORTModelForCustomTasks,
         ORTModelForFeatureExtraction,


### PR DESCRIPTION
With this PR, `from optimum.onnxruntime import ORTModel` imports from `modeling_ort.py`.

All examples use `from optimum.onnxruntime.model import ORTModel` so no need to modify them, and `ORTModel` was not used in the doc.

This is potentially breaking change.

