### PR TITLE
ORTOptimizer refactor

### DIFF
--- a/docs/source/onnxruntime/package_reference/configuration.mdx
+++ b/docs/source/onnxruntime/package_reference/configuration.mdx
@@ -12,15 +12,23 @@ specific language governing permissions and limitations under the License.
 
 # Configuration
 
+The configuration classes are the way to specify how a task should be done. There are two tasks supported with the ONNX Runtime package:
+
+1. Optimization: Performed by the [`~onnxruntime.ORTOptimizer`], this task can be tweaked using an [`~onnxruntime.configuration.OptimizationConfig`].
+
+2. Quantization: Performed by the [`~onnxruntime.ORTQuantizer`], quantization can be set using a [`~onnxruntime.configuration.QuantizationConfig`]. A calibration step is required in some cases (post training static quantization), which can be specified using a [`~onnxruntime.configuration.CalibrationConfig`].
+
 ## OptimizationConfig
 
 [[autodoc]] onnxruntime.configuration.OptimizationConfig
+
+[[autodoc]] onnxruntime.configuration.AutoOptimizationConfig
 
 ## QuantizationConfig
 
 [[autodoc]] onnxruntime.configuration.QuantizationConfig
 
-## CalibrationConfig
+### CalibrationConfig
 
 [[autodoc]] onnxruntime.configuration.CalibrationConfig
 

--- a/docs/source/onnxruntime/usage_guides/optimization.mdx
+++ b/docs/source/onnxruntime/usage_guides/optimization.mdx
@@ -108,3 +108,27 @@ Below you will find an easy end-to-end example on how to optimize a Seq2Seq mode
 >>> outputs = optimized_model.generate(**tokens)
 ```
 
+
+## Optimization Configuration
+
+# TODO: edit this before merging, once the names have been chosen.
+
+In the optimization configuration, there are 4 possible optimization levels:
+- `general_optimization_level=0` to disable all optimizations,
+- `general_optimization_level=1` to enable basic optimizations such as constant folding or redundant node eliminations,
+- `general_optimization_level=2` to enable extended graph optimizations such as node fusions,
+- `general_optimization_level=99` to enable data layout optimizations.
+
+Choosing a level enables the optimizations of that level, as well as the optimizations of all preceding levels.
+More information [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).
+
+`fuse_operators=True` means that graph fusion is performed in addition to ONNX Runtime optimizations described above.
+Here is the list of all the operator fusions you can enable:
+- Gelu fusion with `disable_gelu_fusion=False`,
+- Layer Normalization fusion with `disable_layer_norm_fusion=False`,
+- Attention fusion with `disable_attention_fusion=False`,
+- SkipLayerNormalization fusion with `disable_skip_layer_norm_fusion=False`,
+- Add Bias and SkipLayerNormalization fusion with `disable_bias_skip_layer_norm_fusion=False`,
+- Add Bias and Gelu / FastGelu fusion with `disable_bias_gelu_fusion=False`.
+
+All other optimization configuration options are detailed in [`~onnxruntime.configuration.OptimizationConfig`].

--- a/docs/source/onnxruntime/usage_guides/optimization.mdx
+++ b/docs/source/onnxruntime/usage_guides/optimization.mdx
@@ -114,10 +114,10 @@ Below you will find an easy end-to-end example on how to optimize a Seq2Seq mode
 # TODO: edit this before merging, once the names have been chosen.
 
 In the optimization configuration, there are 4 possible optimization levels:
-- `general_optimization_level=0` to disable all optimizations,
-- `general_optimization_level=1` to enable basic optimizations such as constant folding or redundant node eliminations,
-- `general_optimization_level=2` to enable extended graph optimizations such as node fusions,
-- `general_optimization_level=99` to enable data layout optimizations.
+- `optimization_level=0` to disable all optimizations,
+- `optimization_level=1` to enable basic optimizations such as constant folding or redundant node eliminations,
+- `optimization_level=2` to enable extended graph optimizations such as node fusions,
+- `optimization_level=99` to enable data layout optimizations.
 
 Choosing a level enables the optimizations of that level, as well as the optimizations of all preceding levels.
 More information [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).

--- a/docs/source/onnxruntime/usage_guides/optimization.mdx
+++ b/docs/source/onnxruntime/usage_guides/optimization.mdx
@@ -64,9 +64,10 @@ Here is a list of the possible optimizations you can enable:
 - Gelu approximation with `enable_gelu_approximation=True`.
 
 While [`~onnxruntime.configuration.OptimizationConfig`] gives you full control on how to do optimization, it can be hard to know what to enable / disable. Instead, you can use [`~onnxruntime.configuration.AutoOptimizationConfig`] which provides 3 common optimizations levels:
-- O1: basic general optimizations
-- O2: basic and extended general optimizations, `transformers`-specific fusions, and Gelu approximation
-- O3: same as O2, but adds mixed precision.
+- O1: basic general optimizations.
+- O2: basic and extended general optimizations, `transformers`-specific fusions.
+- O3: same as O2 with Gelu approximation.
+- O4: same as O3 with mixed precision.
 
 Example: Loading a O2 [`~onnxruntime.configuration.OptimizationConfig`]
 

--- a/docs/source/onnxruntime/usage_guides/optimization.mdx
+++ b/docs/source/onnxruntime/usage_guides/optimization.mdx
@@ -17,7 +17,7 @@ specific language governing permissions and limitations under the License.
 
 ## Creating an `ORTOptimizer`
 
-The `ORTOptimizer` class is used to optimize your ONNX model. The class can be initialized using the `from_pretrained()` method, which supports different checkpoint formats.
+The [`~onnxruntime.ORTOptimizer`] class is used to optimize your ONNX model. The class can be initialized using the `from_pretrained()` method, which supports different checkpoint formats.
 
 1. Using an already initialized `ORTModelForXXX` class.
 
@@ -40,14 +40,55 @@ The `ORTOptimizer` class is used to optimize your ONNX model. The class can be i
 >>> optimizer = ORTOptimizer.from_pretrained("path/to/model")
 ```
 
