### PR TITLE
Re-order the task manager doc

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -61,11 +61,11 @@
 - sections:
   - local: exporters/overview
     title: Overview
+  - local: exporters/task_manager
+    title: The TasksManager
   - sections:
     - local: exporters/onnx/overview
       title: Overview
-    - local: exporters/task_manager
-      title: The TasksManager
     - sections:
       - local: exporters/onnx/usage_guides/export_a_model
         title: Export a model to ONNX


### PR DESCRIPTION
# What does this PR do?

The "The Tasks Manager" section was not in the right place in the index.