### PR TITLE
[BT] clearer error message for `norm_first`

### DIFF
--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -14,6 +14,8 @@
 import torch
 import torch.nn as nn
 
+from optimum.utils import is_pytorch_greater_version
+
 
 KNOWN_ACTIVATION_ATTRIBUTES = ["hidden_act", "activation", "act_fn", "activation_function"]
 KNOWN_POS_EMB_ATTRIBUTES = ["position_embedding_type"]
@@ -89,6 +91,14 @@ class BetterTransformerBaseLayer(nn.Module):
                 f"Number of heads {self.num_heads} is not supported"
                 " for `BetterTransformer` integration."
                 f" Number of heads must be even."
+            )
+
+        # Check if norm_first is activated for pytorch==1.12
+        if self.norm_first and not is_pytorch_greater_version("1.13.0"):
+            raise ValueError(
+                "The option `norm_first` is only supported from PyTorch 1.13",
+                " please update your PyTorch to the latest version:",
+                " https://pytorch.org",
             )
 
     def forward_checker(self, *args, **kwargs):

--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -94,7 +94,7 @@ class BetterTransformerBaseLayer(nn.Module):
             )
 
         # Check if norm_first is activated for pytorch==1.12
-        if self.norm_first and not is_pytorch_greater_version("1.13.0"):
+        if self.norm_first == True and not is_pytorch_greater_version("1.13.0"):
             raise ValueError(
                 "The option `norm_first` is only supported from PyTorch 1.13",
                 " please update your PyTorch to the latest version:",

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -45,10 +45,10 @@ def is_accelerate_available():
     return _accelerate_available
 
 
-def is_pytorch_greater_112():
+def is_pytorch_greater_version(pt_version="1.12.0"):
     import torch
 
-    return version.parse(torch.__version__) >= version.parse("1.12.0")
+    return version.parse(torch.__version__) >= version.parse(pt_version)
 
 
 @contextmanager
@@ -58,7 +58,7 @@ def check_if_pytorch_greater_112():
     """
     import torch
 
-    if not is_pytorch_greater_112():
+    if not is_pytorch_greater_version("1.12.0"):
         raise ImportError(
             f"Found an incompatible version of PyTorch. Found version {torch.__version__}, but only 1.12.0 and above are supported."
         )


### PR DESCRIPTION
# What does this PR do?

This PR fixes a small nit, when users run `BetterTransformer` under some models that uses `norm_first` the error message is not clear. This PR adds a sanity check and a clear explanation of what a user should do in case they're using a BT model under PyTorch 1.12 that uses `norm_first` 

cc @fxmarty @michaelbenayoun 