+## Optimization Configuration
+
+The [`~onnxruntime.configuration.OptimizationConfig`] class allows to specify how the optimization should be performed by the [`~onnxruntime.ORTOptimizer`].
+
+In the optimization configuration, there are 4 possible optimization levels:
+- `optimization_level=0`: to disable all optimizations
+- `optimization_level=1`: to enable basic optimizations such as constant folding or redundant node eliminations
+- `optimization_level=2`: to enable extended graph optimizations such as node fusions
+- `optimization_level=99`: to enable data layout optimizations
+
+Choosing a level enables the optimizations of that level, as well as the optimizations of all preceding levels.
+More information [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).
+
+`enable_transformers_specific_optimizations=True` means that `transformers`-specific graph fusion and approximation are performed in addition to the ONNX Runtime optimizations described above.
+Here is a list of the possible optimizations you can enable:
+- Gelu fusion with `disable_gelu_fusion=False`,
+- Layer Normalization fusion with `disable_layer_norm_fusion=False`,
+- Attention fusion with `disable_attention_fusion=False`,
+- SkipLayerNormalization fusion with `disable_skip_layer_norm_fusion=False`,
+- Add Bias and SkipLayerNormalization fusion with `disable_bias_skip_layer_norm_fusion=False`,
+- Add Bias and Gelu / FastGelu fusion with `disable_bias_gelu_fusion=False`,
+- Gelu approximation with `enable_gelu_approximation=True`.
+
+While [`~onnxruntime.configuration.OptimizationConfig`] gives you full control on how to do optimization, it can be hard to know what to enable / disable. Instead, you can use [`~onnxruntime.configuration.AutoOptimizationConfig`] which provides 3 common optimizations levels:
+- O1: basic general optimizations
+- O2: basic and extended general optimizations, `transformers`-specific fusions, and Gelu approximation
+- O3: same as O2, but adds mixed precision.
+
+Example: Loading a O2 [`~onnxruntime.configuration.OptimizationConfig`]
+
+```python
+>>> from optimum.onnxruntime import AutoOptimizationConfig
+>>> optimization_config = AutoOptimizationConfig.O2()
+```
+
+You can also specify custom argument that were not defined in the O2 configuration, for instance:
+
+```python
+>>> from optimum.onnxruntime import AutoOptimizationConfig
+>>> optimization_config = AutoOptimizationConfig.O2(disable_embed_layer_norm_fusion=False)
+```
+
 
 ## Optimization examples
 
 Below you will find an easy end-to-end example on how to optimize [distilbert-base-uncased-finetuned-sst-2-english](https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english).
 
 ```python
->>> from optimum.onnxruntime import ORTOptimizer, ORTModelForSequenceClassification
->>> from optimum.onnxruntime.configuration import OptimizationConfig
+>>> from optimum.onnxruntime import ORTOptimizer, ORTModelForSequenceClassification, OptimizationConfig
 
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 >>> save_dir = "/tmp/outputs"
@@ -61,7 +102,7 @@ Below you will find an easy end-to-end example on how to optimize [distilbert-ba
 # Define the optimization strategy by creating the appropriate configuration
 >>> optimization_config = OptimizationConfig(
     optimization_level=2,
-    optimize_with_onnxruntime_only=False,
+    enable_transformers_specific_optimizations=True,
     optimize_for_gpu=False,
 )
 
@@ -73,8 +114,7 @@ Below you will find an easy end-to-end example on how to optimize [distilbert-ba
 Below you will find an easy end-to-end example on how to optimize a Seq2Seq model [sshleifer/distilbart-cnn-12-6"](https://huggingface.co/sshleifer/distilbart-cnn-12-6).
 
 ```python
->>> from optimum.onnxruntime import ORTOptimizer, ORTModelForSeq2SeqLM
->>> from optimum.onnxruntime.configuration import OptimizationConfig
+>>> from optimum.onnxruntime import ORTOptimizer, ORTModelForSeq2SeqLM, OptimizationConfig
 >>> from transformers import AutoTokenizer
 
 >>> model_id = "sshleifer/distilbart-cnn-12-6"
@@ -89,7 +129,7 @@ Below you will find an easy end-to-end example on how to optimize a Seq2Seq mode
 # Define the optimization strategy by creating the appropriate configuration
 >>> optimization_config = OptimizationConfig(
     optimization_level=2,
-    optimize_with_onnxruntime_only=False,
+    enable_transformers_specific_optimizations=True,
     optimize_for_gpu=False,
 )
 
