### PR TITLE
Added normalized config ORTEncoder

### DIFF
--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -565,6 +565,7 @@ class ORTEncoder:
         self._device = device
         self.use_io_binding = use_io_binding
         self.main_input_name = "input_ids"
+        self.normalized_config = ORTConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
         self.input_names = {input_key.name: idx for idx, input_key in enumerate(self.session.get_inputs())}
         self.output_names = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None


### PR DESCRIPTION
# What does this PR do?

Add missing normalised config in the `ORTEncoder` class.

The issue leads to error in when exporting model using the `ORTModelForSeq2SeqLM` class.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

