### PR TITLE
[BT] add `BetterTransformer` support for ViLT architecture

### DIFF
--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -38,12 +38,13 @@ The list of supported model below:
 - [MarkupLM](https://arxiv.org/abs/2110.08518)
 - [RoBERTa](https://arxiv.org/abs/1907.11692)
 - [Splinter](https://arxiv.org/abs/2101.00438)
-- [XLMRoberta](https://arxiv.org/abs/1911.02116)
-- [Whisper](https://cdn.openai.com/papers/whisper.pdf)
+- [ViLT](https://arxiv.org/abs/2102.03334)
 - [ViT](https://arxiv.org/abs/2010.11929)
 - [ViT-MAE](https://arxiv.org/abs/2111.06377)
 - [ViT-MSN](https://arxiv.org/abs/2204.07141)
 - [Wav2Vec2](https://arxiv.org/abs/2006.11477)
+- [Whisper](https://cdn.openai.com/papers/whisper.pdf)
+- [XLMRoberta](https://arxiv.org/abs/1911.02116)
 - [YOLOS](https://arxiv.org/abs/2106.00666)
 
 Let us know by opening an issue in 🤗 Optimum if you want more models to be supported, or check out the contribution guideline if you want to add it by yourself!

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -19,6 +19,7 @@ from .encoder_models import (
     BertLayerBetterTransformer,
     DistilBertLayerBetterTransformer,
     ViTLayerBetterTransformer,
+    ViltLayerBetterTransformer,
     Wav2Vec2EncoderLayerBetterTransformer,
     WhisperEncoderLayerBetterTransformer,
 )
@@ -65,6 +66,7 @@ BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     "ViTMAELayer": ViTLayerBetterTransformer,
     "ViTMSNLayer": ViTLayerBetterTransformer,
     "YolosLayer": ViTLayerBetterTransformer,
+    "ViltLayer": ViltLayerBetterTransformer,
 }
 
 

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -18,8 +18,8 @@ from .encoder_models import (
     BartEncoderLayerBetterTransformer,
     BertLayerBetterTransformer,
     DistilBertLayerBetterTransformer,
-    ViTLayerBetterTransformer,
     ViltLayerBetterTransformer,
+    ViTLayerBetterTransformer,
     Wav2Vec2EncoderLayerBetterTransformer,
     WhisperEncoderLayerBetterTransformer,
 )

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -63,6 +63,6 @@ class BetterTransformersViLTTest(BetterTransformersTestMixin, unittest.TestCase)
         text = "How many cats are there?"
 
         # Model takes image and text as input
-        processor = AutoProcessor.from_pretrained("hf-internal-testing/tiny-random-ViltModel")
+        processor = AutoProcessor.from_pretrained(model_id)
         inputs = processor(image, text, return_tensors="pt")
         return inputs

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -15,7 +15,7 @@
 import unittest
 
 from PIL import Image
-from transformers import AutoFeatureExtractor
+from transformers import AutoFeatureExtractor, AutoProcessor
 
 import requests
 from testing_bettertransformer_utils import BetterTransformersTestMixin
@@ -27,6 +27,10 @@ ALL_VISION_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-ViTMAEModel",
     "hf-internal-testing/tiny-random-ViTMSNModel",
     "hf-internal-testing/tiny-random-deit",
+]
+
+
+ALL_VISION_TEXT_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-ViltModel",
 ]
 
@@ -44,4 +48,21 @@ class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCas
         # Use the same feature extractor for everyone
         feature_extractor = AutoFeatureExtractor.from_pretrained("hf-internal-testing/tiny-random-ViTModel")
         inputs = feature_extractor(images=image, return_tensors="pt")
+        return inputs
+
+
+class BetterTransformersViLTTest(BetterTransformersTestMixin, unittest.TestCase):
+    r"""
+    Testing suite for Vision and Text Models - tests all the tests defined in `BetterTransformersTestMixin`
+    """
+    all_models_to_test = ALL_VISION_TEXT_MODELS_TO_TEST
+
+    def prepare_inputs_for_class(self, model_id=None):
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        text = "How many cats are there?"
+
+        # Model takes image and text as input
+        processor = AutoProcessor.from_pretrained("hf-internal-testing/tiny-random-ViltModel")
+        inputs = processor(image, text, return_tensors="pt")
         return inputs

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -31,7 +31,7 @@ ALL_VISION_MODELS_TO_TEST = [
 
 
 ALL_VISION_TEXT_MODELS_TO_TEST = [
-    "hf-internal-testing/tiny-random-ViltModel",
+    "hf-internal-testing/tiny-vilt-random-vqa",
 ]
 
 

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -27,6 +27,7 @@ ALL_VISION_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-ViTMAEModel",
     "hf-internal-testing/tiny-random-ViTMSNModel",
     "hf-internal-testing/tiny-random-deit",
+    "hf-internal-testing/tiny-random-ViltModel",
 ]
 
 


### PR DESCRIPTION
# What does this PR do?

Added BetterTransformer support for ViLT architecture. 
Added test model for ViltModel.

Tested the conversion of ViltLayer:

```
from optimum.bettertransformer import BetterTransformer
model = BetterTransformer.transform("hf-internal-testing/tiny-random-ViltModel")
print(model)
ViltModel(
  (embeddings): ViltEmbeddings(
    (text_embeddings): TextEmbeddings(
      (word_embeddings): Embedding(1124, 32)
      (position_embeddings): Embedding(512, 32)
      (token_type_embeddings): Embedding(16, 32)
      (LayerNorm): LayerNorm((32,), eps=1e-12, elementwise_affine=True)
      (dropout): Dropout(p=0.1, inplace=False)
    )
    (patch_embeddings): ViltPatchEmbeddings(
      (projection): Conv2d(3, 32, kernel_size=(2, 2), stride=(2, 2))
    )
    (token_type_embeddings): Embedding(2, 32)
    (dropout): Dropout(p=0.1, inplace=False)
  )
  (encoder): ViltEncoder(
    (layer): ModuleList(
      (0): ViltLayerBetterTransformer()
      (1): ViltLayerBetterTransformer()
      (2): ViltLayerBetterTransformer()
      (3): ViltLayerBetterTransformer()
      (4): ViltLayerBetterTransformer()
    )
  )
  (layernorm): LayerNorm((32,), eps=1e-12, elementwise_affine=True)
  (pooler): ViltPooler(
    (dense): Linear(in_features=32, out_features=32, bias=True)
    (activation): Tanh()
  )
)

```


To: @younesbelkada @michaelbenayoun  @fxmarty 