@@ -107,28 +147,3 @@ Below you will find an easy end-to-end example on how to optimize a Seq2Seq mode
 >>> tokens = tokenizer("This is a sample input", return_tensors="pt")
 >>> outputs = optimized_model.generate(**tokens)
 ```
-
-
-## Optimization Configuration
-
-# TODO: edit this before merging, once the names have been chosen.
-
-In the optimization configuration, there are 4 possible optimization levels:
-- `optimization_level=0` to disable all optimizations,
-- `optimization_level=1` to enable basic optimizations such as constant folding or redundant node eliminations,
-- `optimization_level=2` to enable extended graph optimizations such as node fusions,
-- `optimization_level=99` to enable data layout optimizations.
-
-Choosing a level enables the optimizations of that level, as well as the optimizations of all preceding levels.
-More information [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).
-
-`fuse_operators=True` means that graph fusion is performed in addition to ONNX Runtime optimizations described above.
-Here is the list of all the operator fusions you can enable:
-- Gelu fusion with `disable_gelu_fusion=False`,
-- Layer Normalization fusion with `disable_layer_norm_fusion=False`,
-- Attention fusion with `disable_attention_fusion=False`,
-- SkipLayerNormalization fusion with `disable_skip_layer_norm_fusion=False`,
-- Add Bias and SkipLayerNormalization fusion with `disable_bias_skip_layer_norm_fusion=False`,
-- Add Bias and Gelu / FastGelu fusion with `disable_bias_gelu_fusion=False`.
-
-All other optimization configuration options are detailed in [`~onnxruntime.configuration.OptimizationConfig`].

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -64,11 +64,11 @@ def main():
         ),
     )
     parser.add_argument("--cache_dir", type=str, default=None, help="Path indicating where to store cache.")
-    parser.add_argument("output", type=Path, help="Path indicating where to store generated ONNX model.")
+    parser.add_argument("output", type=Path, help="Path indicating the directory where to store generated ONNX model.")
 
     # Retrieve CLI arguments
     args = parser.parse_args()
-    args.output = args.output if args.output.is_file() else args.output.joinpath("model.onnx")
+    args.output = args.output.joinpath("model.onnx")
 
     if not args.output.parent.exists():
         args.output.parent.mkdir(parents=True)
@@ -121,6 +121,9 @@ def main():
         args.opset,
         args.output,
     )
+
+    # Saving the model config as this is needed sometimes.
+    model.config.save_pretrained(args.output.parent)
 
     if args.atol is None:
         args.atol = onnx_config.ATOL_FOR_VALIDATION

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -267,6 +267,8 @@ class BartDummyTextInputGenerator(DummyTextInputGenerator):
         # This inserts EOS_TOKEN_ID at random locations along the sequence length dimension.
         if self.force_eos_token_id_presence and "input_ids" in input_name and self.task == "sequence-classification":
             for idx in range(self.batch_size):
+                if self.eos_token_id in int_tensor[idx]:
+                    continue
                 random_idx = random.randint(1, self.sequence_length - 1)
                 int_tensor[idx][random_idx] = self.eos_token_id
 

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -23,7 +23,8 @@ _import_structure = {
         "QuantizationMode",
         "AutoQuantizationConfig",
         "OptimizationConfig",
-        "ORTConfig"
+        "AutoOptimizationConfig",
+        "ORTConfig",
     ],
     "model": ["ORTModel"],
     "modeling_ort": [

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -17,7 +17,14 @@ from transformers.utils import _LazyModule
 
 
 _import_structure = {
-    "configuration": ["ORTConfig"],
+    "configuration": [
+        "CalibrationConfig",
+        "AutoCalibrationConfig",
+        "QuantizationMode",
+        "AutoQuantizationConfig",
+        "OptimizationConfig",
+        "ORTConfig"
+    ],
     "model": ["ORTModel"],
     "modeling_ort": [
         "ORTModelForCausalLM",

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -11,6 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+"""Configuration classes for graph optimization and quantization with ONNX Runtime."""
+
 import os
 import warnings
 from dataclasses import asdict, dataclass, field

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -789,7 +789,7 @@ class AutoOptimizationConfig:
             `OptimizationConfig`: The `OptimizationConfig` corresponding to the requested optimization level.
         """
         if optimization_level not in cls._LEVELS:
-            raise ValueError(f"optimization_level must be in {', '.join(cls._LEVELS.keys())}")
+            raise ValueError(f"optimization_level must be in {', '.join(cls._LEVELS.keys())}, got {optimization_level}")
         return OptimizationConfig(optimize_for_gpu=for_gpu, **cls._LEVELS[optimization_level], **kwargs)
 
     @classmethod

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import os
+import warnings
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -21,6 +22,7 @@ from datasets import Dataset
 from packaging.version import Version, parse
 
 from onnxruntime import __version__ as ort_version
+from onnxruntime.transformers.fusion_options import FusionOptions
 from onnxruntime.quantization import CalibraterBase, CalibrationMethod, QuantFormat, QuantizationMode, QuantType
 from onnxruntime.quantization.calibrate import create_calibrator
 
@@ -604,36 +606,44 @@ class AutoQuantizationConfig:
 class OptimizationConfig:
     """
     OptimizationConfig is the configuration class handling all the ONNX Runtime optimization parameters.
+    There are two stacks of optimizations:
+        1. The ONNX Runtime general-purpose optimization tool: it can work on any ONNX model.
+        2. The ONNX Runtime transformers optimization tool: it can only work on a subset of transformers models.
 
-    Args:
-        optimization_level (`int`, defaults to 1):
-            ONNX opset version to export the model with.
+    Attributes that tune the general-purpose tool contain "onnxruntime_general_tool" in their name to distinguish them
+    from the others.
+
+    Attributes:
+        onnxruntime_general_tool_optimization_level (`int`, defaults to 1):
             Optimization level performed by ONNX Runtime of the loaded graph.
             Supported optimization level are 0, 1, 2 and 99.
-            0 will disable all optimizations.
-            1 will enable basic optimizations.
-            2 will enable basic and extended optimizations, including complex node fusions applied to the nodes
-            assigned to the CPU or CUDA execution provider, making the resulting optimized graph hardware dependent.
-            99 will enable all available optimizations including layout optimizations.
-        optimize_for_gpu (`bool`, defaults to `False`):
+                - 0 will disable all optimizations
+                - 1 will enable basic optimizations
+                - 2 will enable basic and extended optimizations, including complex node fusions applied to the nodes
+                assigned to the CPU or CUDA execution provider, making the resulting optimized graph hardware dependent
+                - 99 will enable all available optimizations including layout optimizations
+        onnxruntime_general_tool_optimize_for_gpu (`bool`, defaults to `False`):
             Whether to optimize the model for GPU inference.
             The optimized graph might contain operators for GPU or CPU only when `optimization_level` > 1.
         fp16 (`bool`, defaults to `False`):
             Whether all weights and nodes should be converted from float32 to float16.
-        optimize_with_onnxruntime_only (`bool`, defaults to `False`):
+        optimize_with_onnxruntime_general_tool_only (`bool`, defaults to `False`):
             Whether to only use ONNX Runtime to optimize the model and no graph fusion in Python.
-        disable_gelu (`bool`, defaults to `False`):
+        disable_gelu_fusion (`bool`, defaults to `False`):
             Whether to disable the Gelu fusion.
-        disable_layer_norm (`bool`, defaults to `False`):
+        disable_layer_norm_fusion (`bool`, defaults to `False`):
             Whether to disable Layer Normalization fusion.
-        disable_attention (`bool`, defaults to `False`):
+        disable_attention_fusion (`bool`, defaults to `False`):
             Whether to disable Attention fusion.
-        disable_skip_layer_norm (`bool`, defaults to `False`):
+        disable_skip_layer_norm_fusion (`bool`, defaults to `False`):
             Whether to disable SkipLayerNormalization fusion.
-        disable_bias_skip_layer_norm (`bool`, defaults to `False`):
+        disable_bias_skip_layer_norm_fusion (`bool`, defaults to `False`):
             Whether to disable Add Bias and SkipLayerNormalization fusion.
-        disable_bias_gelu (`bool`, defaults to `False`):
+        disable_bias_gelu_fusion (`bool`, defaults to `False`):
             Whether to disable Add Bias and Gelu / FastGelu fusion.
+        disable_embed_layer_norm_fusion (`bool`, defaults to `True`):
+            Whether to disable EmbedLayerNormalization fusion.
+            The default value is set to `True` since this fusion is incompatible with ONNX Runtime quantization.
         enable_gelu_approximation (`bool`, defaults to `False`):
             Whether to enable Gelu / BiasGelu to FastGelu conversion.
             The default value is set to `False` since this approximation might slightly impact the model's accuracy.
@@ -641,36 +651,99 @@ class OptimizationConfig:
             Whether to use mask index instead of raw attention mask in the attention operator.
         no_attention_mask (`bool`, defaults to `False`):
             Whether to not use attention masks. Only works for bert model type.
-        disable_embed_layer_norm (`bool`, defaults to `True`):
-            Whether to disable EmbedLayerNormalization fusion.
-            The default value is set to `True` since this fusion is incompatible with ONNX Runtime quantization.
         disable_shape_inference (`bool`, defaults to `False`):
             Whether to disable symbolic shape inference.
             The default value is set to `False` but symbolic shape inference might cause issues sometimes.
     """
 
-    optimization_level: int = 1
-    optimize_for_gpu: bool = False
+    optimization_level: Optional[int] = None
+    onnxruntime_general_tool_optimization_level: int = 1
+
+    optimize_for_gpu: Optional[bool] = None
+    onnxruntime_general_tool_optimize_for_gpu: bool = False
+
     fp16: bool = False
-    optimize_with_onnxruntime_only: bool = False
-    disable_gelu: bool = False
-    disable_layer_norm: bool = False
-    disable_attention: bool = False
-    disable_skip_layer_norm: bool = False
-    disable_bias_skip_layer_norm: bool = False
-    disable_bias_gelu: bool = False
+
+    optimize_with_onnxruntime_only: Optional[bool] = None
+    optimize_with_onnxruntime_general_tool_only: bool = False
+
+    disable_gelu: Optional[bool] = None
+    disable_gelu_fusion: bool = False
+
+    disable_layer_norm: Optional[bool] = None
+    disable_layer_norm_fusion: bool = False
+
+    disable_attention: Optional[bool] = None
+    disable_attention_fusion: bool = False
+
+    disable_skip_layer_norm: Optional[bool] = None
+    disable_skip_layer_norm_fusion: bool = False
+
+    disable_bias_skip_layer_norm: Optional[bool] = None
+    disable_bias_skip_layer_norm_fusion: bool = False
+
+    disable_bias_gelu: Optional[bool] = None
+    disable_bias_gelu_fusion: bool = False
+
+    disable_embed_layer_norm: Optional[bool] = None
+    disable_embed_layer_norm_fusion: bool = True
+
     enable_gelu_approximation: bool = False
     use_mask_index: bool = False
     no_attention_mask: bool = False
-    disable_embed_layer_norm: bool = True
     disable_shape_inference: bool = False
+
+    def __post_init__(self):
+
+        def deprecate_renamed_attribute(old_name, new_name):
+            if getattr(self, old_name, None) is not None:
+                warnings.warn(
+                    f"{old_name} will be deprecated soon, use {new_name} instead.",
+                    FutureWarning,
+                )
+                setattr(self, new_name, getattr(self, old_name))
+
+        deprecate_renamed_attribute("optimization_level", "onnxruntime_general_tool_optimization_level")
+        deprecate_renamed_attribute("optimize_for_gpu", "onnxruntime_general_tool_optimize_for_gpu")
+        deprecate_renamed_attribute("optimize_with_onnxruntime_only", "optimize_with_onnxruntime_general_tool_only")
+
+        deprecate_renamed_attribute("disable_gelu", "disable_bias_gelu_fusion")
+        deprecate_renamed_attribute("disable_layer_norm", "disable_layer_norm_fusion")
+        deprecate_renamed_attribute("disable_attention", "disable_attention_fusion")
+        deprecate_renamed_attribute("disable_skip_layer_norm", "disable_skip_layer_norm_fusion")
+        deprecate_renamed_attribute("disable_bias_skip_layer_norm", "disable_bias_skip_layer_norm_fusion")
+        deprecate_renamed_attribute("disable_bias_gelu", "disable_bias_gelu_fusion")
+        deprecate_renamed_attribute("disable_embed_layer_norm", "disable_embed_layer_norm_fusion")
+
+    def create_fusion_options(self, model_type: str) -> FusionOptions:
+        args = object()
+        args.model_type = model_type
+        attribute_map = {
+            "disable_gelu_fusion": "disable_gelu",
+            "disable_layer_norm_fusion": "disable_layer_norm",
+            "disable_attention_fusion": "disable_attention",
+            "disable_skip_layer_norm_fusion": "disable_skip_layer_norm",
+            "disable_bias_skip_layer_norm_fusion": "disable_bias_skip_layer_norm",
+            "disable_bias_gelu_fusion": "disable_bias_gelu",
+            "disable_embed_layer_norm_fusion": "disable_embed_layer_norm",
+        }
+        for attr_name, fusion_attr_name in attribute_map.items():
+            setattr(args, fusion_attr_name, getattr(self, attr_name))
+
+        for attr, value in self.__dict__:
+            if hasattr(args, attr):
+                continue
+            setattr(args, attr, value)
+
+        return FusionOptions.parse(args)
 
 
 class ORTConfig(BaseConfig):
     """
-    ORTConfig is the configuration class handling all the ONNX Runtime parameters related to the ONNX IR model export, optimization and quantization parameters.
+    ORTConfig is the configuration class handling all the ONNX Runtime parameters related to the ONNX IR model export,
+    optimization and quantization parameters.
 
-    Args:
+    Attributes:
         opset (`int`, *optional*):
             ONNX opset version to export the model with.
         use_external_data_format (`bool`, *optional*, defaults to `False`):

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -758,9 +758,13 @@ class AutoOptimizationConfig:
         "O2": {
             "optimization_level": 2,
             "enable_transformers_specific_optimizations": True,
-            "enable_gelu_approximation": True,
         },
         "O3": {
+            "optimization_level": 2,
+            "enable_transformers_specific_optimizations": True,
+            "enable_gelu_approximation": True,
+        },
+        "O4": {
             "optimization_level": 2,
             "enable_transformers_specific_optimizations": True,
             "enable_gelu_approximation": True,
@@ -777,8 +781,9 @@ class AutoOptimizationConfig:
             optimization_level (`str`):
                 The optimization level, the following values are allowed:
                 - O1: Basic general optimizations
-                - O2: Basic and extended general optimizations, transformers-specific fusions, and Gelu approximation.
-                - O3: Same as O2, with mixed precision.
+                - O2: Basic and extended general optimizations, transformers-specific fusions.
+                - O3: Same as O2 with Fast Gelu approximation.
+                - O4: Same as O3 with mixed precision.
             for_gpu (`bool`, *optional*, defaults to `False`):
                 Whether the model to optimize will run on GPU, some optimizations depends on the hardware the model
                 will run on. Only needed for optimization_level > 1.
@@ -842,6 +847,23 @@ class AutoOptimizationConfig:
             `OptimizationConfig`: The `OptimizationConfig` corresponding to the O3 optimization level.
         """
         return cls.with_optimization_level("O3", for_gpu=for_gpu, **kwargs)
+
+    @classmethod
+    def O4(cls, for_gpu: bool = False, **kwargs) -> OptimizationConfig:
+        """
+        Creates an O4 [`~OptimizationConfig`].
+
+        Args:
+            for_gpu (`bool`, *optional*, defaults to `False`):
+                Whether the model to optimize will run on GPU, some optimizations depends on the hardware the model
+                will run on. Only needed for optimization_level > 1.
+            kwargs (`Dict[str, Any]`, *optional*):
+                Arguments to provide to the [`~OptimizationConfig`] constructor.
+
+        Returns:
+            `OptimizationConfig`: The `OptimizationConfig` corresponding to the O4 optimization level.
+        """
+        return cls.with_optimization_level("O4", for_gpu=for_gpu, **kwargs)
 
 
 class ORTConfig(BaseConfig):

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -746,6 +746,10 @@ class OptimizationConfig:
 
 
 class AutoOptimizationConfig:
+    """
+    Factory to create common `OptimizationConfig`.
+    """
+
     _LEVELS = {
         "O1": {
             "optimization_level": 1,
@@ -774,7 +778,7 @@ class AutoOptimizationConfig:
                 The optimization level, the following values are allowed:
                 - O1: Basic general optimizations
                 - O2: Basic and extended general optimizations, transformers-specific fusions, and Gelu approximation.
-                - O3: Same as O2, with weights in fp16
+                - O3: Same as O2, with mixed precision.
             for_gpu (`bool`, *optional*, defaults to `False`):
                 Whether the model to optimize will run on GPU, some optimizations depends on the hardware the model
                 will run on. Only needed for optimization_level > 1.
@@ -787,6 +791,57 @@ class AutoOptimizationConfig:
         if optimization_level not in cls._LEVELS:
             raise ValueError(f"optimization_level must be in {', '.join(cls._LEVELS.keys())}")
         return OptimizationConfig(optimize_for_gpu=for_gpu, **cls._LEVELS[optimization_level], **kwargs)
+
+    @classmethod
+    def O1(cls, for_gpu: bool = False, **kwargs) -> OptimizationConfig:
+        """
+        Creates an O1 [`~OptimizationConfig`].
+
+        Args:
+            for_gpu (`bool`, *optional*, defaults to `False`):
+                Whether the model to optimize will run on GPU, some optimizations depends on the hardware the model
+                will run on. Only needed for optimization_level > 1.
+            kwargs (`Dict[str, Any]`, *optional*):
+                Arguments to provide to the [`~OptimizationConfig`] constructor.
+
+        Returns:
+            `OptimizationConfig`: The `OptimizationConfig` corresponding to the O1 optimization level.
+        """
+        return cls.with_optimization_level("O1", for_gpu=for_gpu, **kwargs)
+
+    @classmethod
+    def O2(cls, for_gpu: bool = False, **kwargs) -> OptimizationConfig:
+        """
+        Creates an O2 [`~OptimizationConfig`].
+
+        Args:
+            for_gpu (`bool`, *optional*, defaults to `False`):
+                Whether the model to optimize will run on GPU, some optimizations depends on the hardware the model
+                will run on. Only needed for optimization_level > 1.
+            kwargs (`Dict[str, Any]`, *optional*):
+                Arguments to provide to the [`~OptimizationConfig`] constructor.
+
+        Returns:
+            `OptimizationConfig`: The `OptimizationConfig` corresponding to the O2 optimization level.
+        """
+        return cls.with_optimization_level("O2", for_gpu=for_gpu, **kwargs)
+
+    @classmethod
+    def O3(cls, for_gpu: bool = False, **kwargs) -> OptimizationConfig:
+        """
+        Creates an O3 [`~OptimizationConfig`].
+
+        Args:
+            for_gpu (`bool`, *optional*, defaults to `False`):
+                Whether the model to optimize will run on GPU, some optimizations depends on the hardware the model
+                will run on. Only needed for optimization_level > 1.
+            kwargs (`Dict[str, Any]`, *optional*):
+                Arguments to provide to the [`~OptimizationConfig`] constructor.
+
+        Returns:
+            `OptimizationConfig`: The `OptimizationConfig` corresponding to the O3 optimization level.
+        """
+        return cls.with_optimization_level("O3", for_gpu=for_gpu, **kwargs)
 
 
 class ORTConfig(BaseConfig):

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -794,7 +794,9 @@ class AutoOptimizationConfig:
             `OptimizationConfig`: The `OptimizationConfig` corresponding to the requested optimization level.
         """
         if optimization_level not in cls._LEVELS:
-            raise ValueError(f"optimization_level must be in {', '.join(cls._LEVELS.keys())}, got {optimization_level}")
+            raise ValueError(
+                f"optimization_level must be in {', '.join(cls._LEVELS.keys())}, got {optimization_level}"
+            )
         return OptimizationConfig(optimize_for_gpu=for_gpu, **cls._LEVELS[optimization_level], **kwargs)
 
     @classmethod

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -715,7 +715,7 @@ class ORTDecoder:
             output_shape = (batch_size, sequence_length, self.normalized_config.vocab_size)
             output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
         elif "key_values" in output_name:
-            num_attention_heads = self.normalized_confi.num_attention_heads
+            num_attention_heads = self.normalized_config.num_attention_heads
             hidden_size = self.normalized_config.hidden_size
             embed_size_per_head = hidden_size // num_attention_heads
             if is_self_attn:

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -574,7 +574,7 @@ class ORTEncoder:
         ort_type = TypeHelper.get_output_type(self.session, "last_hidden_state")
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 
-        hidden_size = getattr(self.config, ORTConfigManager.get_hidden_size_name(self.config.model_type))
+        hidden_size = self.normalized_config.hidden_size
         output_shape = (batch_size, sequence_length, hidden_size)
         output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
 
@@ -683,6 +683,7 @@ class ORTDecoder:
     ):
         self.session = session
         self.config = config
+        self.normalized_config = ORTConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
         self._device = device
         self.use_io_binding = use_io_binding
         self.session_inputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_inputs())}
@@ -711,18 +712,18 @@ class ORTDecoder:
             output_shape = (1,)
             output_buffer = torch.empty(1, dtype=torch_type, device=self._device).contiguous()
         elif output_name == "logits":
-            output_shape = (batch_size, sequence_length, self.config.vocab_size)
+            output_shape = (batch_size, sequence_length, self.normalized_config.vocab_size)
             output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
         elif "key_values" in output_name:
-            num_heads = getattr(self.config, ORTConfigManager.get_num_heads_name(self.config.model_type))
-            hidden_size = getattr(self.config, ORTConfigManager.get_hidden_size_name(self.config.model_type))
-            embed_size_per_head = hidden_size // num_heads
+            num_attention_heads = self.normalized_confi.num_attention_heads
+            hidden_size = self.normalized_config.hidden_size
+            embed_size_per_head = hidden_size // num_attention_heads
             if is_self_attn:
                 if past_sequence_length is not None:
                     sequence_length += past_sequence_length
-                output_shape = (batch_size, num_heads, sequence_length, embed_size_per_head)
+                output_shape = (batch_size, num_attention_heads, sequence_length, embed_size_per_head)
             else:
-                output_shape = (batch_size, num_heads, encoder_sequence_length, embed_size_per_head)
+                output_shape = (batch_size, num_attention_heads, encoder_sequence_length, embed_size_per_head)
 
             output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
 

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -14,21 +14,22 @@
 import logging
 import os
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-import transformers
 from transformers.models.auto.configuration_auto import AutoConfig
 
 from onnx import load_model
-from onnxruntime.transformers.fusion_options import FusionOptions
 from onnxruntime.transformers.onnx_model_bert import BertOnnxModel
-from onnxruntime.transformers.optimizer import get_fusion_statistics, optimize_model
+from onnxruntime.transformers.optimizer import optimize_model
 
 from ..utils import CONFIG_NAME
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForSeq2SeqLM
 from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
 
 
 LOGGER = logging.getLogger(__name__)
@@ -39,12 +40,12 @@ class ORTOptimizer:
     Handles the ONNX Runtime optimization process for models shared on huggingface.co/models.
     """
 
-    def __init__(self, onnx_model_path: List[os.PathLike], config: transformers.PretrainedConfig):
+    def __init__(self, onnx_model_path: List[os.PathLike], config: "PretrainedConfig"):
         """
         Args:
             onnx_model_path (`List[os.PathLike]`):
                 The paths of the onnx models to optimize.
-            config (`transformers.PretrainedConfig`):
+            config ([`~PretrainedConfig`]):
                 An instance of the configuration associated to the model to optimize.
         """
         super().__init__()
@@ -52,7 +53,7 @@ class ORTOptimizer:
         self.config = config
 
     @classmethod
-    def from_pretrained(cls, model_or_path: Union[str, os.PathLike, ORTModel], file_names: Optional[List[str]] = None):
+    def from_pretrained(cls, model_or_path: Union[str, os.PathLike, ORTModel], file_names: Optional[List[str]] = None) -> "ORTOptimizer":
         """
         Args:
             model_or_path (`Union[str, os.PathLike, ORTModel]`):
@@ -63,6 +64,8 @@ class ORTOptimizer:
             file_names(`List[str]`, *optional*):
                 The list of file names of the models to optimize.
         """
+        onnx_model_path = []
+        config = None
         if isinstance(model_or_path, ORTModel):
             if isinstance(model_or_path, ORTModelForSeq2SeqLM):
                 model_save_dir = model_or_path.model_save_dir
@@ -75,29 +78,28 @@ class ORTOptimizer:
                     onnx_model_path.append(model_save_dir.joinpath(model_or_path.decoder_file_with_past_name))
             else:
                 onnx_model_path = [model_or_path.model_save_dir.joinpath(model_or_path.latest_model_name)]
-            return cls(onnx_model_path, config=model_or_path.config)
+            config = model_or_path.config
         elif os.path.isdir(model_or_path):
             file_names = [ONNX_WEIGHTS_NAME] if file_names is None else file_names
             model_or_path = Path(model_or_path)
             if CONFIG_NAME not in os.listdir(model_or_path):
                 raise ValueError(f"The local directory does not contain the configuration file {CONFIG_NAME}.")
             config = AutoConfig.from_pretrained(model_or_path)
-            onnx_model_path = []
             for file_name in file_names:
                 onnx_model_path.append(model_or_path.joinpath(file_name))
-            return cls(onnx_model_path, config=config)
         else:
             raise ValueError(f"Unable to load the model from {model_or_path}.")
+        return cls(onnx_model_path, config=config)
 
     def optimize(
         self,
         optimization_config: OptimizationConfig,
         save_dir: Union[str, os.PathLike],
-        file_suffix: Optional[str] = "optimized",
+        file_suffix: str = "optimized",
         use_external_data_format: bool = False,
     ):
         """
-        Optimize a model given the optimization specifications defined in `optimization_config`.
+        Optimizes a model given the optimization specifications defined in `optimization_config`.
 
         Args:
             optimization_config (`OptimizationConfig`):
@@ -112,7 +114,7 @@ class ORTOptimizer:
         save_dir = Path(save_dir)
         save_dir.mkdir(parents=True, exist_ok=True)
         model_type = self.config.model_type
-        ORTConfigManager.check_optimization_supported_model_or_raise(model_type)
+        ORTConfigManager.check_optimization_supported_model(model_type)
 
         # Save the model configuration
         self.config.save_pretrained(save_dir)
@@ -121,11 +123,12 @@ class ORTOptimizer:
         ort_config = ORTConfig(optimization=optimization_config)
         ort_config.save_pretrained(save_dir)
 
+        # TODO: use NormalizedConfig.
         num_heads = getattr(self.config, ORTConfigManager.get_num_heads_name(model_type))
         hidden_size = getattr(self.config, ORTConfigManager.get_hidden_size_name(model_type))
         model_type = ORTConfigManager.get_model_ort_type(model_type)
-        optimization_config.model_type = model_type
-        optimization_options = FusionOptions.parse(optimization_config)
+        optimization_options = optimization_config.create_fusion_options(model_type)
+
         LOGGER.info("Optimizing model...")
 
         for model_path in self.onnx_model_path:
@@ -155,7 +158,7 @@ class ORTOptimizer:
     @staticmethod
     def get_fused_operators(onnx_model_path: Union[str, os.PathLike]) -> Dict[str, int]:
         """
-        Compute the dictionary mapping the name of the fused operators to their number of apparition in the model.
+        Computes the dictionary mapping the name of the fused operators to their number of apparition in the model.
 
         Args:
             onnx_model_path (`Union[str, os.PathLike]`):

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -140,10 +140,10 @@ class ORTOptimizer:
                 model_type,
                 self.normalized_config.num_attention_heads,
                 self.normalized_config.hidden_size,
-                opt_level=optimization_config.onnxruntime_general_tool_optimization_level,
+                opt_level=optimization_config.general_optimization_level,
                 optimization_options=optimization_options,
-                use_gpu=optimization_config.onnxruntime_general_tool_optimize_for_gpu,
-                only_onnxruntime=optimization_config.optimize_with_onnxruntime_general_tool_only,
+                use_gpu=optimization_config.optimize_for_gpu,
+                only_onnxruntime=not optimization_config.enable_transformers_specific_optimizations,
             )
 
             if optimization_config.fp16:

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -28,6 +28,7 @@ from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForSeq2SeqLM
 from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
 
+
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
@@ -53,7 +54,9 @@ class ORTOptimizer:
         self.config = config
 
     @classmethod
-    def from_pretrained(cls, model_or_path: Union[str, os.PathLike, ORTModel], file_names: Optional[List[str]] = None) -> "ORTOptimizer":
+    def from_pretrained(
+        cls, model_or_path: Union[str, os.PathLike, ORTModel], file_names: Optional[List[str]] = None
+    ) -> "ORTOptimizer":
         """
         Args:
             model_or_path (`Union[str, os.PathLike, ORTModel]`):
@@ -137,10 +140,10 @@ class ORTOptimizer:
                 model_type,
                 num_heads,
                 hidden_size,
-                opt_level=optimization_config.optimization_level,
+                opt_level=optimization_config.onnxruntime_general_tool_optimization_level,
                 optimization_options=optimization_options,
-                use_gpu=optimization_config.optimize_for_gpu,
-                only_onnxruntime=optimization_config.optimize_with_onnxruntime_only,
+                use_gpu=optimization_config.onnxruntime_general_tool_optimize_for_gpu,
+                only_onnxruntime=optimization_config.optimize_with_onnxruntime_general_tool_only,
             )
 
             if optimization_config.fp16:

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -102,7 +102,7 @@ class ORTOptimizer:
         self,
         optimization_config: OptimizationConfig,
         save_dir: Union[str, os.PathLike],
-        file_suffix: str = "optimized",
+        file_suffix: Optional[str] = "optimized",
         use_external_data_format: bool = False,
     ):
         """
@@ -140,7 +140,7 @@ class ORTOptimizer:
                 model_type,
                 self.normalized_config.num_attention_heads,
                 self.normalized_config.hidden_size,
-                opt_level=optimization_config.general_optimization_level,
+                opt_level=optimization_config.optimization_level,
                 optimization_options=optimization_options,
                 use_gpu=optimization_config.optimize_for_gpu,
                 only_onnxruntime=not optimization_config.enable_transformers_specific_optimizations,

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -87,7 +87,7 @@ class ORTConfigManager:
         "gpt_neo": (NormalizedTextConfig.with_args(num_attention_heads="num_heads"), "gpt2"),
         "marian": (BartLikeNormalizedTextConfig, "bart"),
         "mbart": (BartLikeNormalizedTextConfig, "bart"),
-        "mt5": (T5LikeNormalizedTextConfig, "t5"),
+        "mt5": (T5LikeNormalizedTextConfig, "bart"),
         "m2m_100": (BartLikeNormalizedTextConfig, "bart"),
         "roberta": (NormalizedTextConfig, "bert"),
         "t5": (T5LikeNormalizedTextConfig, "t5"),
@@ -102,7 +102,7 @@ class ORTConfigManager:
     @classmethod
     def get_model_ort_type(cls, model_type: str) -> str:
         cls.check_supported_model(model_type)
-        return cls._conf[model_type][2]
+        return cls._conf[model_type][1]
 
     @classmethod
     def check_supported_model(cls, model_type: str):
@@ -116,7 +116,7 @@ class ORTConfigManager:
     @classmethod
     def check_optimization_supported_model(cls, model_type: str):
         supported_model_types_for_optimization = ["bert", "gpt2", "bart"]
-        if (model_type not in cls._conf) or (cls._conf[model_type][2] not in supported_model_types_for_optimization):
+        if (model_type not in cls._conf) or (cls._conf[model_type][1] not in supported_model_types_for_optimization):
             raise KeyError(
                 f"ONNX Runtime doesn't support the graph optimization of {model_type} yet. Only {supported_model_types_for_optimization} are supported. "
                 f"If you want to support {model_type} please propose a PR or open up an issue in ONNX Runtime:https://github.com/microsoft/onnxruntime."

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -48,9 +48,7 @@ class ORTOptimizerTest(unittest.TestCase):
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)
     def test_compare_original_model_with_optimized_model(self, model_cls, model_name):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        optimization_config = OptimizationConfig(
-            general_optimization_level=2, enable_transformers_specific_optimizations=True
-        )
+        optimization_config = OptimizationConfig(optimization_level=2, enable_transformers_specific_optimizations=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = model_cls.from_pretrained(model_name, from_transformers=True)
             model.save_pretrained(tmp_dir)
@@ -121,7 +119,7 @@ class ORTOptimizerTest(unittest.TestCase):
     def test_optimization_details(self):
         model_name = "hf-internal-testing/tiny-random-distilbert"
         optimization_config = OptimizationConfig(
-            general_optimization_level=0, enable_transformers_specific_optimizations=False
+            optimization_level=0, enable_transformers_specific_optimizations=False
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir)
@@ -141,7 +139,7 @@ class ORTOptimizerTest(unittest.TestCase):
 
     def test_optimization_fp16(self):
         model_name = "hf-internal-testing/tiny-random-distilbert"
-        optimization_config = OptimizationConfig(general_optimization_level=0, fp16=True)
+        optimization_config = OptimizationConfig(optimization_level=0, fp16=True)
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = ORTModelForSequenceClassification.from_pretrained(model_name, from_transformers=True)

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -48,7 +48,9 @@ class ORTOptimizerTest(unittest.TestCase):
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)
     def test_compare_original_model_with_optimized_model(self, model_cls, model_name):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        optimization_config = OptimizationConfig(optimization_level=2, optimize_with_onnxruntime_only=False)
+        optimization_config = OptimizationConfig(
+            onnxruntime_general_tool_optimization_level=2, optimize_with_onnxruntime_general_tool_only=False
+        )
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = model_cls.from_pretrained(model_name, from_transformers=True)
             model.save_pretrained(tmp_dir)
@@ -118,7 +120,9 @@ class ORTOptimizerTest(unittest.TestCase):
 
     def test_optimization_details(self):
         model_name = "hf-internal-testing/tiny-random-distilbert"
-        optimization_config = OptimizationConfig(optimization_level=0, optimize_with_onnxruntime_only=True)
+        optimization_config = OptimizationConfig(
+            onnxruntime_general_tool_optimization_level=0, optimize_with_onnxruntime_general_tool_only=True
+        )
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir)
             model = ORTModelForSequenceClassification.from_pretrained(model_name, from_transformers=True)
@@ -137,7 +141,7 @@ class ORTOptimizerTest(unittest.TestCase):
 
     def test_optimization_fp16(self):
         model_name = "hf-internal-testing/tiny-random-distilbert"
-        optimization_config = OptimizationConfig(optimization_level=0, fp16=True)
+        optimization_config = OptimizationConfig(onnxruntime_general_tool_optimization_level=0, fp16=True)
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = ORTModelForSequenceClassification.from_pretrained(model_name, from_transformers=True)

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -49,7 +49,7 @@ class ORTOptimizerTest(unittest.TestCase):
     def test_compare_original_model_with_optimized_model(self, model_cls, model_name):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         optimization_config = OptimizationConfig(
-            onnxruntime_general_tool_optimization_level=2, optimize_with_onnxruntime_general_tool_only=False
+            general_optimization_level=2, enable_transformers_specific_optimizations=True
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = model_cls.from_pretrained(model_name, from_transformers=True)
@@ -121,7 +121,7 @@ class ORTOptimizerTest(unittest.TestCase):
     def test_optimization_details(self):
         model_name = "hf-internal-testing/tiny-random-distilbert"
         optimization_config = OptimizationConfig(
-            onnxruntime_general_tool_optimization_level=0, optimize_with_onnxruntime_general_tool_only=True
+            general_optimization_level=0, enable_transformers_specific_optimizations=False
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir)
@@ -141,7 +141,7 @@ class ORTOptimizerTest(unittest.TestCase):
 
     def test_optimization_fp16(self):
         model_name = "hf-internal-testing/tiny-random-distilbert"
-        optimization_config = OptimizationConfig(onnxruntime_general_tool_optimization_level=0, fp16=True)
+        optimization_config = OptimizationConfig(general_optimization_level=0, fp16=True)
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = ORTModelForSequenceClassification.from_pretrained(model_name, from_transformers=True)


### PR DESCRIPTION
# What does this PR do?

- Renames the attributes for the `OptimizationConfig`: 
    - The previous naming was not very clear, because it was matching the naming from what was done in `onnxruntime` for instance `disable_attention` for disabling attention fusion.
    - Make things clearer in terms of optimization tool by explicitly specifying which attributes tune the general purpose ONNX Runtime optimizer (compared to the other which are tuning the transformers specific optimizer).
- Adds an `AutoOptimizationConfig` class, with several optimization levels that cover the most common use cases, to make it easy to create an `OptimizationConfig` without having to dive in the ONNX Runtime ecosystem. 
- Uses `NormalizedConfig` when possible.

To be done:

- [ ] Write tests for configuration classes