### PR TITLE
ORTModel uses optimum.exporters.onnx

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -367,8 +367,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         return {
             "input_ids": {0: "batch_size", 1: "encoder_sequence_length"},
             "attention_mask": {0: "batch_size", 1: "encoder_sequence_length"},
-            "decoder_input_ids": {0: "batch_size", 1: "decoder_sequence_length"},
-            "decoder_attention_mask": {0: "batch_size", 1: "decoder_sequence_length"},
         }
 
     @property

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -725,7 +725,9 @@ class TasksManager:
             raise RuntimeError("Cannot infer the task from a local directory yet, please specify the task manually.")
         else:
             if subfolder:
-                raise RuntimeError("Cannot infer the task from a model repo with a subfolder yet, please specify the task manually.")
+                raise RuntimeError(
+                    "Cannot infer the task from a model repo with a subfolder yet, please specify the task manually."
+                )
             model_info = huggingface_hub.model_info(model_name_or_path, revision=revision)
             transformers_info = model_info.transformersInfo
             if transformers_info is None or transformers_info.get("auto_model") is None:
@@ -744,7 +746,13 @@ class TasksManager:
 
     @staticmethod
     def get_model_from_task(
-        task: str, model: str, subfolder: str = "", revision: Optional[str] = None, framework: Optional[str] = None, cache_dir: Optional[str] = None, **model_kwargs
+        task: str,
+        model: str,
+        subfolder: str = "",
+        revision: Optional[str] = None,
+        framework: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        **model_kwargs
     ) -> Union["PreTrainedModel", "TFPreTrainedModel"]:
         """
         Retrieves a model from its name and the task to be enabled.
@@ -775,12 +783,7 @@ class TasksManager:
             task = TasksManager.infer_task_from_model(model, subfolder=subfolder, revision=revision)
         model_class = TasksManager.get_model_class_for_task(task, framework)
         try:
-            kwargs = {
-                "subfolder": subfolder,
-                "revision": revision,
-                "cache_dir": cache_dir,
-                **model_kwargs
-            }
+            kwargs = {"subfolder": subfolder, "revision": revision, "cache_dir": cache_dir, **model_kwargs}
             model = model_class.from_pretrained(model, **kwargs)
         except OSError:
             if framework == "pt":

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -1,4 +1,19 @@
-import json
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Base class for optimized model inference wrapping."""
+
 import logging
 import os
 import subprocess
@@ -8,8 +23,7 @@ from typing import Optional, Union
 
 from transformers import AutoConfig, add_start_docstrings
 
-import requests
-from huggingface_hub import HfApi, HfFolder, hf_hub_download
+from huggingface_hub import HfApi, HfFolder
 
 from .utils import CONFIG_NAME
 
@@ -19,7 +33,7 @@ logger = logging.getLogger(__name__)
 FROM_PRETRAINED_START_DOCSTRING = r"""
     Instantiate a pretrained model from a pre-trained model configuration.
 
-    Arguments:
+    Args:
         model_id (`Union[str, Path]`):
             Can be either:
                 - A string, the *model id* of a pretrained model hosted inside a model repo on huggingface.co.
@@ -32,17 +46,17 @@ FROM_PRETRAINED_START_DOCSTRING = r"""
         force_download (`bool`, *optional*, defaults to `True`):
             Whether or not to force the (re-)download of the model weights and configuration files, overriding the
             cached versions if they exist.
-        use_auth_token (`str`, *optional*, defaults to `None`):
+        use_auth_token (`Optional[str]`, *optional*):
             The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
             when running `transformers-cli login` (stored in `~/.huggingface`).
-        cache_dir (`str`, *optional*, defaults to `None`):
+        cache_dir (`Optional[str]`, *optional*):
             Path to a directory in which a downloaded pretrained model configuration should be cached if the
             standard cache should not be used.
-        local_files_only(`bool`, *optional*, defaults to `False`):
-            Whether or not to only look at local files (i.e., do not try to download the model).
         subfolder (`str`, *optional*, defaults to `""`):
             In case the relevant files are located inside a subfolder of the model repo either locally or on huggingface.co, you can
             specify the folder name here.
+        local_files_only(`bool`, *optional*, defaults to `False`):
+            Whether or not to only look at local files (i.e., do not try to download the model).
 """
 
 
@@ -51,7 +65,7 @@ class OptimizedModel(ABC):
     load_tf_weights = None
     base_model_prefix = "optimized_model"
 
-    def __init__(self, model=None, config=None, **kwargs):
+    def __init__(self, model=None, config=None):
         super().__init__()
         self.model = model
         self.config = config
@@ -64,7 +78,7 @@ class OptimizedModel(ABC):
         """
         Forward pass of the model, needs to be overwritten.
         """
-        pass
+        raise NotImplementedError
 
     def save_pretrained(
         self,
@@ -73,10 +87,11 @@ class OptimizedModel(ABC):
         **kwargs,
     ):
         """
-        Save a model and its configuration file to a directory, so that it can be re-loaded using the
-        [`~onnxruntime.modeling_ort.OptimizedModel.from_pretrained`] class method.
-        Arguments:
-            save_directory (`str` or `os.PathLike`):
+        Saves a model and its configuration file to a directory, so that it can be re-loaded using the
+        [`from_pretrained`] class method.
+
+        Args:
+            save_directory (`Union[str, os.PathLike]`):
                 Directory to which to save. Will be created if it doesn't exist.
             push_to_hub (`bool`, *optional*, defaults to `False`):
                 Whether or not to push your model to the Hugging Face model hub after saving it.
@@ -95,10 +110,7 @@ class OptimizedModel(ABC):
 
         os.makedirs(save_directory, exist_ok=True)
 
-        # Save the config
         self.config.save_pretrained(save_directory)
-
-        # saving model weights/files
         self._save_pretrained(save_directory, **kwargs)
 
         if push_to_hub:
@@ -107,10 +119,10 @@ class OptimizedModel(ABC):
     @abstractmethod
     def _save_pretrained(self, save_directory, **kwargs):
         """
-        Save a model weights into a directory, so that it can be re-loaded using the
-        [`~onnxruntime.modeling_ort.OptimizedModel.from_pretrained`] class method.
+        Saves a model weights into a directory, so that it can be re-loaded using the
+        [`from_pretrained`] class method.
         """
