### PR TITLE
Fix docstring example for ORTModelForCausalLM

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1323,7 +1323,7 @@ TEXT_GENERATION_EXAMPLE = r"""
     >>> from optimum.onnxruntime import {model_class}
 
     >>> tokenizer = {processor_class}.from_pretrained("{checkpoint}")
-    >>> model = {model_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}", from_transformers=True)
     >>> onnx_gen = pipeline("text-generation", model=model, tokenizer=tokenizer)
 
     >>> text = "My name is Philipp and I live in Germany."

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1424,7 +1424,7 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
         + TEXT_GENERATION_EXAMPLE.format(
             processor_class=_TOKENIZER_FOR_DOC,
             model_class="ORTModelForCausalLM",
-            checkpoint="optimum/gpt2",
+            checkpoint="gpt2",
         )
     )
     def forward(


### PR DESCRIPTION
There was no `optimum/gpt2`. An alternative could be to add `optimum/gpt2`, here the advantage is that if `gpt2` is already cached no need to redownload it.

Note that the modified docstring `TEXT_GENERATION_EXAMPLE` is used only once.