### PR TITLE
Fix onnxruntime gpu test yml

### DIFF
--- a/.github/workflows/test_onnxruntime_gpu.yml
+++ b/.github/workflows/test_onnxruntime_gpu.yml
@@ -51,14 +51,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install dependencies
+      - name: Build image
         run: |
-          sudo apt -y update && sudo pip install --upgrade pip
-          pip install .[onnxruntime-gpu,tests]
-      - name: Test with unittest
-        working-directory: tests
+          docker build -f tests/onnxruntime/Dockerfile_onnxruntime_gpu -t onnxruntime-gpu .
+      - name: Test with unittest within docker container
         run: |
-          python3 -m unittest discover -s onnxruntime -p 'test_*.py'
+          docker run --gpus all --workdir=/workspace/optimum/tests onnxruntime-gpu:latest
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/tests/onnxruntime/Dockerfile_onnxruntime_gpu
+++ b/tests/onnxruntime/Dockerfile_onnxruntime_gpu
@@ -1,0 +1,36 @@
+# Use nvidia/cuda image
+FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
+CMD nvidia-smi
+
+# Ignore interactive questions during `docker build`
+ENV DEBIAN_FRONTEND noninteractive
+
+# Bash shell
+RUN chsh -s /bin/bash
+SHELL ["/bin/bash", "-c"]
+
+# Temporary fix until NVDIA finish the update of its docker images
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+# Install and update tools to minimize security vulnerabilities
+RUN apt-get update
+RUN apt-get install -y software-properties-common wget apt-utils patchelf git libprotobuf-dev protobuf-compiler cmake \
+    bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 mercurial subversion libopenmpi-dev && \
+    apt-get clean
+RUN unattended-upgrade
+RUN apt-get autoremove -y
+
+# Install Pythyon (3.8 as default)
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN apt-get install -y python3-pip
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN pip install -U pip
+RUN pip install pygit2 pgzip
+RUN pip3 install --upgrade requests
+
+# Install Optimum
+COPY . /workspace/optimum
+RUN pip install /workspace/optimum[onnxruntime-gpu,tests]
+
+CMD python3 -m unittest discover -s onnxruntime -p 'test_*.py'


### PR DESCRIPTION
As discussed on slack, one issue with the current EC2 AMI used is that CUDA/cuDNN are not installed, thus using `CUDAExecutionProvider` is not possible. So currently all tests from `test_onnxruntime_gpu.yml`.

As hinted by @JingyaHuang , it may be better to use docker for this.

Something I have noticed though in the AWS sandbox account is that the AMI ami-0dc1c26161f869ed1 used for test_onnxruntime_train.yml and test_onnxruntime_gpu.yml is >300 GB. Should we worry about this?