-        pass
+        raise NotImplementedError
 
     def push_to_hub(
         self,
@@ -156,7 +168,7 @@ class OptimizedModel(ABC):
 
     def git_config_username_and_email(self, git_user: str = None, git_email: str = None):
         """
-        Set git user name and email (only in the current repo)
+        Sets git user name and email (only in the current repo)
         """
         try:
             if git_user is not None:
@@ -182,11 +194,11 @@ class OptimizedModel(ABC):
     def _from_pretrained(
         cls,
         model_id: Union[str, os.PathLike],
-        use_auth_token: Optional[Union[bool, str, None]] = None,
-        revision: Optional[Union[str, None]] = None,
+        use_auth_token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
-        subfolder: Optional[str] = "",
+        subfolder: str = "",
         **kwargs,
     ):
         """Overwrite this method in subclass to define how to load your model from pretrained"""
@@ -201,8 +213,8 @@ class OptimizedModel(ABC):
         force_download: bool = False,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
-        subfolder: Optional[str] = "",
-        **model_kwargs,
+        subfolder: str = "",
+        **kwargs,
     ):
         """
         Returns:
@@ -231,7 +243,7 @@ class OptimizedModel(ABC):
                     cache_dir=cache_dir,
                     force_download=force_download,
                     use_auth_token=use_auth_token,
-                    subfolder=subfolder,
+                    subfoler=subfolder,
                 )
             except OSError as e:
                 # if config not found in subfolder, search for it at the top level
@@ -250,7 +262,7 @@ class OptimizedModel(ABC):
                     raise OSError(e)
 
         if config is not None:
-            model_kwargs.update({"config": config})
+            kwargs["config"] = config
 
         from_pretrained_method = cls._from_transformers if from_transformers else cls._from_pretrained
         return from_pretrained_method(
@@ -260,18 +272,18 @@ class OptimizedModel(ABC):
             force_download=force_download,
             use_auth_token=use_auth_token,
             subfolder=subfolder,
-            **model_kwargs,
+            **kwargs,
         )
 
     @classmethod
     def _from_transformers(
         cls,
         model_id: Union[str, os.PathLike],
-        use_auth_token: Optional[Union[bool, str, None]] = None,
-        revision: Optional[Union[str, None]] = None,
+        use_auth_token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
-        subfolder: Optional[str] = "",
+        subfolder: str = "",
         **kwargs,
     ):
         """Overwrite this method in subclass to define how to load your model from vanilla transformers model"""

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -236,12 +236,12 @@ class OptimizedModel(ABC):
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],
+        config: "PretrainedConfig",
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
         subfolder: str = "",
-        config: Optional["PretrainedConfig"] = None,
         local_files_only: bool = False,
         **kwargs,
     ) -> "OptimizedModel":
@@ -252,12 +252,12 @@ class OptimizedModel(ABC):
     def _from_transformers(
         cls,
         model_id: Union[str, Path],
+        config: "PretrainedConfig",
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
         subfolder: str = "",
-        config: Optional["PretrainedConfig"] = None,
         local_files_only: bool = False,
         **kwargs,
     ) -> "OptimizedModel":

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -252,26 +252,16 @@ class OptimizedModel(ABC):
         if config is not None:
             model_kwargs.update({"config": config})
 
-        if from_transformers:
-            return cls._from_transformers(
-                model_id=model_id,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                use_auth_token=use_auth_token,
-                subfolder=subfolder,
-                **model_kwargs,
-            )
-        else:
-            return cls._from_pretrained(
-                model_id=model_id,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                use_auth_token=use_auth_token,
-                subfolder=subfolder,
-                **model_kwargs,
-            )
+        from_pretrained_method = cls._from_transformers if from_transformers else cls._from_pretrained
+        return from_pretrained_method(
+            model_id=model_id,
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            use_auth_token=use_auth_token,
+            subfolder=subfolder,
+            **model_kwargs,
+        )
 
     @classmethod
     def _from_transformers(

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -29,7 +29,7 @@ from .utils import CONFIG_NAME
 
 
 if TYPE_CHECKING:
-    from transformers import PretrainedConfig
+    from transformers import PretrainedConfig, PreTrainedModel, TFPreTrainedModel
 
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class OptimizedModel(ABC):
     load_tf_weights = None
     base_model_prefix = "optimized_model"
 
-    def __init__(self, model=None, config=None):
+    def __init__(self, model: Union["PreTrainedModel", "TFPreTrainedModel"], config: "PretrainedConfig"):
         super().__init__()
         self.model = model
         self.config = config
@@ -321,12 +321,12 @@ class OptimizedModel(ABC):
         from_pretrained_method = cls._from_transformers if from_transformers else cls._from_pretrained
         return from_pretrained_method(
             model_id=model_id,
+            config=config,
             revision=revision,
             cache_dir=cache_dir,
             force_download=force_download,
             use_auth_token=use_auth_token,
             subfolder=subfolder,
-            config=config,
             local_files_only=local_files_only,
             **kwargs,
         )

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -213,7 +213,7 @@ class OptimizedModel(ABC):
                 cache_dir=cache_dir,
                 force_download=force_download,
                 use_auth_token=use_auth_token,
-                subfoler=subfolder,
+                subfolder=subfolder,
             )
         except OSError as e:
             # if config not found in subfolder, search for it at the top level

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -27,6 +27,7 @@ from huggingface_hub import HfApi, HfFolder
 
 from .utils import CONFIG_NAME
 
+
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
@@ -234,7 +235,7 @@ class OptimizedModel(ABC):
     @classmethod
     def _from_pretrained(
         cls,
-        model_id: Union[str, os.PathLike],
+        model_id: Union[str, Path],
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
@@ -243,14 +244,14 @@ class OptimizedModel(ABC):
         config: Optional["PretrainedConfig"] = None,
         local_files_only: bool = False,
         **kwargs,
-    ):
+    ) -> "OptimizedModel":
         """Overwrite this method in subclass to define how to load your model from pretrained"""
         raise NotImplementedError("Overwrite this method in subclass to define how to load your model from pretrained")
 
     @classmethod
     def _from_transformers(
         cls,
-        model_id: Union[str, os.PathLike],
+        model_id: Union[str, Path],
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
@@ -259,7 +260,7 @@ class OptimizedModel(ABC):
         config: Optional["PretrainedConfig"] = None,
         local_files_only: bool = False,
         **kwargs,
-    ):
+    ) -> "OptimizedModel":
         """Overwrite this method in subclass to define how to load your model from vanilla transformers model"""
         raise NotImplementedError(
             "Overwrite this method in subclass to define how to load your model from vanilla transformers model"
@@ -278,7 +279,7 @@ class OptimizedModel(ABC):
         config: Union["PretrainedConfig"] = None,
         local_files_only: bool = False,
         **kwargs,
-    ):
+    ) -> "OptimizedModel":
         """
         Returns:
             `OptimizedModel`: The loaded optimized model.
@@ -299,9 +300,23 @@ class OptimizedModel(ABC):
                 else:
                     raise OSError(f"config.json not found in {model_id} local folder")
             else:
