### PR TITLE
Deprecate PyTorch 1.12. for BetterTransformer

### DIFF
--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -14,8 +14,6 @@
 import torch
 import torch.nn as nn
 
-from optimum.utils import is_pytorch_greater_version
-
 
 KNOWN_ACTIVATION_ATTRIBUTES = ["hidden_act", "activation", "act_fn", "activation_function"]
 KNOWN_POS_EMB_ATTRIBUTES = ["position_embedding_type"]
@@ -91,14 +89,6 @@ class BetterTransformerBaseLayer(nn.Module):
                 f"Number of heads {self.num_heads} is not supported"
                 " for `BetterTransformer` integration."
                 f" Number of heads must be even."
-            )
-
-        # Check if norm_first is activated for pytorch==1.12
-        if self.norm_first == True and not is_pytorch_greater_version("1.13.0"):
-            raise ValueError(
-                "The option `norm_first` is only supported from PyTorch 1.13",
-                " please update your PyTorch to the latest version:",
-                " https://pytorch.org",
             )
 
     def forward_checker(self, *args, **kwargs):

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import torch
 
-from optimum.utils import check_if_pytorch_greater_112, is_accelerate_available
+from optimum.utils import check_if_pytorch_greater, is_accelerate_available
 
 from .models import BETTER_TRANFORMER_LAYERS_MAPPING_DICT, warn_uncompatible_save
 
@@ -123,7 +123,10 @@ class BetterTransformer(object):
     # Original PR from: https://github.com/huggingface/transformers/pull/19553 adapted and wrapped in this script.
     """
 
-    @check_if_pytorch_greater_112()
+    @check_if_pytorch_greater(
+        "1.13",
+        "Please upgrade PyTorch following https://pytorch.org/get-started/locally/ in order to use BetterTransformer.",
+    )
     def transform(
         model: torch.nn.Module, keep_original_model: bool = False, max_memory: Optional[dict] = None, **kwargs
     ) -> torch.nn.Module:

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -124,7 +124,7 @@ class BetterTransformer(object):
     """
 
     @check_if_pytorch_greater(
-        "1.13",
+        "1.13.0",
         "Please upgrade PyTorch following https://pytorch.org/get-started/locally/ in order to use BetterTransformer.",
     )
     def transform(

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -45,22 +45,16 @@ def is_accelerate_available():
     return _accelerate_available
 
 
-def is_pytorch_greater_version(pt_version="1.12.0"):
-    import torch
-
-    return version.parse(torch.__version__) >= version.parse(pt_version)
-
-
 @contextmanager
-def check_if_pytorch_greater_112():
+def check_if_pytorch_greater(target_version: str, message: str):
     r"""
-    A context manager that does nothing except checking if the PyTorch version is greater than 1.12.0.
+    A context manager that does nothing except checking if the PyTorch version is greater than `pt_version`
     """
     import torch
 
-    if not is_pytorch_greater_version("1.12.0"):
+    if not version.parse(torch.__version__) >= version.parse(target_version):
         raise ImportError(
-            f"Found an incompatible version of PyTorch. Found version {torch.__version__}, but only 1.12.0 and above are supported."
+            f"Found an incompatible version of PyTorch. Found version {torch.__version__}, but only {target_version} and above are supported. {message}"
         )
     try:
         yield


### PR DESCRIPTION
# What does this PR do?

Fixes

```
terminate called after throwing an instance of 'c10::Error'
  what():  Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor
Exception raised from sizes_custom at ../aten/src/ATen/NestedTensorImpl.cpp:80 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::string) + 0x3e (0x7f76e70c520e in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, char const*) + 0x60 (0x7f76e70a06a9 in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libc10.so)
frame #2: <unknown function> + 0x17836a3 (0x7f769f3a56a3 in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so)
frame #3: <unknown function> + 0x3da70ab (0x7f76a19c90ab in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so)
frame #4: <unknown function> + 0x3da40bd (0x7f76a19c60bd in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so)
frame #5: <unknown function> + 0x3da5cdf (0x7f76a19c7cdf in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so)
frame #6: <unknown function> + 0x20693fe (0x7f769fc8b3fe in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so)
frame #7: at::_ops::_nested_tensor_from_mask::call(at::Tensor const&, at::Tensor const&) + 0x1c9 (0x7f76a006c539 in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so)
frame #8: <unknown function> + 0x49cd68 (0x7f76c70e4d68 in /home/fxmarty/anaconda3/envs/hf-inf/lib/python3.9/site-packages/torch/lib/libtorch_python.so)
<omitting python frames>
frame #61: <unknown function> + 0x29d90 (0x7f76e7d23d90 in /lib/x86_64-linux-gnu/libc.so.6)
frame #62: __libc_start_main + 0x80 (0x7f76e7d23e40 in /lib/x86_64-linux-gnu/libc.so.6)

Aborted (core dumped)
```

in e.g. this script with PyTorch 1.12 (no error in 1.13)
```python
from optimum.bettertransformer import BetterTransformer

from transformers import AutoTokenizer, AutoModelForSequenceClassification

import torch

model_name = "distilbert-base-uncased-finetuned-sst-2-english"

tokenizer = AutoTokenizer.from_pretrained(model_name)

model = AutoModelForSequenceClassification.from_pretrained(model_name)

model = BetterTransformer.transform(model)

input_ids = torch.randint(tokenizer.vocab_size, (8, 128), dtype=torch.int64)

attention_mask = torch.ones((8, 128), dtype=torch.int64)

input_ids = input_ids.to("cuda:0")
attention_mask = attention_mask.to("cuda:0")
model = model.to("cuda:0")

# warmup
for _ in range(2):
    _ = model(input_ids=input_ids, attention_mask=attention_mask)
torch.cuda.synchronize()

start_event = torch.cuda.Event(enable_timing=True)
end_event = torch.cuda.Event(enable_timing=True)
start_event.record()
for _ in range(100):
    _ = model(input_ids=input_ids, attention_mask=attention_mask)
end_event.record()
torch.cuda.synchronize()

print(start_event.elapsed_time(end_event))
```

The doc is already up to date so no need to edit.

