### PR TITLE
Replace sklearn by scikit-learn

### DIFF
--- a/examples/onnxruntime/training/docker/conda/requirements.yml
+++ b/examples/onnxruntime/training/docker/conda/requirements.yml
@@ -151,7 +151,6 @@ dependencies:
     - sacremoses==0.0.47
     - scikit-learn==1.0.2
     - scipy==1.7.3
-    - sklearn==0.0
     - sniffio==1.2.0
     - sympy==1.9
     - threadpoolctl==3.0.0

--- a/examples/onnxruntime/training/docker/run.sh
+++ b/examples/onnxruntime/training/docker/run.sh
@@ -14,7 +14,7 @@ GPU_DEVICES=${2:-"all"}
 # Install dependencies
 pip install git+https://github.com/huggingface/transformers
 pip install datasets accelerate evaluate
-pip install coloredlogs absl-py rouge_score seqeval scipy sacrebleu nltk sklearn parameterized sentencepiece
+pip install coloredlogs absl-py rouge_score seqeval scipy sacrebleu nltk scikit-learn parameterized sentencepiece
 pip install fairscale deepspeed mpi4py
 # pip install optuna ray sigopt wandb # Hyper parameter search
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ known_third_party =
     rouge_score
     sacrebleu
     seqeval
-    sklearn
+    scikit-learn
     streamlit
     tensorboardX
     tensorflow

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ TESTS_REQUIRE = ["pytest", "requests", "parameterized", "pytest-xdist", "Pillow"
 
 QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.5.4"]
 
-BENCHMARK_REQUIRE = ["optuna", "tqdm", "sklearn", "seqeval", "torchvision", "evaluate>=0.2.0"]
+BENCHMARK_REQUIRE = ["optuna", "tqdm", "scikit-learn", "seqeval", "torchvision", "evaluate>=0.2.0"]
 
 EXTRAS_REQUIRE = {
     "onnxruntime": [


### PR DESCRIPTION
# What does this PR do?

The `sklearn` package on PyPI is an historical thing and will start failing from December 1st 2022, see https://github.com/scikit-learn/sklearn-pypi-package for more details.


## Before submitting
I checked the first one as this seems the one more applicable here:
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