-                config = cls._load_config(model_id, revision=revision, cache_dir=cache_dir, use_auth_token=use_auth_token, force_download=force_download, subfolder=subfolder)
+                config = cls._load_config(
+                    model_id,
+                    revision=revision,
+                    cache_dir=cache_dir,
+                    use_auth_token=use_auth_token,
+                    force_download=force_download,
+                    subfolder=subfolder,
+                )
         elif isinstance(config, (str, os.PathLike)):
-            config = cls._load_config(config, revision=revision, cache_dir=cache_dir, use_auth_token=use_auth_token, force_download=force_download, subfolder=subfolder)
+            config = cls._load_config(
+                config,
+                revision=revision,
+                cache_dir=cache_dir,
+                use_auth_token=use_auth_token,
+                force_download=force_download,
+                subfolder=subfolder,
+            )
 
         from_pretrained_method = cls._from_transformers if from_transformers else cls._from_pretrained
         return from_pretrained_method(
@@ -312,5 +327,6 @@ class OptimizedModel(ABC):
             use_auth_token=use_auth_token,
             subfolder=subfolder,
             config=config,
+            local_files_only=local_files_only,
             **kwargs,
         )

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -270,13 +270,13 @@ class ORTModel(OptimizedModel):
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],
+        config: "PretrainedConfig",
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
         file_name: str = ONNX_WEIGHTS_NAME,
         subfolder: str = "",
-        config: Optional["PretrainedConfig"] = None,
         local_files_only: bool = False,
         provider: str = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
@@ -315,13 +315,13 @@ class ORTModel(OptimizedModel):
     def _from_transformers(
         cls,
         model_id: str,
+        config: "PretrainedConfig",
         save_dir: Union[str, Path] = default_cache_path,
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
         subfolder: str = "",
-        config: Optional["PretrainedConfig"] = None,
         local_files_only: bool = False,
         provider: str = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
@@ -349,8 +349,6 @@ class ORTModel(OptimizedModel):
             "subfolder": subfolder,
             "revision": revision,
         }
-        if "config" in kwargs:
-            kwargs_to_get_model["config"] = kwargs["config"]
 
         model = TasksManager.get_model_from_task(task, model_id, **kwargs_to_get_model)
         model_type = model.config.model_type.replace("_", "-")

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -229,9 +229,9 @@ class ORTModel(OptimizedModel):
             provider (`str`, *optional*, defaults to `"CPUExecutionProvider"`):
                 ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/
                 for possible providers.
-            session_options (`onnxruntime.SessionOptions`, *optional*):
+            session_options (`Optional[onnxruntime.SessionOptions]`, *optional*):
                 ONNX Runtime session options to use for loading the model.
