### PR TITLE
`vit` + `wav2vec2` support

### DIFF
--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -29,6 +29,7 @@ The list of supported model below:
 - [CamemBERT](https://arxiv.org/abs/1911.03894)
 - [Data2VecText](https://arxiv.org/abs/2202.03555)
 - [DistilBert](https://arxiv.org/abs/1910.01108)
+- [DeiT](https://arxiv.org/abs/2012.12877)
 - [Electra](https://arxiv.org/abs/2003.10555)
 - [Ernie](https://arxiv.org/abs/1904.09223)
 - [HuBERT](https://arxiv.org/pdf/2106.07447.pdf)
@@ -38,7 +39,11 @@ The list of supported model below:
 - [Splinter](https://arxiv.org/abs/2101.00438)
 - [XLMRoberta](https://arxiv.org/abs/1911.02116)
 - [Whisper](https://cdn.openai.com/papers/whisper.pdf)
+- [ViT](https://arxiv.org/abs/2010.11929)
+- [ViT-MAE](https://arxiv.org/abs/2111.06377)
+- [ViT-MSN](https://arxiv.org/abs/2204.07141)
 - [Wav2Vec2](https://arxiv.org/abs/2006.11477)
+- [YOLOS](https://arxiv.org/abs/2106.00666)
 
 Let us know by opening an issue in 🤗 Optimum if you want more models to be supported, or check out the contribution guideline if you want to add it by yourself!
 

--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -31,6 +31,7 @@ The list of supported model below:
 - [DistilBert](https://arxiv.org/abs/1910.01108)
 - [Electra](https://arxiv.org/abs/2003.10555)
 - [Ernie](https://arxiv.org/abs/1904.09223)
+- [HuBERT](https://arxiv.org/pdf/2106.07447.pdf)
 - [LayoutLM](https://arxiv.org/abs/1912.13318)
 - [MarkupLM](https://arxiv.org/abs/2110.08518)
 - [RoBERTa](https://arxiv.org/abs/1907.11692)

--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -37,6 +37,7 @@ The list of supported model below:
 - [Splinter](https://arxiv.org/abs/2101.00438)
 - [XLMRoberta](https://arxiv.org/abs/1911.02116)
 - [Whisper](https://cdn.openai.com/papers/whisper.pdf)
+- [Wav2Vec2](https://arxiv.org/abs/2006.11477)
 
 Let us know by opening an issue in 🤗 Optimum if you want more models to be supported, or check out the contribution guideline if you want to add it by yourself!
 

--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -26,6 +26,7 @@ The list of supported model below:
 - [AlBERT](https://arxiv.org/abs/1909.11942)
 - [BART](https://arxiv.org/abs/1910.13461)
 - [BERT](https://arxiv.org/abs/1810.04805)
+- [BERT-generation](https://arxiv.org/abs/1907.12461)
 - [CamemBERT](https://arxiv.org/abs/1911.03894)
 - [Data2VecText](https://arxiv.org/abs/2202.03555)
 - [DistilBert](https://arxiv.org/abs/1910.01108)

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -18,6 +18,7 @@ from .encoder_models import (
     BartEncoderLayerBetterTransformer,
     BertLayerBetterTransformer,
     DistilBertLayerBetterTransformer,
+    ViTLayerBetterTransformer,
     WhisperEncoderLayerBetterTransformer,
 )
 
@@ -53,6 +54,11 @@ BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     # WhisperModel
     "WhisperEncoderLayer": WhisperEncoderLayerBetterTransformer,
     # TODO: add Wav2vec2
+    "ViTLayer": ViTLayerBetterTransformer,
+    "DeiTLayer": ViTLayerBetterTransformer,
+    "ViTMAELayer": ViTLayerBetterTransformer,
+    "ViTMSNLayer": ViTLayerBetterTransformer,
+    "YolosLayer": ViTLayerBetterTransformer,
 }
 
 

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -56,6 +56,9 @@ BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     "WhisperEncoderLayer": WhisperEncoderLayerBetterTransformer,
     # Wav2vec2 family:
     "Wav2Vec2EncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
+    "HubertEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
+    # "UniSpeechEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
+    # "Data2VecAudioEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     # ViT Family:
     "ViTLayer": ViTLayerBetterTransformer,
     "DeiTLayer": ViTLayerBetterTransformer,

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -19,6 +19,7 @@ from .encoder_models import (
     BertLayerBetterTransformer,
     DistilBertLayerBetterTransformer,
     ViTLayerBetterTransformer,
+    Wav2Vec2EncoderLayerBetterTransformer,
     WhisperEncoderLayerBetterTransformer,
 )
 
@@ -53,7 +54,9 @@ BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     "TransformerBlock": DistilBertLayerBetterTransformer,
     # WhisperModel
     "WhisperEncoderLayer": WhisperEncoderLayerBetterTransformer,
-    # TODO: add Wav2vec2
+    # Wav2vec2 family:
+    "Wav2Vec2EncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
+    # ViT Family:
     "ViTLayer": ViTLayerBetterTransformer,
     "DeiTLayer": ViTLayerBetterTransformer,
     "ViTMAELayer": ViTLayerBetterTransformer,

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -453,15 +453,14 @@ class DistilBertLayerBetterTransformer(BetterTransformerBaseLayer):
 
 
 class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
-    r"""
-    A simple conversion of the WhisperEncoderLayer to its `BetterTransformer` implementation.
-
-    Args:
-        whisper_layer (`torch.nn.Module`):
-            The original `WhisperEncoderLayer` where the weights needs to be retrieved.
-    """
-
     def __init__(self, whisper_layer, config):
+        r"""
+        A simple conversion of the WhisperEncoderLayer to its `BetterTransformer` implementation.
+
+        Args:
+            whisper_layer (`torch.nn.Module`):
+                The original `WhisperEncoderLayer` where the weights needs to be retrieved.
+        """
         super().__init__(config)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
@@ -550,15 +549,14 @@ class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
 
 
 class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
-    r"""
-    A simple conversion of the ViTLayer to its `BetterTransformer` implementation.
-
-    Args:
-        vit_layer (`torch.nn.Module`):
-            The original `ViTLayer` where the weights needs to be retrieved.
-    """
-
     def __init__(self, vit_layer, config):
+        r"""
+        A simple conversion of the ViTLayer to its `BetterTransformer` implementation.
+
+        Args:
+            vit_layer (`torch.nn.Module`):
+                The original `ViTLayer` where the weights needs to be retrieved.
+        """
         super().__init__(config)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
@@ -618,7 +616,6 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
         https://github.com/huggingface/transformers/pull/19553
         """
         super().forward_checker()
-        # attention mask seems to be always None: https://github.com/huggingface/transformers/blob/94b3f544a1f5e04b78d87a2ae32a7ac252e22e31/src/transformers/models/whisper/modeling_whisper.py#L690
         attention_mask = None
 
         hidden_states = torch._transformer_encoder_layer_fwd(
@@ -648,15 +645,14 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
 
 
 class Wav2Vec2EncoderLayerBetterTransformer(BetterTransformerBaseLayer):
-    r"""
-    A simple conversion of the Wav2Vec2EncoderLayer to its `BetterTransformer` implementation.
-
-    Args:
-        vit_layer (`torch.nn.Module`):
-            The original `Wav2Vec2EncoderLayer` where the weights needs to be retrieved.
-    """
-
     def __init__(self, wav2vec2_layer, config):
+        r"""
+        A simple conversion of the Wav2Vec2EncoderLayer to its `BetterTransformer` implementation.
+
+        Args:
+            wav2vec2_layer (`torch.nn.Module`):
+                The original `Wav2Vec2EncoderLayer` where the weights needs to be retrieved.
+        """
         super().__init__(config)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -547,3 +547,101 @@ class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
         if hidden_states.is_nested and self.is_last_layer:
             hidden_states = hidden_states.to_padded_tensor(0.0)
         return (hidden_states,)
+
+
+class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
+    r"""
+    A simple conversion of the ViTLayer to its `BetterTransformer` implementation.
+
+    Args:
+        vit_layer (`torch.nn.Module`):
+            The original `ViTLayer` where the weights needs to be retrieved.
+    """
+
+    def __init__(self, vit_layer, config):
+        super().__init__(config)
+        # In_proj layer
+        self.in_proj_weight = nn.Parameter(
+            torch.cat(
+                [
+                    vit_layer.attention.attention.query.weight,
+                    vit_layer.attention.attention.key.weight,
+                    vit_layer.attention.attention.value.weight,
+                ]
+            )
+        )
+        self.in_proj_bias = nn.Parameter(
+            torch.cat(
+                [
+                    vit_layer.attention.attention.query.bias,
+                    vit_layer.attention.attention.key.bias,
+                    vit_layer.attention.attention.value.bias,
+                ]
+            )
+        )
+
+        # Out proj layer
+        self.out_proj_weight = vit_layer.attention.output.dense.weight
+        self.out_proj_bias = vit_layer.attention.output.dense.bias
+
+        # Linear layer 1
+        self.linear1_weight = vit_layer.intermediate.dense.weight
+        self.linear1_bias = vit_layer.intermediate.dense.bias
+
+        # Linear layer 2
+        self.linear2_weight = vit_layer.output.dense.weight
+        self.linear2_bias = vit_layer.output.dense.bias
+
+        # Layer norm 1
+        self.norm1_eps = vit_layer.layernorm_before.eps
+        self.norm1_weight = vit_layer.layernorm_before.weight
+        self.norm1_bias = vit_layer.layernorm_before.bias
+
+        # Layer norm 2
+        self.norm2_eps = vit_layer.layernorm_after.eps
+        self.norm2_weight = vit_layer.layernorm_after.weight
+        self.norm2_bias = vit_layer.layernorm_after.bias
+
+        # Model hyper parameters
+        self.num_heads = vit_layer.attention.attention.num_attention_heads
+        self.embed_dim = int(vit_layer.attention.attention.attention_head_size * self.num_heads)
+
+        # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
+        self.is_last_layer = False
+        self.norm_first = True
+
+        self.validate_bettertransformer()
+
+    def forward(self, hidden_states, *_, **__):
+        r"""
+        This is just a wrapper around the forward function proposed in:
+        https://github.com/huggingface/transformers/pull/19553
+        """
+        super().forward_checker()
+        # attention mask seems to be always None: https://github.com/huggingface/transformers/blob/94b3f544a1f5e04b78d87a2ae32a7ac252e22e31/src/transformers/models/whisper/modeling_whisper.py#L690
+        attention_mask = None
+
+        hidden_states = torch._transformer_encoder_layer_fwd(
+            hidden_states,
+            self.embed_dim,
+            self.num_heads,
+            self.in_proj_weight,
+            self.in_proj_bias,
+            self.out_proj_weight,
+            self.out_proj_bias,
+            self.use_gelu,
+            self.norm_first,
+            self.norm1_eps,
+            self.norm1_weight,
+            self.norm1_bias,
+            self.norm2_weight,
+            self.norm2_bias,
+            self.linear1_weight,
+            self.linear1_bias,
+            self.linear2_weight,
+            self.linear2_bias,
+            attention_mask,
+        )
+        if hidden_states.is_nested and self.is_last_layer:
+            hidden_states = hidden_states.to_padded_tensor(0.0)
+        return (hidden_states,)

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -645,3 +645,113 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
         if hidden_states.is_nested and self.is_last_layer:
             hidden_states = hidden_states.to_padded_tensor(0.0)
         return (hidden_states,)
+
+
+class Wav2Vec2EncoderLayerBetterTransformer(BetterTransformerBaseLayer):
+    r"""
+    A simple conversion of the Wav2Vec2EncoderLayer to its `BetterTransformer` implementation.
+
+    Args:
+        vit_layer (`torch.nn.Module`):
+            The original `Wav2Vec2EncoderLayer` where the weights needs to be retrieved.
+    """
+
+    def __init__(self, wav2vec2_layer, config):
+        super().__init__(config)
+        # In_proj layer
+        self.in_proj_weight = nn.Parameter(
+            torch.cat(
+                [
+                    wav2vec2_layer.attention.q_proj.weight,
+                    wav2vec2_layer.attention.k_proj.weight,
+                    wav2vec2_layer.attention.v_proj.weight,
+                ]
+            )
+        )
+        self.in_proj_bias = nn.Parameter(
+            torch.cat(
+                [
+                    wav2vec2_layer.attention.q_proj.bias,
+                    wav2vec2_layer.attention.k_proj.bias,
+                    wav2vec2_layer.attention.v_proj.bias,
+                ]
+            )
+        )
+
+        # Out proj layer
+        self.out_proj_weight = wav2vec2_layer.attention.out_proj.weight
+        self.out_proj_bias = wav2vec2_layer.attention.out_proj.bias
+
+        # Linear layer 1
+        self.linear1_weight = wav2vec2_layer.feed_forward.intermediate_dense.weight
+        self.linear1_bias = wav2vec2_layer.feed_forward.intermediate_dense.bias
+
+        # Linear layer 2
+        self.linear2_weight = wav2vec2_layer.feed_forward.output_dense.weight
+        self.linear2_bias = wav2vec2_layer.feed_forward.output_dense.bias
+
+        # Layer norm 1
+        self.norm1_eps = wav2vec2_layer.layer_norm.eps
+        self.norm1_weight = wav2vec2_layer.layer_norm.weight
+        self.norm1_bias = wav2vec2_layer.layer_norm.bias
+
+        # Layer norm 2
+        self.norm2_eps = wav2vec2_layer.final_layer_norm.eps
+        self.norm2_weight = wav2vec2_layer.final_layer_norm.weight
+        self.norm2_bias = wav2vec2_layer.final_layer_norm.bias
+
+        # Model hyper parameters
+        self.num_heads = wav2vec2_layer.attention.num_heads
+        self.embed_dim = wav2vec2_layer.attention.embed_dim
+
+        # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
+        self.is_last_layer = False
+
+        self.validate_bettertransformer()
+
+    def forward(self, hidden_states, attention_mask, **__):
+        r"""
+        This is just a wrapper around the forward function proposed in:
+        https://github.com/huggingface/transformers/pull/19553
+        """
+        super().forward_checker()
+        if hidden_states.is_nested:
+            attention_mask = None
+
+        if attention_mask is not None:
+            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+            # 0->false->keep this token -inf->true->mask this token
+            attention_mask = attention_mask.bool()
+            if len(attention_mask.shape) == 4:
+                attention_mask = attention_mask.squeeze(1)[:, 0]
+            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+            seqlen = attention_mask.shape[1]
+            lengths = torch.sum(~attention_mask, 1)
+            if not all([l == seqlen for l in lengths]):
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+            attention_mask = None
+
+        hidden_states = torch._transformer_encoder_layer_fwd(
+            hidden_states,
+            self.embed_dim,
+            self.num_heads,
+            self.in_proj_weight,
+            self.in_proj_bias,
+            self.out_proj_weight,
+            self.out_proj_bias,
+            self.use_gelu,
+            self.norm_first,
+            self.norm1_eps,
+            self.norm1_weight,
+            self.norm1_bias,
+            self.norm2_weight,
+            self.norm2_bias,
+            self.linear1_weight,
+            self.linear1_bias,
+            self.linear2_weight,
+            self.linear2_bias,
+            attention_mask,
+        )
+        if hidden_states.is_nested and self.is_last_layer:
+            hidden_states = hidden_states.to_padded_tensor(0.0)
+        return (hidden_states,)

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -165,7 +165,7 @@ class BetterTransformer(object):
                     f"The model {model.__class__.__name__} does not support `deepcopy` operation that is "
                     " internally used to create a copy of the original model when using"
                     " `keep_original_model=True`. Please run the conversion with "
-                    " `keep_original_model=Fale` and create a new copy of the original"
+                    " `keep_original_model=False` and create a new copy of the original"
                     " model somewhere else."
                 )
             model_fast = replace_to_bettertransformer(model_fast, hf_config).eval()

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -157,7 +157,17 @@ class BetterTransformer(object):
             remove_hook_from_module(model, recurse=True)
 
         if keep_original_model:
-            model_fast = deepcopy(model)
+            model = model.requires_grad_(False)
+            try:
+                model_fast = deepcopy(model)
+            except RuntimeError:
+                raise ValueError(
+                    f"The model {model.__class__.__name__} does not support `deepcopy` operation that is "
+                    " internally used to create a copy of the original model when using"
+                    " `keep_original_model=True`. Please run the conversion with "
+                    " `keep_original_model=Fale` and create a new copy of the original"
+                    " model somewhere else."
+                )
             model_fast = replace_to_bettertransformer(model_fast, hf_config).eval()
         else:
             model_fast = replace_to_bettertransformer(model, hf_config).eval()

--- a/tests/benchmark/benchmark_bettertransformer_vit.py
+++ b/tests/benchmark/benchmark_bettertransformer_vit.py
@@ -1,0 +1,116 @@
+import argparse
+
+import torch
+from PIL import Image
+from transformers import AutoFeatureExtractor, AutoModel
+
+import requests
+from optimum.bettertransformer import BetterTransformer
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--num-batches",
+        type=int,
+        default=50,
+        help="",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default="google/vit-base-patch16-224",
+        help="",
+    )
+    parser.add_argument(
+        "--use-cuda",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--use-half",
+        action="store_true",
+    )
+    return parser
+
+
+def get_batch(batch_size, model_name):
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)
+
+    input_features = feature_extractor([image for _ in range(batch_size)], return_tensors="pt")
+    return input_features
+
+
+def timing_cuda(model, num_batches, input_features):
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(num_batches):
+        _ = model(input_features)
+    end_event.record()
+    torch.cuda.synchronize()
+    return (start_event.elapsed_time(end_event) * 1.0e-3) / num_batches
+
+
+def benchmark(model_name, num_batches, batch_size, is_cuda, is_half):
+    print("Loading model {}".format(model_name))
+    if is_cuda:
+        hf_model = AutoModel.from_pretrained(
+            model_name, torch_dtype=torch.float16 if is_half else None, device_map="auto"
+        ).eval()
+    else:
+        hf_model = AutoModel.from_pretrained(model_name, torch_dtype=torch.float16 if is_half else None).eval()
+
+    bt_model = BetterTransformer.transform(hf_model, keep_original_model=True)
+
+    inputs = get_batch(batch_size, model_name)
+    input_features = inputs["pixel_values"]
+
+    if is_cuda:
+        input_features = input_features.to(0)
+
+    # Warmup
+    _ = hf_model(input_features[0].unsqueeze(0))
+    torch.cuda.synchronize()
+    _ = bt_model(input_features[0].unsqueeze(0))
+    torch.cuda.synchronize()
+
+    total_hf_time = timing_cuda(hf_model, num_batches, input_features)
+    total_bt_time = timing_cuda(bt_model, num_batches, input_features)
+
+    return total_bt_time, total_hf_time
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+
+    BATCH_SIZES = [2, 4, 8, 16, 32]
+
+    output_file = open("log_{}.csv".format(args.model_name.replace("/", "-")), "w")
+    output_file.write("num_batches,batch_size,is_cuda,is_half,HF_time,BT_time,Speedup\n")
+    for bs in BATCH_SIZES:
+
+        total_bt_time, total_hf_time = benchmark(
+            args.model_name,
+            args.num_batches,
+            bs,
+            args.use_cuda,
+            args.use_half,
+        )
+
+        speedup = total_hf_time / total_bt_time
+
+        output_file.write(
+            "{},{},{},{},{},{},{}\n".format(
+                args.num_batches,
+                bs,
+                args.use_cuda,
+                args.use_half,
+                total_hf_time,
+                total_bt_time,
+                speedup,
+            )
+        )
+    output_file.close()

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -25,6 +25,7 @@ from testing_bettertransformer_utils import BetterTransformersTestMixin
 ALL_AUDIO_MODELS_TO_TEST = [
     "openai/whisper-tiny",
     "patrickvonplaten/wav2vec2_tiny_random",
+    "facebook/hubert-base-ls960",
 ]
 
 
@@ -52,7 +53,6 @@ class BetterTransformersWhisperTest(BetterTransformersTestMixin, unittest.TestCa
 
 
 class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase):
-    r""" """
     all_models_to_test = ALL_AUDIO_MODELS_TO_TEST[1:]
 
     def prepare_inputs_for_class(self, model_id):

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+import torch
+from transformers import AutoFeatureExtractor
+
+from testing_bettertransformer_utils import BetterTransformersTestMixin
+
+
+ALL_AUDIO_MODELS_TO_TEST = [
+    "openai/whisper-tiny",
+]
+
+
+class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase):
+    r""" """
+    all_models_to_test = ALL_AUDIO_MODELS_TO_TEST
+
+    def _generate_random_audio_data(self):
+        np.random.seed(10)
+        t = np.linspace(0, 5.0, int(5.0 * 22050), endpoint=False)
+        # generate pure sine wave at 220 Hz
+        audio_data = 0.5 * np.sin(2 * np.pi * 220 * t)
+        return audio_data
+
+    def prepare_inputs_for_class(self, model_id):
+        input_audio = self._generate_random_audio_data()
+
+        feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)
+
+        input_dict = {
+            "input_features": feature_extractor(input_audio, return_tensors="pt").input_features,
+            "decoder_input_ids": torch.LongTensor([0]),
+        }
+        return input_dict

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -16,19 +16,21 @@ import unittest
 
 import numpy as np
 import torch
-from transformers import AutoFeatureExtractor
+from transformers import AutoFeatureExtractor, AutoModel, AutoProcessor
 
+from optimum.bettertransformer import BetterTransformer
 from testing_bettertransformer_utils import BetterTransformersTestMixin
 
 
 ALL_AUDIO_MODELS_TO_TEST = [
     "openai/whisper-tiny",
+    "patrickvonplaten/wav2vec2_tiny_random",
 ]
 
 
-class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase):
+class BetterTransformersWhisperTest(BetterTransformersTestMixin, unittest.TestCase):
     r""" """
-    all_models_to_test = ALL_AUDIO_MODELS_TO_TEST
+    all_models_to_test = [ALL_AUDIO_MODELS_TO_TEST[0]]
 
     def _generate_random_audio_data(self):
         np.random.seed(10)
@@ -47,3 +49,95 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
             "decoder_input_ids": torch.LongTensor([0]),
         }
         return input_dict
+
+
+class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase):
+    r""" """
+    all_models_to_test = ALL_AUDIO_MODELS_TO_TEST[1:]
+
+    def prepare_inputs_for_class(self, model_id):
+        batch_duration_in_seconds = [1, 3, 2, 6]
+        input_features = [np.random.random(16_000 * s) for s in batch_duration_in_seconds]
+
+        feature_extractor = AutoProcessor.from_pretrained(model_id, return_attention_mask=True)
+
+        input_dict = feature_extractor(input_features, return_tensors="pt", padding=True)
+        return input_dict
+
+    def test_logits(self):
+        r"""
+        This tests if the converted model produces the same logits
+        than the original model.
+        """
+        # The first row of the attention mask needs to be all ones -> check: https://github.com/pytorch/pytorch/blob/19171a21ee8a9cc1a811ac46d3abd975f0b6fc3b/test/test_nn.py#L5283
+
+        for model_to_test in self.all_models_to_test:
+            inputs = self.prepare_inputs_for_class(model_to_test)
+
+            torch.manual_seed(0)
+            hf_random_model = AutoModel.from_pretrained(model_to_test).eval()
+            random_config = hf_random_model.config
+
+            torch.manual_seed(0)
+            converted_model = BetterTransformer.transform(hf_random_model)
+
+            torch.manual_seed(0)
+            hf_random_model = AutoModel.from_pretrained(model_to_test).eval()
+            random_config = hf_random_model.config
+
+            self.assertFalse(
+                hasattr(hf_random_model, "use_bettertransformer"),
+                f"The model {hf_random_model.__class__.__name__} has been converted to a `fast` model by mistake.",
+            )
+
+            with torch.no_grad():
+                r"""
+                Make sure the models are in eval mode! Make also sure that the original model
+                has not been converted to a fast model. The check is done above.
+                """
+                torch.manual_seed(0)
+                hf_hidden_states = hf_random_model(**inputs)[0]
+
+                torch.manual_seed(0)
+                bt_hidden_states = converted_model(**inputs)[0]
+
+                if "gelu_new" in vars(random_config).values():
+                    # Since `gelu_new` is a slightly modified version of `GeLU` we expect a small
+                    # discrepency.
+                    tol = 4e-2
+                else:
+                    tol = 1e-3
+
+                self.assertTrue(
+                    torch.allclose(bt_hidden_states[0][-3:], torch.zeros_like(bt_hidden_states[0][-3:])),
+                    "The BetterTransformers converted model does not give null hidden states on padded tokens",
+                )
+
+                self.assertTrue(
+                    torch.allclose(hf_hidden_states[-1], bt_hidden_states[-1], atol=tol),
+                    "The BetterTransformers Converted model does not produce the same logits as the original model. Failed for the model {}".format(
+                        hf_random_model.__class__.__name__
+                    ),
+                )
+
+    def test_raise_autocast(self):
+        r"""
+        Autocast seems to be incompatible with `Wav2Vec2` and `cpu`, let's skip this
+        test. The test below should be fine to test if the `forward_checker` has been run correctly.
+        """
+        pass
+
+    def test_raise_train(self):
+        r"""
+        A tests that checks if the conversion raises an error if the model is run under
+        `model.train()`.
+        """
+        for model_id in self.all_models_to_test:
+            inputs = self.prepare_inputs_for_class(model_id)
+
+            hf_random_model = AutoModel.from_pretrained(model_id).eval()
+            # Check for training mode
+            with self.assertRaises(ValueError):
+                bt_model = BetterTransformer.transform(hf_random_model)
+                bt_model.train()
+                _ = bt_model(**inputs)

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -30,7 +30,11 @@ ALL_AUDIO_MODELS_TO_TEST = [
 
 
 class BetterTransformersWhisperTest(BetterTransformersTestMixin, unittest.TestCase):
-    r""" """
+    r"""
+    Testing suite for Whisper - tests all the tests defined in `BetterTransformersTestMixin`
+    Since `Whisper` uses slightly different inputs than other audio models, it is preferrable
+    to define its own testing class.
+    """
     all_models_to_test = [ALL_AUDIO_MODELS_TO_TEST[0]]
 
     def _generate_random_audio_data(self):
@@ -53,6 +57,9 @@ class BetterTransformersWhisperTest(BetterTransformersTestMixin, unittest.TestCa
 
 
 class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase):
+    r"""
+    Testing suite for Audio models - tests all the tests defined in `BetterTransformersTestMixin`
+    """
     all_models_to_test = ALL_AUDIO_MODELS_TO_TEST[1:]
 
     def prepare_inputs_for_class(self, model_id):
@@ -119,13 +126,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
                         hf_random_model.__class__.__name__
                     ),
                 )
-
-    def test_raise_autocast(self):
-        r"""
-        Autocast seems to be incompatible with `Wav2Vec2` and `cpu`, let's skip this
-        test. The test below should be fine to test if the `forward_checker` has been run correctly.
-        """
-        pass
 
     def test_raise_train(self):
         r"""

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -25,7 +25,7 @@ from testing_bettertransformer_utils import BetterTransformersTestMixin
 ALL_AUDIO_MODELS_TO_TEST = [
     "openai/whisper-tiny",
     "patrickvonplaten/wav2vec2_tiny_random",
-    "facebook/hubert-base-ls960",
+    "ybelkada/hubert-tiny-random",
 ]
 
 

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
-import tempfile
 import timeit
 import unittest
 
 import torch
 import transformers
-from transformers import AutoModel, AutoModelForMaskedLM, AutoTokenizer, pipeline
+from transformers import AutoModel
 
 from optimum.bettertransformer import BETTER_TRANFORMER_LAYERS_MAPPING_DICT, BetterTransformer
 from optimum.utils import is_accelerate_available
@@ -33,6 +32,9 @@ from optimum.utils.testing_utils import (
 
 if is_accelerate_available():
     from accelerate import init_empty_weights
+
+from testing_bettertransformer_utils import BetterTransformersTestMixin
+
 
 ALL_ENCODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-DistilBertModel",
@@ -56,22 +58,34 @@ ALL_AUDIO_MODELS_TO_TEST = [
 ]
 
 
-class BetterTransformersTest(unittest.TestCase):
+class BetterTransformersEncoderTest(BetterTransformersTestMixin, unittest.TestCase):
     r"""
     Full testing suite of the `BetterTransformers` integration into Hugging Face
     `transformers` ecosystem. Check the docstring of each test to understand the
     purpose of each test. Basically we test:
-
     - if the conversion dictionnary is consistent, ie if the converted model exists
     in HuggingFace `transformers` library.
     - if the converted model produces the same logits as the original model.
     - if the converted model is faster than the original model.
     """
+    all_models_to_test = ALL_ENCODER_MODELS_TO_TEST
 
     def tearDown(self):
         gc.collect()
 
+    def prepare_inputs_for_class(self, model_id=None):
+        input_dict = {
+            "input_ids": torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]]),
+            "attention_mask": torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]]),
+        }
+        return input_dict
+
     def _loop_all_classes(self):
+        r"""
+        An utility function to automatically loop over all classes to test.
+        this is a generator that will generate random config class for each
+        model to test.
+        """
         for layer_class in BETTER_TRANFORMER_LAYERS_MAPPING_DICT.keys():
             if layer_class == "TransformerBlock":
                 # Hardcode it for distilbert - see https://github.com/huggingface/transformers/pull/19966
@@ -94,10 +108,6 @@ class BetterTransformersTest(unittest.TestCase):
 
         ALL_SUPPORTED_HF_CLASSES = convert_to_hf_classes(BETTER_TRANFORMER_LAYERS_MAPPING_DICT)
         self.assertEqual(len(ALL_SUPPORTED_HF_CLASSES.keys()), len(BETTER_TRANFORMER_LAYERS_MAPPING_DICT.keys()))
-        self.assertEqual(
-            len(BETTER_TRANFORMER_LAYERS_MAPPING_DICT.keys()),
-            len(ALL_ENCODER_MODELS_TO_TEST) + len(ALL_AUDIO_MODELS_TO_TEST),
-        )
 
     @unittest.skipIf(not is_accelerate_available(), "Skipping the test since `accelerate` is not available...")
     @init_empty_weights()
@@ -134,50 +144,6 @@ class BetterTransformersTest(unittest.TestCase):
             self.assertTrue(isinstance(converted_model, ALL_SUPPORTED_HF_CLASSES[layer_class]))
             self.assertTrue(hasattr(converted_model, "generate"))
 
-    def test_logits(self):
-        r"""
-        This tests if the converted model produces the same logits
-        than the original model.
-        """
-        # The first row of the attention mask needs to be all ones -> check: https://github.com/pytorch/pytorch/blob/19171a21ee8a9cc1a811ac46d3abd975f0b6fc3b/test/test_nn.py#L5283
-        inputs_ids = torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
-        attention_mask = torch.Tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]])
-
-        for model_to_test in ALL_ENCODER_MODELS_TO_TEST:
-
-            # hf_random_model = AutoModel.from_config(random_config()).eval()
-            hf_random_model = AutoModel.from_pretrained(model_to_test).eval()
-            random_config = hf_random_model.config
-
-            converted_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
-
-            self.assertFalse(
-                hasattr(hf_random_model, "use_bettertransformer"),
-                f"The model {hf_random_model.__class__.__name__} has been converted to a `fast` model by mistake.",
-            )
-
-            with torch.no_grad():
-                r"""
-                Make sure the models are in eval mode! Make also sure that the original model
-                has not been converted to a fast model. The check is done above.
-                """
-                hf_hidden_states = hf_random_model(inputs_ids, attention_mask=attention_mask)[0]
-                bt_hidden_states = converted_model(inputs_ids, attention_mask=attention_mask)[0]
-
-                if "gelu_new" in vars(random_config).values():
-                    # Since `gelu_new` is a slightly modified version of `GeLU` we expect a small
-                    # discrepency.
-                    tol = 4e-2
-                else:
-                    tol = 1e-3
-
-                self.assertTrue(
-                    torch.allclose(hf_hidden_states[:, :3, :], bt_hidden_states[:, :3, :], atol=tol),
-                    "The BetterTransformers Converted model does not produce the same logits as the original model. Failed for the model {}".format(
-                        hf_random_model.__class__.__name__
-                    ),
-                )
-
     def test_raise_pos_emb(self):
         r"""
         Test if the converion properly raises an error if the model has an activate function that is
@@ -190,16 +156,6 @@ class BetterTransformersTest(unittest.TestCase):
             hf_model = AutoModel.from_config(random_config).eval()
             _ = BetterTransformer.transform(hf_model, keep_original_model=False)
 
-    def test_raise_on_save(self):
-        r"""
-        Test if the converion properly raises an error if someone tries to save the model using `save_pretrained`.
-        """
-        for model_id in ALL_ENCODER_MODELS_TO_TEST:
-            with self.assertWarns(UserWarning), tempfile.TemporaryDirectory() as tmpdirname:
-                hf_model = AutoModel.from_pretrained(model_id).eval()
-                bt_model = BetterTransformer.transform(hf_model, keep_original_model=False)
-                bt_model.save_pretrained(tmpdirname)
-
     def test_raise_activation_fun(self):
         r"""
         A tests that checks if the conversion raises an error if the model contains an activation function
@@ -211,38 +167,6 @@ class BetterTransformersTest(unittest.TestCase):
             hf_random_model = AutoModel.from_config(hf_random_config).eval()
             with self.assertRaises(ValueError):
                 _ = BetterTransformer.transform(hf_random_model, keep_original_model=True)
-
-    def test_raise_autocast(self):
-        r"""
-        A tests that checks if the conversion raises an error if the model is run under
-        `torch.cuda.amp.autocast`.
-        """
-        inputs_ids = torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
-        attention_mask = torch.Tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]])
-
-        for model_id in ALL_ENCODER_MODELS_TO_TEST:
-            hf_random_model = AutoModel.from_pretrained(model_id).eval()
-
-            # Check for the autocast on CPU
-            with self.assertRaises(ValueError), torch.amp.autocast("cpu"):
-                bt_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
-                _ = bt_model(inputs_ids, attention_mask=attention_mask)
-
-    def test_raise_train(self):
-        r"""
-        A tests that checks if the conversion raises an error if the model is run under
-        `model.train()`.
-        """
-        inputs_ids = torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
-        attention_mask = torch.Tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]])
-
-        for model_id in ALL_ENCODER_MODELS_TO_TEST:
-            hf_random_model = AutoModel.from_pretrained(model_id).eval()
-            # Check for training mode
-            with self.assertRaises(ValueError):
-                bt_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
-                bt_model.train()
-                _ = bt_model(inputs_ids, attention_mask=attention_mask)
 
     @unittest.skipIf(not is_torch_greater_than_113(), "the test needs Pytorch >= 1.13.0")
     @torch.no_grad()
@@ -306,7 +230,6 @@ class BetterTransformersTest(unittest.TestCase):
         r"""
         This tests if a model loaded with `accelerate` will be successfully converted
         into its BetterTransformers format.
-
         If this works for roberta, it should work for all other models too.
         """
 

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -26,11 +26,14 @@ ALL_AUDIO_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-YolosModel",
     "hf-internal-testing/tiny-random-ViTMAEModel",
     "hf-internal-testing/tiny-random-ViTMSNModel",
+    "hf-internal-testing/tiny-random-deit",
 ]
 
 
 class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCase):
-    r""" """
+    r"""
+    Testing suite for Vision Models - tests all the tests defined in `BetterTransformersTestMixin`
+    """
     all_models_to_test = ALL_AUDIO_MODELS_TO_TEST
 
     def prepare_inputs_for_class(self, model_id=None):

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from PIL import Image
+from transformers import AutoFeatureExtractor
+
+import requests
+from testing_bettertransformer_utils import BetterTransformersTestMixin
+
+
+ALL_AUDIO_MODELS_TO_TEST = [
+    "hf-internal-testing/tiny-random-ViTModel",
+    "hf-internal-testing/tiny-random-YolosModel",
+    "hf-internal-testing/tiny-random-ViTMAEModel",
+    "hf-internal-testing/tiny-random-ViTMSNModel",
+]
+
+
+class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCase):
+    r""" """
+    all_models_to_test = ALL_AUDIO_MODELS_TO_TEST
+
+    def prepare_inputs_for_class(self, model_id=None):
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+
+        # Use the same feature extractor for everyone
+        feature_extractor = AutoFeatureExtractor.from_pretrained("hf-internal-testing/tiny-random-ViTModel")
+        inputs = feature_extractor(images=image, return_tensors="pt")
+        return inputs

--- a/tests/bettertransformer/testing_bettertransformer_utils.py
+++ b/tests/bettertransformer/testing_bettertransformer_utils.py
@@ -1,0 +1,154 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tempfile
+import unittest
+
+import torch
+from transformers import AutoModel
+
+from optimum.bettertransformer import BetterTransformer
+
+
+class BetterTransformersTestMixin(unittest.TestCase):
+    r"""
+    `BetterTransformersTestMixin` to wrap necessary functions for testing `BetterTransformer`
+    integration. This includes the following tests:
+        - `test_logits`: This tests if the converted model produces the same logits
+        than the original model.
+        - `test_raise_on_save`: Test if the converion properly raises an error if someone tries to save the model using `save_pretrained`.
+        - `test_raise_autocast`: A tests that checks if the conversion raises an error if the model is run under
+        `torch.cuda.amp.autocast`.
+        - `test_raise_train`: A tests that checks if the conversion raises an error if the model is run in training mode.
+    """
+    all_models_to_test = []
+
+    def prepare_inputs_for_class(self):
+        raise NotImplementedError
+
+    def test_logits(self):
+        r"""
+        This tests if the converted model produces the same logits
+        than the original model.
+        """
+        # The first row of the attention mask needs to be all ones -> check: https://github.com/pytorch/pytorch/blob/19171a21ee8a9cc1a811ac46d3abd975f0b6fc3b/test/test_nn.py#L5283
+
+        for model_to_test in self.all_models_to_test:
+            inputs = self.prepare_inputs_for_class(model_to_test)
+
+            torch.manual_seed(0)
+            hf_random_model = AutoModel.from_pretrained(model_to_test).eval()
+            random_config = hf_random_model.config
+
+            torch.manual_seed(0)
+            converted_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
+
+            self.assertFalse(
+                hasattr(hf_random_model, "use_bettertransformer"),
+                f"The model {hf_random_model.__class__.__name__} has been converted to a `fast` model by mistake.",
+            )
+
+            with torch.no_grad():
+                r"""
+                Make sure the models are in eval mode! Make also sure that the original model
+                has not been converted to a fast model. The check is done above.
+                """
+                torch.manual_seed(0)
+                hf_hidden_states = hf_random_model(**inputs)[0]
+
+                torch.manual_seed(0)
+                bt_hidden_states = converted_model(**inputs)[0]
+
+                if "gelu_new" in vars(random_config).values():
+                    # Since `gelu_new` is a slightly modified version of `GeLU` we expect a small
+                    # discrepency.
+                    tol = 4e-2
+                else:
+                    tol = 1e-3
+
+                self.assertTrue(
+                    torch.allclose(hf_hidden_states[:, :3, :], bt_hidden_states[:, :3, :], atol=tol),
+                    "The BetterTransformers Converted model does not produce the same logits as the original model. Failed for the model {}".format(
+                        hf_random_model.__class__.__name__
+                    ),
+                )
+
+    def test_raise_on_save(self):
+        r"""
+        Test if the converion properly raises an error if someone tries to save the model using `save_pretrained`.
+        """
+        for model_id in self.all_models_to_test:
+            with self.assertWarns(UserWarning), tempfile.TemporaryDirectory() as tmpdirname:
+                hf_model = AutoModel.from_pretrained(model_id).eval()
+                bt_model = BetterTransformer.transform(hf_model, keep_original_model=False)
+                bt_model.save_pretrained(tmpdirname)
+
+    def test_raise_autocast(self):
+        r"""
+        A tests that checks if the conversion raises an error if the model is run under
+        `torch.cuda.amp.autocast`.
+        """
+
+        for model_id in self.all_models_to_test:
+            inputs = self.prepare_inputs_for_class(model_id)
+            hf_random_model = AutoModel.from_pretrained(model_id).eval()
+
+            # Check for the autocast on CPU
+            with self.assertRaises(ValueError), torch.amp.autocast("cpu"):
+                bt_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
+                _ = bt_model(**inputs)
+
+    def test_raise_train(self):
+        r"""
+        A tests that checks if the conversion raises an error if the model is run under
+        `model.train()`.
+        """
+        for model_id in self.all_models_to_test:
+            inputs = self.prepare_inputs_for_class(model_id)
+
+            hf_random_model = AutoModel.from_pretrained(model_id).eval()
+            # Check for training mode
+            with self.assertRaises(ValueError):
+                bt_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
+                bt_model.train()
+                _ = bt_model(**inputs)
+
+
+def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):
+    r"""
+    Utility function to generate a batch of random sequences, together with their
+    attention mask and lengths.
+    Copied from: https://github.com/HamidShojanazeri/transformers/blob/ddf0299a13e7c4f54459a0731abd80204a1078f5/examples/pytorch/benchmarking/benchmark_bettertransformer.py#L149
+    """
+    mean_tensor = torch.Tensor([avg_seqlen]).expand(batch_size)
+    stdev_tensor = torch.Tensor([seqlen_stdev]).expand(batch_size)
+    lengths = torch.normal(mean_tensor, stdev_tensor).to(torch.int)
+    lengths = torch.clamp(lengths, min=0, max=max_sequence_length)
+    tokens = torch.full(
+        (batch_size, max_sequence_length),
+        pad_idx,
+    )
+    for i in range(batch_size):
+        tokens[i, : lengths[i]] = torch.randint(
+            pad_idx + 1,
+            vocab_size - 1,
+            size=(lengths[i],),
+        )
+    mask = torch.full(
+        (batch_size, max_sequence_length),
+        0,
+    )
+    for i in range(batch_size):
+        mask[i, : lengths[i]] = 1
+    return tokens, lengths, mask

--- a/tests/bettertransformer/testing_bettertransformer_utils.py
+++ b/tests/bettertransformer/testing_bettertransformer_utils.py
@@ -124,6 +124,24 @@ class BetterTransformersTestMixin(unittest.TestCase):
                 bt_model.train()
                 _ = bt_model(**inputs)
 
+    def test_conversion(self):
+        r"""
+        This tests if the conversion of a slow model to its BetterTransformer version using fastpath
+        has been successfull.
+        """
+
+        for model_id in self.all_models_to_test:
+            hf_random_model = AutoModel.from_pretrained(model_id)
+            converted_model = BetterTransformer.transform(hf_random_model)
+
+            self.assertTrue(
+                hasattr(converted_model, "use_bettertransformer"),
+                f"The model {converted_model.__class__.__name__} is not a fast model.",
+            )
+
+            self.assertTrue(isinstance(converted_model, hf_random_model.__class__))
+            self.assertTrue(hasattr(converted_model, "generate"))
+
 
 def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):
     r"""

--- a/tests/bettertransformer/testing_bettertransformer_utils.py
+++ b/tests/bettertransformer/testing_bettertransformer_utils.py
@@ -21,7 +21,7 @@ from transformers import AutoModel
 from optimum.bettertransformer import BetterTransformer
 
 
-class BetterTransformersTestMixin(unittest.TestCase):
+class BetterTransformersTestMixin:
     r"""
     `BetterTransformersTestMixin` to wrap necessary functions for testing `BetterTransformer`
     integration. This includes the following tests:


### PR DESCRIPTION
# What does this PR do?

Adds `ViT` family to BetterTransformer integration
Adds also `Wav2vec2` family to BT integration

Replaces #469 

cc @fxmarty @michaelbenayoun 
