### PR TITLE
Explicit error message when model not found for ORTModel

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -212,6 +212,7 @@ class OptimizedModel(ABC):
         if len(str(model_id).split("@")) == 2:
             model_id, revision = model_id.split("@")
 
+        config = None
         if os.path.isdir(os.path.join(model_id, subfolder)):
             if CONFIG_NAME in os.listdir(os.path.join(model_id, subfolder)):
                 config = AutoConfig.from_pretrained(os.path.join(model_id, subfolder, CONFIG_NAME))


### PR DESCRIPTION
https://github.com/huggingface/optimum/pull/436 broke the error message when the specified model is neither on the Hub or a local path. We would only get `UnboundLocalError: local variable 'config' referenced before assignment`

This PR fixes the issue.