-            provider_options (`Dict[str, Any]`, *optional*):
+            provider_options (`Optional[Dict[str, Any]]`, *optional*):
                 Provider option dictionary corresponding to the provider used. See available options
                 for each provider: https://onnxruntime.ai/docs/api/c/group___global.html .
         """
@@ -330,7 +330,6 @@ class ORTModel(OptimizedModel):
     ) -> "ORTModel":
         save_dir = Path(save_dir).joinpath(model_id, subfolder)
         save_dir.mkdir(parents=True, exist_ok=True)
-        kwargs["model_save_dir"] = save_dir
 
         # Reads pipeline task from ORTModelForXXX class if available else tries to extract from hub
         if cls.export_feature is not None:
@@ -365,7 +364,7 @@ class ORTModel(OptimizedModel):
             output=save_dir.joinpath(ONNX_WEIGHTS_NAME),
         )
 
-        return cls._from_pretrained(save_dir.as_posix(), **kwargs)
+        return cls._from_pretrained(save_dir.as_posix(), config, **kwargs)
 
     @classmethod
     @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
@@ -388,9 +387,9 @@ class ORTModel(OptimizedModel):
         provider (`str`, *optional*, defaults to `"CPUExecutionProvider"`):
             ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/ for
             possible providers.
-        session_options (`onnxruntime.SessionOptions`, *optional*),:
+        session_options (`Optional[onnxruntime.SessionOptions]`, *optional*),:
             ONNX Runtime session options to use for loading the model.
-        provider_options (`Dict[str, Any]`, *optional*):
+        provider_options (`Optional[Dict[str, Any]]`, *optional*):
             Provider option dictionaries corresponding to the provider used. See available options
             for each provider: https://onnxruntime.ai/docs/api/c/group___global.html .
         kwargs (`Dict[str, Any]`):

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -284,7 +284,12 @@ class ORTModel(OptimizedModel):
         **kwargs,
     ) -> "ORTModel":
         if os.path.isdir(os.path.join(model_id, subfolder)):
-            model = ORTModel.load_model(os.path.join(model_id, subfolder, file_name), **kwargs)
+            model = ORTModel.load_model(
+                os.path.join(model_id, subfolder, file_name),
+                provider=provider,
+                session_options=session_options,
+                provider_options=provider_options,
+            )
             kwargs["model_save_dir"] = Path(model_id).joinpath(subfolder)
             kwargs["latest_model_name"] = file_name
         else:
@@ -298,7 +303,9 @@ class ORTModel(OptimizedModel):
                 force_download=force_download,
                 local_files_only=local_files_only,
             )
-            model = ORTModel.load_model(model_cache_path, **kwargs)
+            model = ORTModel.load_model(
+                model_cache_path, provider=provider, session_options=session_options, provider_options=provider_options
+            )
             kwargs["model_save_dir"] = Path(model_cache_path).parent
             kwargs["latest_model_name"] = Path(model_cache_path).name
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -127,8 +127,8 @@ class ORTModel(OptimizedModel):
     Common attributes:
         - model (`ort.InferenceSession`) -- The ONNX Runtime InferenceSession that is running the model.
         - config ([`~transformers.PretrainedConfig`] -- The configuration of the model.
-        - use_io_binding (`bool`, *optional*, defaults to `True`) -- Whether to use I/O bindings with ONNX Runtime, this
-        can significantly speedup inference depending on the task.
+        - use_io_binding (`bool`, *optional*, defaults to `True`) -- Whether to use I/O bindings with **ONNX Runtime
+        with the CUDAExecutionProvider**, this can significantly speedup inference depending on the task.
         - model_save_dir (`Optional[str]`, *optional*) -- The directory where the model exported to ONNX will be saved.
         By defaults, if the loaded model is local, the directory where the original model will be used. Otherwise, the
         cache directory is used.
@@ -162,7 +162,6 @@ class ORTModel(OptimizedModel):
             )
 
         if "TensorrtExecutionProvider" in self.providers and self.use_io_binding:
-            # TODO: is it an actual check? Like let's say I have multiple providers, how do I know TensorRT is going to be used?
             logger.warning(
                 "There is no need to do IO binding for TensorrtExecutionProvider, `use_io_binding` is set to False."
             )

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -11,12 +11,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+"""ORTModelForXXX classes, allowing to run ONNX Models with ONNX Runtime using the same API as Transformers."""
 
 import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import numpy as np
 import torch
@@ -29,7 +30,6 @@ from transformers import (
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
-    PretrainedConfig,
 )
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, default_cache_path
 from transformers.generation_utils import GenerationMixin
@@ -58,6 +58,10 @@ from .utils import (
     parse_device,
     validate_provider_availability,
 )
+
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
 
 
 logger = logging.getLogger(__name__)
@@ -113,41 +117,63 @@ ONNX_IMAGE_INPUTS_DOCSTRING = r"""
     """,
 )
 class ORTModel(OptimizedModel):
-    base_model_prefix = "onnx_model"
+    """
+    Class attributes:
+        - model_type (`str`, *optional*, defaults to `"onnx_model"`) -- The name of the model type to use when
+        registering the ORTModel classes.
+        - auto_model_class (`Type`, *optional*, defaults to `AutoModel`) -- The "AutoModel" class to represented by the
+        current ORTModel class.
+
+    Common attributes:
+        - model (`ort.InferenceSession`) -- The ONNX Runtime InferenceSession that is running the model.
+        - config ([`~transformers.PretrainedConfig`] -- The configuration of the model.
+        - use_io_binding (`bool`, *optional*, defaults to `True`) -- Whether to use I/O bindings with ONNX Runtime, this
+        can significantly speedup inference depending on the task.
+        - model_save_dir (`Optional[str]`, *optional*) -- The directory where the model exported to ONNX will be saved.
+        By defaults, if the loaded model is local, the directory where the original model will be used. Otherwise, the
+        cache directory is used.
+        - latest_model_name (`str`, *optional*, defaults to `"model.onnx"` -- The name of the last ONNX model file.
+        - providers (`List[str]) -- The list of execution providers available to ONNX Runtime.
+    """
+
+    model_type = "onnx_model"
     auto_model_class = AutoModel
 
     def __init__(
         self,
-        model: ort.InferenceSession = None,
-        config: PretrainedConfig = None,
+        model: ort.InferenceSession,
+        config: "PretrainedConfig",
         use_io_binding: bool = True,
-        **kwargs
+        model_save_dir: Optional[str] = None,
+        latest_model_name: str = "model.onnx",
     ):
         self.model = model
         self.config = config
         self.use_io_binding = use_io_binding
-        self.model_save_dir = kwargs.get("model_save_dir", None)
-        self.latest_model_name = kwargs.get("latest_model_name", "model.onnx")
+        self.model_save_dir = model_save_dir
+        self.latest_model_name = latest_model_name
         self.providers = model.get_providers()
         self._device = get_device_for_provider(self.providers[0])
 
-        if self._device == None:
+        if self._device is None:
             logger.warning(
                 f"ORTModel outputs will be sent to CPU as the device could not be inferred from the execution provider {self.providers[0]}."
                 f" Use `ort_model.to()` to send the outputs to the wanted device."
             )
 
         if "TensorrtExecutionProvider" in self.providers and self.use_io_binding:
+            # TODO: is it an actual check? Like let's say I have multiple providers, how do I know TensorRT is going to be used?
             logger.warning(
-                "There is no need to do IO binding for TensorrtExecutionProvider, `use_io_binding` will be set to False."
+                "There is no need to do IO binding for TensorrtExecutionProvider, `use_io_binding` is set to False."
             )
             self.use_io_binding = False
 
-        # registers the ORTModelForXXX classes into the transformers AutoModel classes
-        # to avoid warnings when create a pipeline https://github.com/huggingface/transformers/blob/cad61b68396a1a387287a8e2e2fef78a25b79383/src/transformers/pipelines/base.py#L863
-        AutoConfig.register(self.base_model_prefix, AutoConfig)
+        # Registers the ORTModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating
+        # a pipeline https://github.com/huggingface/transformers/blob/cad61b68396a1a387287a8e2e2fef78a25b79383/src/transformers/pipelines/base.py#L863
+        AutoConfig.register(self.model_type, AutoConfig)
         self.auto_model_class.register(AutoConfig, self.__class__)
 
+    # TODO: why do we make device a property since we are only access the value, and do not do any check when setting the value?
     @property
     def device(self) -> torch.device:
         """
@@ -164,7 +190,7 @@ class ORTModel(OptimizedModel):
         """
         Changes the ONNX Runtime provider according to the device.
 
-        Arguments:
+        Args:
             device (`torch.device` or `str` or `int`):
                 Device ordinal for CPU/GPU supports. Setting this to -1 will leverage CPU, a positive will run
                 the model on the associated CUDA device id. You can pass native `torch.device` or a `str` too.
@@ -189,31 +215,31 @@ class ORTModel(OptimizedModel):
     @staticmethod
     def load_model(
         path: Union[str, Path],
-        provider: Optional[str] = "CPUExecutionProvider",
+        provider: str = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
-        provider_options: Optional[Dict] = None,
-        **kwargs
-    ):
+        provider_options: Optional[Dict[str, Any]] = None,
+    ) -> ort.InferenceSession:
         """
-        Loads an ONNX Inference session with a given provider. Default provider is `CPUExecutionProvider` to match the default behaviour in PyTorch/TensorFlow/JAX.
+        Loads an ONNX Inference session with a given provider. Default provider is `CPUExecutionProvider` to match the
+        default behaviour in PyTorch/TensorFlow/JAX.
 
-        Arguments:
-            path (`str` or `Path`):
+        Args:
+            path (`Union[str, Path]`):
                 Path of the ONNX model.
-            provider (`str`, *optional*):
+            provider (`str`, *optional*, defaults to `"CPUExecutionProvider"`):
                 ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/
-                for possible providers. Defaults to `CPUExecutionProvider`.
+                for possible providers.
             session_options (`onnxruntime.SessionOptions`, *optional*):
-                ONNX Runtime session options to use for loading the model. Defaults to `None`.
-            provider_options (`Dict`, **optional**):
+                ONNX Runtime session options to use for loading the model.
+            provider_options (`Dict[str, Any]`, *optional*):
                 Provider option dictionary corresponding to the provider used. See available options
-                for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
+                for each provider: https://onnxruntime.ai/docs/api/c/group___global.html .
         """
         validate_provider_availability(provider)  # raise error if the provider is not available
 
         providers = [provider]
         if provider == "TensorrtExecutionProvider":
-            # follow advice in https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#python
+            # Follow advice in https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#python
             providers.append("CUDAExecutionProvider")
 
         # `providers` list must of be of the same length as `provider_options` list
@@ -224,21 +250,20 @@ class ORTModel(OptimizedModel):
             provider_options=None if provider_options is None else [provider_options],
         )
 
-    def _save_pretrained(self, save_directory: Union[str, Path], file_name: Optional[str] = None, **kwargs):
+    def _save_pretrained(self, save_directory: Union[str, Path], file_name: str = ONNX_WEIGHTS_NAME):
         """
         Saves a model and its configuration file to a directory, so that it can be re-loaded using the
-        [`~optimum.onnxruntime.modeling_ort.ORTModel.from_pretrained`] class method. It will always save the latest_model_name.
-        Arguments:
-            save_directory (`str` or `Path`):
-                Directory where to save the model file.
-            file_name(`str`, *optional*):
-                Overwrites the default model file name from `"model.onnx"` to `file_name`. This allows you to save the model with
-                a different name.
-        """
-        model_file_name = file_name if file_name is not None else ONNX_WEIGHTS_NAME
+        [`~optimum.onnxruntime.modeling_ort.ORTModel.from_pretrained`] class method. It will always save the
+        file under model_save_dir/latest_model_name.
 
+        Args:
+            save_directory (`Union[str, Path]`):
+                Directory where to save the model file.
+            file_name (`str`, *optional*, defaults to the value of `optimum.onnxruntime.utils.ONNX_WEIGHTS_NAME`):
+                The filename to use when saving the model.
+        """
         src_path = self.model_save_dir.joinpath(self.latest_model_name)
-        dst_path = Path(save_directory).joinpath(model_file_name)
+        dst_path = Path(save_directory).joinpath(file_name)
         shutil.copyfile(src_path, dst_path)
 
     @classmethod
@@ -250,33 +275,37 @@ class ORTModel(OptimizedModel):
         force_download: bool = False,
         use_auth_token: Optional[str] = None,
         cache_dir: Optional[str] = None,
-        subfolder: Optional[str] = "",
-        provider: Optional[str] = "CPUExecutionProvider",
+        subfolder: str = "",
+        provider: str = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
-        provider_options: Optional[Dict] = None,
+        provider_options: Optional[Dict[str, Any]] = None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """
-        provider (`str`, *optional*):
-            ONNX Runtime providers to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/ for
-            possible providers. Defaults to `CPUExecutionProvider`.
+        provider (`str`, *optional*, defaults to `"CPUExecutionProvider"`):
+            ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/ for
+            possible providers.
         session_options (`onnxruntime.SessionOptions`, *optional*),:
-            ONNX Runtime session options to use for loading the model. Defaults to `None`.
-        provider_options (`Dict`, **optional**):
+            ONNX Runtime session options to use for loading the model.
+        provider_options (`Dict[str, Any]`, *optional*):
             Provider option dictionaries corresponding to the provider used. See available options
-            for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
+            for each provider: https://onnxruntime.ai/docs/api/c/group___global.html .
+        args (`Tuple[Any]`):
+            Will be passed to the underlying model loading methods.
+        kwargs (`Dict[str, Any]`):
+            Will be passed to the underlying model loading methods.
 
         Returns:
             `ORTModel`: The loaded ORTModel model.
         """
         return super().from_pretrained(
             model_id,
-            from_transformers,
-            force_download,
-            use_auth_token,
-            cache_dir,
-            subfolder,
+            from_transformers=from_transformers,
+            force_download=force_download,
+            use_auth_token=use_auth_token,
+            cache_dir=cache_dir,
+            subfolder=subfolder,
             provider=provider,
             session_options=session_options,
             provider_options=provider_options,
@@ -288,22 +317,27 @@ class ORTModel(OptimizedModel):
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],
+        config: Optional["PretrainedConfig"] = None,
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
-        file_name: Optional[str] = None,
-        subfolder: Optional[str] = "",
+        file_name: str = ONNX_WEIGHTS_NAME,
+        subfolder: str = "",
+        local_files_only: bool = False,
         **kwargs,
     ):
         """
         Loads a model and its configuration file from a directory or the HF Hub.
         Implements: https://github.com/huggingface/huggingface_hub/blob/e67de48368bc1843e40afc1cc9d236402b9609ee/src/huggingface_hub/hub_mixin.py#L73
-        Arguments:
+
+        Args:
             model_id (`Union[str, Path]`):
-                Directory from which to load
-            use_auth_token (`Union[bool, str]`):
-                Is needed to load models from a private repository
+                Directory from which to load.
+            config (`Optional[PretrainedConfig]`, *optional*):
+                The model config to use when loading the model.
+            use_auth_token (`Optional[Union[bool, str]]`, *optional*):
+                Is needed to load models from a private repository.
             revision (`Optional[str]`, *optional*):
                 Revision is the specific model version to use. It can be a branch name, a tag name, or a commit id
             force_download (`bool`, *optional*, defaults to `False`):
@@ -312,31 +346,23 @@ class ORTModel(OptimizedModel):
             cache_dir (`Optional[str]`, *optional*):
                 Path to a directory in which a downloaded pretrained model configuration should be cached if the
                 standard cache should not be used.
-            file_name(`Optional[str]`, *optional*):
-                Overwrites the default model file name from `"model.onnx"` to `file_name`. This allows you to load
-                different model files from the same repository or directory.
+            file_name (`str`, *optional*, defaults to the value of `optimum.onnxruntime.utils.ONNX_WEIGHTS_NAME`):
+                The filename to use when saving the model.
             subfolder (`str`, *optional*, defaults to `""`):
                 The subfolder where the model is stored.
             local_files_only(`bool`, *optional*, defaults to `False`):
                 Whether or not to only look at local files (i.e., do not try to download the model).
-            kwargs (`Dict`, *optional*):
-                kwargs will be passed to the model during initialization
+            kwargs (`Dict[str, Any]`):
+                Keyword arguments passed to the ORTModel during initialization.
         """
-        # TODO: why not make this as a keyword argument.
-        local_files_only = kwargs.pop("local_files_only", False)
-        config = kwargs.pop("config", {})
-        model_file_name = file_name if file_name is not None else ONNX_WEIGHTS_NAME
-        # load model from local directory
         if os.path.isdir(os.path.join(model_id, subfolder)):
-            model = ORTModel.load_model(os.path.join(model_id, subfolder, model_file_name), **kwargs)
+            model = ORTModel.load_model(os.path.join(model_id, subfolder, file_name), **kwargs)
             kwargs["model_save_dir"] = Path(model_id).joinpath(subfolder)
-            kwargs["latest_model_name"] = model_file_name
-        # load model from hub
+            kwargs["latest_model_name"] = file_name
         else:
-            # download model
             model_cache_path = hf_hub_download(
                 repo_id=model_id,
-                filename=model_file_name,
+                filename=file_name,
                 subfolder=subfolder,
                 use_auth_token=use_auth_token,
                 revision=revision,
@@ -383,7 +409,7 @@ class ORTModel(OptimizedModel):
             subfolder (`str`, *optional*, defaults to `""`):
                 The subfolder where the model is stored.
             kwargs (`Dict[str, Any]`, *optional*):
-                Keyword arguments to pass to the ORTModel during initialization.
+                Keyword arguments passed to the ORTModel during initialization.
         """
         # Create local save dir in cache dir
         save_dir = Path(save_dir).joinpath(model_id, subfolder)
@@ -479,12 +505,11 @@ class ORTModelForFeatureExtraction(ORTModel):
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
         super().__init__(model, config, use_io_binding, **kwargs)
-        # create {name:idx} dict for model outputs
         self.model_outputs = {output_key.name: idx for idx, output_key in enumerate(self.model.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.model) if self.use_io_binding else None
 
     def prepare_output_buffer(self, batch_size, sequence_length, hidden_size, output_name: str):
-        """Prepare the buffer of output_name with a 1D tensor on shape: (batch_size, sequence_length, hidden_size)."""
+        """Prepares the buffer of output_name with a 1D tensor on shape: (batch_size, sequence_length, hidden_size)."""
         ort_type = TypeHelper.get_output_type(self.model, output_name)
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 
@@ -647,18 +672,16 @@ class ORTModelForQuestionAnswering(ORTModel):
     Question Answering model for ONNX.
     """
 
-    # used in from_transformers to export model to onnx
     export_feature = "question-answering"
     auto_model_class = AutoModelForQuestionAnswering
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
         super().__init__(model, config, use_io_binding, **kwargs)
-        # create {name:idx} dict for model outputs
         self.model_outputs = {output_key.name: idx for idx, output_key in enumerate(self.model.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.model) if self.use_io_binding else None
 
     def prepare_logits_buffer(self, batch_size, sequence_length, output_name: str):
-        """Prepare the buffer of logits with a 1D tensor on shape: (batch_size, sequence_length)."""
+        """Prepares the buffer of logits with a 1D tensor on shape: (batch_size, sequence_length)."""
         ort_type = TypeHelper.get_output_type(self.model, output_name)
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 
@@ -849,19 +872,17 @@ class ORTModelForSequenceClassification(ORTModel):
     Sequence Classification model for ONNX.
     """
 
-    # used in from_transformers to export model to onnx
     export_feature = "sequence-classification"
     auto_model_class = AutoModelForSequenceClassification
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
         super().__init__(model, config, use_io_binding, **kwargs)
-        # create {name:idx} dict for model outputs
         self.model_outputs = {output_key.name: idx for idx, output_key in enumerate(self.model.get_outputs())}
         self.model_inputs = {input_key.name: idx for idx, input_key in enumerate(self.model.get_inputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.model) if self.use_io_binding else None
 
     def prepare_logits_buffer(self, batch_size, num_labels):
-        """Prepare the buffer of logits with a 1D tensor on shape: (batch_size, config.num_labels)."""
+        """Prepares the buffer of logits with a 1D tensor on shape: (batch_size, config.num_labels)."""
         ort_type = TypeHelper.get_output_type(self.model, "logits")
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 
@@ -1022,18 +1043,16 @@ class ORTModelForTokenClassification(ORTModel):
     Token Classification model for ONNX.
     """
 
-    # used in from_transformers to export model to onnx
     export_feature = "token-classification"
     auto_model_class = AutoModelForTokenClassification
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
         super().__init__(model, config, use_io_binding, **kwargs)
-        # create {name:idx} dict for model outputs
         self.model_outputs = {output_key.name: idx for idx, output_key in enumerate(self.model.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.model) if self.use_io_binding else None
 
     def prepare_logits_buffer(self, batch_size, sequence_length, num_labels):
-        """Prepare the buffer of logits with a 1D tensor on shape: (batch_size, sequence_length, config.num_labels)."""
+        """Prepares the buffer of logits with a 1D tensor on shape: (batch_size, sequence_length, config.num_labels)."""
         ort_type = TypeHelper.get_output_type(self.model, "logits")
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 
@@ -1190,7 +1209,6 @@ class ORTModelForMultipleChoice(ORTModel):
     Multiple choice model for ONNX.
     """
 
-    # used in from_transformers to export model to onnx
     export_feature = "multiple-choice"
     auto_model_class = AutoModelForMultipleChoice
 
@@ -1200,7 +1218,7 @@ class ORTModelForMultipleChoice(ORTModel):
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.model) if self.use_io_binding else None
 
     def prepare_logits_buffer(self, batch_size, num_choices):
-        """Prepare the buffer of logits with a 1D tensor on shape: (batch_size, num_choices)."""
+        """Preparesthe buffer of logits with a 1D tensor on shape: (batch_size, num_choices)."""
         ort_type = TypeHelper.get_output_type(self.model, "logits")
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 
@@ -1361,18 +1379,16 @@ class ORTModelForImageClassification(ORTModel):
     Image Classification model for ONNX.
     """
 
-    # used in from_transformers to export model to onnx
     export_feature = "image-classification"
     auto_model_class = AutoModelForImageClassification
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
         super().__init__(model, config, use_io_binding, **kwargs)
-        # create {name:idx} dict for model outputs
         self.model_outputs = {output_key.name: idx for idx, output_key in enumerate(self.model.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.model) if self.use_io_binding else None
 
     def prepare_logits_buffer(self, batch_size):
-        """Prepare the buffer of logits with a 1D tensor on shape: (batch_size, config.num_labels)."""
+        """Preparesthe buffer of logits with a 1D tensor on shape: (batch_size, config.num_labels)."""
         ort_type = TypeHelper.get_output_type(self.model, "logits")
         torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -24,7 +24,6 @@ import torch
 from transformers import (
     AutoConfig,
     AutoModel,
-    AutoModelForCausalLM,
     AutoModelForImageClassification,
     AutoModelForMultipleChoice,
     AutoModelForQuestionAnswering,
@@ -32,10 +31,8 @@ from transformers import (
     AutoModelForTokenClassification,
 )
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, default_cache_path
-from transformers.generation_utils import GenerationMixin
 from transformers.modeling_outputs import (
     BaseModelOutput,
-    CausalLMOutputWithCrossAttentions,
     ImageClassifierOutput,
     ModelOutput,
     MultipleChoiceModelOutput,
@@ -73,7 +70,8 @@ _FEATURE_EXTRACTOR_FOR_DOC = "AutoFeatureExtractor"
 ONNX_MODEL_START_DOCSTRING = r"""
     This model inherits from [~`onnxruntime.modeling_ort.ORTModel`]. Check the superclass documentation for the generic methods the
     library implements for all its model (such as downloading or saving)
-    Parameters:
+
+    Args:
         config (`transformers.PretrainedConfig`): [PretrainedConfig](https://huggingface.co/docs/transformers/main_classes/configuration#transformers.PretrainedConfig) is the Model configuration class with all the parameters of the model.
             Initializing with a config file does not load the weights associated with the model, only the
             configuration. Check out the [`~onnxruntime.modeling_ort.ORTModel.from_pretrained`] method to load the model weights.
@@ -109,15 +107,13 @@ ONNX_IMAGE_INPUTS_DOCSTRING = r"""
 """
 
 
-@add_start_docstrings(
-    """
-    Base ORTModel class for implementing models using ONNX Runtime. The ORTModel implements generic methods for interacting
-    with the Hugging Face Hub as well as exporting vanilla transformers models to ONNX using `transformers.onnx` toolchain.
-    The ORTModel implements additionally generic methods for optimizing and quantizing Onnx models.
-    """,
-)
 class ORTModel(OptimizedModel):
     """
+    Base class for implementing models using ONNX Runtime.
+
+    The ORTModel implements generic methods for interacting with the Hugging Face Hub as well as exporting vanilla
+    transformers models to ONNX using `optimum.exporters.onnx` toolchain.
+
     Class attributes:
         - model_type (`str`, *optional*, defaults to `"onnx_model"`) -- The name of the model type to use when
         registering the ORTModel classes.

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -239,6 +239,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         last_encoder_model_name: str = ONNX_ENCODER_NAME,
         last_decoder_model_name: str = ONNX_DECODER_NAME,
         last_decoder_with_past_model_name: str = ONNX_DECODER_WITH_PAST_NAME,
+        **kwargs
     ):
         self.config = config
         self.encoder_file_name = last_encoder_model_name
@@ -391,10 +392,9 @@ class ORTModelForConditionalGeneration(ORTModel):
         revision: Optional[str] = None,
         force_download: bool = False,
         cache_dir: Optional[str] = None,
-        # TODO: should we make the default values available here?
-        encoder_file_name: Optional[str] = None,
-        decoder_file_name: Optional[str] = None,
-        decoder_with_past_file_name: Optional[str] = None,
+        encoder_file_name: str = ONNX_ENCODER_NAME,
+        decoder_file_name: str = ONNX_DECODER_NAME,
+        decoder_with_past_file_name: str = ONNX_DECODER_WITH_PAST_NAME,
         subfolder: str = "",
         local_files_only: bool = False,
         use_cache: bool = True,
@@ -403,10 +403,6 @@ class ORTModelForConditionalGeneration(ORTModel):
         provider_options: Optional[Dict[str, Any]] = None,
         use_io_binding: bool = True,
     ):
-        encoder_file_name = encoder_file_name or ONNX_ENCODER_NAME
-        decoder_file_name = decoder_file_name or ONNX_DECODER_NAME
-        decoder_with_past_file_name = decoder_with_past_file_name or ONNX_DECODER_WITH_PAST_NAME
-
         kwargs = {"use_io_binding": use_io_binding}
 
         # Load model from a local directory

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -375,7 +375,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         src_file_names = [self.encoder_file_name, self.decoder_file_name]
         dst_file_names = [encoder_file_name or ONNX_ENCODER_NAME, decoder_file_name or ONNX_DECODER_NAME]
         if self.use_cache:
-            src_file_names.append(self.last_decoder_with_past_model_name)
+            src_file_names.append(self.decoder_file_with_past_name)
             dst_file_names.append(decoder_with_past_file_name or ONNX_DECODER_WITH_PAST_NAME)
 
         for src_file_name, dst_file_name in zip(src_file_names, dst_file_names):

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 import numpy as np
 import torch
 from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq, AutoTokenizer
-from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, default_cache_path
+from transformers.file_utils import add_start_docstrings_to_model_forward, default_cache_path
 from transformers.generation_utils import GenerationMixin
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.onnx import FeaturesManager, export
@@ -57,37 +57,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ONNX_INPUTS_DOCSTRING = r"""
-    Important attributes:
-        config ([`PretrainedConfig`]):
-            Instance of the configuration associated to the model. Initializing with a config file does
-            not load the weights associated with the model, only the configuration.
-        use_io_binding (`bool`):
-            Whether use IOBinding during inference to avoid memory copy between the host and devices. Defaults to `True`
-            if the device is CUDA, otherwise defaults to `False`.
-        use_cache (`bool`):
-            Whether or not past key/values cache should be used. It is determined by whether an InferenceSession for
-            that was provided or not.
-        providers (`List[str`]):
-            The list of execution providers the model is running on.
-        encoder (`ORTEncoder`):
-            The encoder model.
-        decoder (`ORTDecoder`):
-            The decoder model.
-        decoder_with_past (`Optional[ORTDecoder]`):
-            The decoder model handling the past key/values if `use_cache=True`, else `None`.
-
-    Other attributes:
-        encoder_file_name (`str`, defaults to `optimum.onnxruntime.utils.ONNX_ENCODER_NAME`):
-            The name of the ONNX file containing the encoder part of the model.
-        decoder_file_name (`str`,  defaults to `optimum.onnxruntime.utils.ONNX_DECODER_NAME`):
-            The name of the ONNX file containing the decoder part of the model.
-        decoder_file_with_past_name (`str`, defaults to `optimum.onnxruntime.utils.ONNX_DECODER_WITH_PAST_NAME`):
-            The name of the ONNX file containing the decoder with past key/values part of the model.
-        model_save_dir (`str`, defaults to `""`):
-            The directory under which the model exported to ONNX was saved.
-
-"""
 
 SEQ2SEQ_ENCODER_INPUTS_DOCSTRING = r"""
     Args:
@@ -225,13 +194,41 @@ AUTOMATIC_SPEECH_RECOGNITION_EXAMPLE = r"""
 """
 
 
-@add_start_docstrings(
+class ORTModelForConditionalGeneration(ORTModel, ABC):
     """
     Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
-    """,
-    ONNX_INPUTS_DOCSTRING,
-)
-class ORTModelForConditionalGeneration(ORTModel, ABC):
+
+    Important attributes:
+        config ([`PretrainedConfig`]):
+            Instance of the configuration associated to the model. Initializing with a config file does
+            not load the weights associated with the model, only the configuration.
+        use_io_binding (`bool`):
+            Whether use IOBinding during inference to avoid memory copy between the host and devices. Defaults to `True`
+            if the device is CUDA, otherwise defaults to `False`.
+        use_cache (`bool`):
+            Whether or not past key/values cache should be used. It is determined by whether an InferenceSession for
+            that was provided or not.
+        providers (`List[str`]):
+            The list of execution providers the model is running on.
+        encoder (`ORTEncoder`):
+            The encoder model.
+        decoder (`ORTDecoder`):
+            The decoder model.
+        decoder_with_past (`Optional[ORTDecoder]`):
+            The decoder model handling the past key/values if `use_cache=True`, else `None`.
+
+    Other attributes:
+        encoder_file_name (`str`, defaults to `optimum.onnxruntime.utils.ONNX_ENCODER_NAME`):
+            The name of the ONNX file containing the encoder part of the model.
+        decoder_file_name (`str`,  defaults to `optimum.onnxruntime.utils.ONNX_DECODER_NAME`):
+            The name of the ONNX file containing the decoder part of the model.
+        decoder_file_with_past_name (`str`, defaults to `optimum.onnxruntime.utils.ONNX_DECODER_WITH_PAST_NAME`):
+            The name of the ONNX file containing the decoder with past key/values part of the model.
+        model_save_dir (`str`, defaults to `""`):
+            The directory under which the model exported to ONNX was saved.
+
+    """
+
     # Used in from_transformers to export model to onnxORTEncoder
     base_model_prefix = "onnx_model"
 

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
-import transformers
 from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq, AutoTokenizer
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward, default_cache_path
 from transformers.generation_utils import GenerationMixin
@@ -293,23 +292,23 @@ class ORTModelForConditionalGeneration(ORTModel):
         provider_options: Optional[Dict] = None,
     ):
         """
-        Creates an instance of [`~optimum.ort.modeling_seq2seq.ORTModelForConditionalGeneration`].
+        Creates an instance of [`~optimum.onnxruntime.modeling_seq2seq.ORTModelForConditionalGeneration`].
         Three inference sessions will be created for respectively the encoder, decoder and decoder with past key values
         models. The default provider is `CPUExecutionProvider` to match the default behaviour in PyTorch/TensorFlow/JAX.
 
         Args:
-            encoder_path (`str` or `Path`):
+            encoder_path (`Union[str, Path]`):
                 The path of the encoder ONNX model.
-            decoder_path (`str` or `Path`):
+            decoder_path (`Union[str, Path]`):
                 The path of the decoder ONNX model.
-            decoder_with_past_path (`str` or `Path`, *optional*):
+            decoder_with_past_path (`Optional[Union[str, Path]]`, *optional*):
                 The path of the decoder with past key values ONNX model.
             provider (`str`, *optional*, defaults to `"CPUExecutionProvider"`):
                 ONNX Runtime provider to use for loading the model. See https://ort.ai/docs/execution-providers/
                 for possible providers.
-            session_options (`ort.SessionOptions`, *optional*),:
+            session_options (`Optional[ort.SessionOptions]`, *optional*),:
                 ONNX Runtime session options to use for loading the model. Defaults to `None`.
-            provider_options (`Dict`, **optional**):
+            provider_options (`Optional[Dict]`, *optional*):
                 Provider option dictionary corresponding to the provider used. See available options
                 for each provider: https://ort.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
@@ -317,7 +316,7 @@ class ORTModelForConditionalGeneration(ORTModel):
 
         providers = [provider]
         if provider == "TensorrtExecutionProvider":
-            # follow advice in https://ort.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#python
+            # follow advice in https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#python
             providers.append("CUDAExecutionProvider")
 
         encoder_session = ort.InferenceSession(
@@ -357,7 +356,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         """
         Saves the model encoder, decoder and decoder with past key values as well as its configuration file to a
         directory, so that it can be re-loaded using the
-        [`~optimum.ort.modeling_seq2seq.ORTModelForSeq2SeqLM.from_pretrained`] class method.
+        [`~optimum.onnxruntime.modeling_seq2seq.ORTModelForSeq2SeqLM.from_pretrained`] class method.
 
         Args:
             save_directory (`Union[str, Path`]):

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -287,7 +287,7 @@ class ORTModelForConditionalGeneration(ORTModel):
     def load_model(
         encoder_path: Union[str, Path],
         decoder_path: Union[str, Path],
-        decoder_with_past_path: Union[str, Path] = None,
+        decoder_with_past_path: Optional[Union[str, Path]] = None,
         provider: str = "CPUExecutionProvider",
         session_options: Optional[ort.SessionOptions] = None,
         provider_options: Optional[Dict] = None,
@@ -622,7 +622,6 @@ class ORTEncoder:
         device: torch.device,
         use_io_binding: bool = True,
         main_input_name: str = "input_ids",
-        **kwargs
     ):
         self.session = session
         self.config = config
@@ -816,7 +815,6 @@ class ORTDecoder:
         config: "PretrainedConfig",
         device: torch.device,
         use_io_binding: bool = True,
-        **kwargs
     ):
         self.session = session
         self.config = config
@@ -1240,9 +1238,6 @@ class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin
     _MODEL_TYPE_TO_ORTENCODER = {
         "whisper": ORTEncoderForWhisper,
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def _initialize_encoder(
         self,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -344,13 +344,13 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             decoder_with_past_path (`Optional[Union[str, Path]]`, *optional*):
                 The path of the decoder with past key values ONNX model.
             provider (`str`, *optional*, defaults to `"CPUExecutionProvider"`):
-                ONNX Runtime provider to use for loading the model. See https://ort.ai/docs/execution-providers/
+                ONNX Runtime provider to use for loading the model. See https://onnxruntime.ai/docs/execution-providers/
                 for possible providers.
             session_options (`Optional[ort.SessionOptions]`, *optional*),:
                 ONNX Runtime session options to use for loading the model. Defaults to `None`.
             provider_options (`Optional[Dict]`, *optional*):
                 Provider option dictionary corresponding to the provider used. See available options
-                for each provider: https://ort.ai/docs/api/c/group___global.html . Defaults to `None`.
+                for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
         validate_provider_availability(provider)  # raise error if the provider is not available
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -393,7 +393,6 @@ class ORTModelIntegrationTest(unittest.TestCase):
     @require_torch_gpu
     def test_seq2seq_model_on_gpu_str(self):
         model = ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, use_cache=True)
-        gpu = torch.device("cuda")
         model.to("cuda")
         self.assertEqual(model.device, torch.device("cuda:0"))
         self.assertEqual(model.encoder._device, torch.device("cuda:0"))

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -98,7 +98,7 @@ class ORTOptimizerTest(unittest.TestCase):
                 tmp_dir,
                 encoder_file_name="encoder_model_optimized.onnx",
                 decoder_file_name="decoder_model_optimized.onnx",
-                decoder_file_with_past_name="decoder_with_past_model_optimized.onnx" if use_cache else None,
+                decoder_with_past_file_name="decoder_with_past_model_optimized.onnx" if use_cache else None,
                 from_transformers=False,
                 use_cache=use_cache,
             )


### PR DESCRIPTION
# What does this PR do?

- Uses `optimum.exporters.onnx` to export transformers models in `ORTModel`
- Refactors / clean the API 
- Docstring

Fixes: #481 