### PR TITLE
[BT] Fix failing CI tests

### DIFF
--- a/.github/workflows/test_bettertransformer.yml
+++ b/.github/workflows/test_bettertransformer.yml
@@ -29,7 +29,8 @@ jobs:
       run: |
         pip install .[tests]
         pip3 install --upgrade torch torchvision torchaudio
-        pip install accelerate transformers
+        pip install accelerate
+        pip install git+https://github.com/huggingface/transformers@main#egg=transformers
     - name: Test with unittest
       working-directory: tests
       run: |


### PR DESCRIPTION
# What does this PR do?

fixes the failing CI tests for BT

using `transformers==4.24.0` , the snippet:
```
import requests
from PIL import Image
from transformers import AutoFeatureExtractor

url = "http://images.cocodataset.org/val2017/000000039769.jpg"
image = Image.open(requests.get(url, stream=True).raw)

# Use the same feature extractor for everyone
feature_extractor = AutoFeatureExtractor.from_pretrained("hf-internal-testing/tiny-random-ViTModel")
inputs = feature_extractor(images=image, return_tensors="pt")
```
fails
Using the main branch of `transformers` should fix the issue

cc @fxmarty 