### PR TITLE
Clearer error messages when initilizing the requested ONNX Runtime execution provider fails

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -51,7 +51,7 @@ from huggingface_hub import HfApi, hf_hub_download
 
 from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
 from .io_binding import TypeHelper
-from .utils import ONNX_WEIGHTS_NAME, get_device_for_provider, get_provider_for_device, parse_device
+from .utils import ONNX_WEIGHTS_NAME, get_device_for_provider, get_provider_for_device, parse_device, validate_provider_availability
 
 
 logger = logging.getLogger(__name__)
@@ -170,6 +170,8 @@ class ORTModel(OptimizedModel):
 
         self.device = device
         provider = get_provider_for_device(self.device)
+        validate_provider_availability(provider)  # raise error if the provider is not available
+
         self.model.set_providers([provider], provider_options=[provider_options])
         self.providers = self.model.get_providers()
 
@@ -201,11 +203,7 @@ class ORTModel(OptimizedModel):
                 Provider option dictionary corresponding to the provider used. See available options
                 for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
-        available_providers = ort.get_available_providers()
-        if provider not in available_providers:
-            raise ValueError(
-                f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
-            )
+        validate_provider_availability(provider)
 
         providers = [provider]
         if provider == "TensorrtExecutionProvider":
@@ -933,9 +931,11 @@ class ORTModelForSequenceClassification(ORTModel):
         **kwargs,
     ):
         if self.device.type == "cuda" and self.use_io_binding:
+            print("in here")
             io_binding, output_shapes, output_buffers = self.prepare_io_binding(
                 input_ids, attention_mask, token_type_ids
             )
+            print("after prepare")
 
             # run inference with binding & synchronize in case of multiple CUDA streams
             io_binding.synchronize_inputs()

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -51,7 +51,13 @@ from huggingface_hub import HfApi, hf_hub_download
 
 from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
 from .io_binding import TypeHelper
-from .utils import ONNX_WEIGHTS_NAME, get_device_for_provider, get_provider_for_device, parse_device, validate_provider_availability
+from .utils import (
+    ONNX_WEIGHTS_NAME,
+    get_device_for_provider,
+    get_provider_for_device,
+    parse_device,
+    validate_provider_availability,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -209,7 +209,7 @@ class ORTModel(OptimizedModel):
                 Provider option dictionary corresponding to the provider used. See available options
                 for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
-        validate_provider_availability(provider)
+        validate_provider_availability(provider)  # raise error if the provider is not available
 
         providers = [provider]
         if provider == "TensorrtExecutionProvider":

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -937,11 +937,9 @@ class ORTModelForSequenceClassification(ORTModel):
         **kwargs,
     ):
         if self.device.type == "cuda" and self.use_io_binding:
-            print("in here")
             io_binding, output_shapes, output_buffers = self.prepare_io_binding(
                 input_ids, attention_mask, token_type_ids
             )
-            print("after prepare")
 
             # run inference with binding & synchronize in case of multiple CUDA streams
             io_binding.synchronize_inputs()

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -304,7 +304,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 Provider option dictionary corresponding to the provider used. See available options
                 for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
-        validate_provider_availability(provider)
+        validate_provider_availability(provider)  # raise error if the provider is not available
 
         providers = [provider]
         if provider == "TensorrtExecutionProvider":
@@ -621,7 +621,7 @@ class ORTModelForConditionalGeneration(ORTModel):
         device, provider_options = parse_device(device)
 
         provider = get_provider_for_device(device)
-        validate_provider_availability(provider)
+        validate_provider_availability(provider)  # raise error if the provider is not available
 
         self.device = device
         self.encoder._device = device

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Dict, Mapping, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -27,9 +27,8 @@ from transformers.generation_utils import GenerationMixin
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.onnx import FeaturesManager, export
 
-import onnx
 import onnxruntime
-from huggingface_hub import HfApi, hf_hub_download
+from huggingface_hub import hf_hub_download
 
 from ..exporters.onnx.model_configs import SpeechSeq2SeqDecoderOnnxConfig, SpeechSeq2SeqEncoderOnnxConfig
 from ..onnx.configuration import DecoderOnnxConfig, EncoderOnnxConfig
@@ -44,6 +43,7 @@ from .utils import (
     get_device_for_provider,
     get_provider_for_device,
     parse_device,
+    validate_provider_availability,
 )
 
 
@@ -304,11 +304,7 @@ class ORTModelForConditionalGeneration(ORTModel):
                 Provider option dictionary corresponding to the provider used. See available options
                 for each provider: https://onnxruntime.ai/docs/api/c/group___global.html . Defaults to `None`.
         """
-        available_providers = onnxruntime.get_available_providers()
-        if provider not in available_providers:
-            raise ValueError(
-                f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
-            )
+        validate_provider_availability(provider)
 
         providers = [provider]
         if provider == "TensorrtExecutionProvider":
@@ -625,6 +621,8 @@ class ORTModelForConditionalGeneration(ORTModel):
         device, provider_options = parse_device(device)
 
         provider = get_provider_for_device(device)
+        validate_provider_availability(provider)
+
         self.device = device
         self.encoder._device = device
         self.encoder.session.set_providers([provider], provider_options=[provider_options])

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -202,6 +202,21 @@ def parse_device(device: Union[torch.device, str, int]) -> Tuple[torch.device, D
     return device, provider_options
 
 
+def validate_provider_availability(provider: str):
+    """
+    Ensure the ONNX Runtime execution provider `provider` is available.
+
+    Args:
+        provider (str): Name of an ONNX Runtime execution provider.
+    """
+    available_providers = ort.get_available_providers()
+    if provider not in available_providers:
+        raise ValueError(
+            f"Asked to use {provider} as an ONNX Runtime execution provider, but the available execution providers are {available_providers}."
+        )
+    #TODO better message for Tensorrt/cuda
+    
+
 class ORTQuantizableOperator(Enum):
     # Common ops
     Gather = "Gather"

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Utility functions, classes and constants for ONNX Runtime."""
 
+import os
 from enum import Enum
 from typing import Dict, Tuple, Type, Union
 
@@ -24,7 +25,7 @@ import onnx
 import onnxruntime as ort
 
 from ..onnx import OnnxConfigWithLoss, OnnxConfigWithPastAndLoss, OnnxSeq2SeqConfigWithPastAndLoss
-from ..utils import NormalizedTextConfig, is_onnxruntime_gpu_available, is_onnxruntime_strict_available
+from ..utils import NormalizedTextConfig
 
 
 logger = logging.get_logger(__name__)
@@ -204,31 +205,41 @@ def parse_device(device: Union[torch.device, str, int]) -> Tuple[torch.device, D
 
 def validate_provider_availability(provider: str):
     """
-    Ensure the ONNX Runtime execution provider `provider` is available.
+    Ensure the ONNX Runtime execution provider `provider` is available, and raise an error if it is not.
 
     Args:
         provider (str): Name of an ONNX Runtime execution provider.
     """
-
     if provider in ["CUDAExecutionProvider", "TensorrtExecutionProvider"]:
-        additional_message = ""
-        if provider == "CUDAExecutionProvider":
-            additional_message = " Additionally, refer to https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html for required dependencies."
-        if provider == "TensorrtExecutionProvider":
-            additional_message = " Additionally, refer to https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html and https://hf.co/docs/optimum/onnxruntime/usage_guides/gpu#tensorrtexecutionprovider for required dependencies."
+        path_cuda_lib = os.path.join(ort.__path__[0], "capi", "libonnxruntime_providers_cuda.so")
+        path_trt_lib = os.path.join(ort.__path__[0], "capi", "libonnxruntime_providers_tensorrt.so")
+        path_dependecy_loading = os.path.join(ort.__path__[0], "capi", "_ld_preload.py")
 
-        if is_onnxruntime_strict_available() == True and is_onnxruntime_gpu_available() == True:
-            raise ValueError(
-                f"Both `onnxruntime` and `onnxruntime-gpu` packages are installed. To use Optimum ONNX Runtime integration on GPU, only `onnxruntime-gpu` should be installed.{additional_message}"
-            )
-        elif is_onnxruntime_strict_available() == True and is_onnxruntime_gpu_available() == False:
-            raise ValueError(
-                f"The `onnxruntime` package was found, please install instead `onnxruntime-gpu` to use Optimum ONNX Runtime integration on GPU.{additional_message}"
-            )
-        elif is_onnxruntime_gpu_available() == False:
-            raise ValueError(
-                f"Please install the `onnxruntime-gpu` to use the Optimum ONNX Runtime integration on GPU.{additional_message}"
-            )
+        with open(path_dependecy_loading, "r") as f:
+            file_string = f.read()
+
+            if "ORT_CUDA" not in file_string or "ORT_TENSORRT" not in file_string:
+                if os.path.isfile(path_cuda_lib) and os.path.isfile(path_trt_lib):
+                    raise ImportError(
+                        f"`onnxruntime-gpu` is installed, but GPU dependencies are not loaded. It is likely there is a conflicting install between `onnxruntime` and `onnxruntime-gpu`. Please install only `onnxruntime-gpu` in order to use {provider}."
+                    )
+                else:
+                    raise ImportError(
+                        f"Asked to use {provider}, but `onnxruntime-gpu` package was not found. Make sure to install `onnxruntime-gpu` package instead of `onnxruntime`."
+                    )
+
+            from onnxruntime.capi import _ld_preload
+
+            if provider == "CUDAExecutionProvider":
+                if os.environ.get("ORT_CUDA_UNAVAILABLE", "0") == "1":
+                    raise ImportError(
+                        "`onnxruntime-gpu` package is installed, but CUDA requirements could not be loaded. Make sure to meet the required dependencies: https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html"
+                    )
+            if provider == "TensorrtExecutionProvider":
+                if os.environ.get("ORT_TENSORRT_UNAVAILABLE", "0") == "1":
+                    raise ImportError(
+                        "`onnxruntime-gpu` package is installed, but TensorRT requirements could not be loaded. Make sure to meet the required dependencies following https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html and https://hf.co/docs/optimum/onnxruntime/usage_guides/gpu#tensorrtexecutionprovider ."
+                    )
 
     available_providers = ort.get_available_providers()
     if provider not in available_providers:

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -13,13 +13,9 @@
 #  limitations under the License.
 import importlib.util
 import inspect
-import os
-import subprocess
 from contextlib import contextmanager
 
 from packaging import version
-
-import onnxruntime
 
 
 CONFIG_NAME = "config.json"
@@ -30,7 +26,6 @@ _accelerate_available = importlib.util.find_spec("accelerate") is not None
 
 
 def is_onnxruntime_available():
-    """Not strict (will pass if either `onnxruntime`, `onnxruntime-gpu` or `onnxruntime-training` is installed)."""
     try:
         # Try to import the source file of onnxruntime - if you run the tests from `tests` the function gets
         # confused since there a folder named `onnxruntime` in `tests`. Therefore, `_onnxruntime_available`

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 import importlib.util
 import inspect
+import os
+import subprocess
 from contextlib import contextmanager
 
 from packaging import version
@@ -26,6 +28,7 @@ _accelerate_available = importlib.util.find_spec("accelerate") is not None
 
 
 def is_onnxruntime_available():
+    """Not strict (will pass if either `onnxruntime` or `onnxruntime-gpu` is installed)."""
     try:
         # Try to import the source file of onnxruntime - if you run the tests from `tests` the function gets
         # confused since there a folder named `onnxruntime` in `tests`. Therefore, `_onnxruntime_available`
@@ -35,6 +38,22 @@ def is_onnxruntime_available():
     except:
         return False
     return _onnxruntime_available
+
+
+def is_onnxruntime_strict_available():
+    tokenizers_parallelism = os.environ.get("TOKENIZERS_PARALLELISM", "")
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    result = subprocess.check_output(["pip list | grep 'onnxruntime ' || true"], shell=True).decode("utf-8") != ""
+    os.environ["TOKENIZERS_PARALLELISM"] = tokenizers_parallelism
+    return result
+
+
+def is_onnxruntime_gpu_available():
+    tokenizers_parallelism = os.environ.get("TOKENIZERS_PARALLELISM", "")
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    result = subprocess.check_output(["pip list | grep onnxruntime-gpu || true"], shell=True).decode("utf-8") != ""
+    os.environ["TOKENIZERS_PARALLELISM"] = tokenizers_parallelism
+    return result
 
 
 def is_pydantic_available():

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -19,6 +19,8 @@ from contextlib import contextmanager
 
 from packaging import version
 
+import onnxruntime
+
 
 CONFIG_NAME = "config.json"
 
@@ -28,7 +30,7 @@ _accelerate_available = importlib.util.find_spec("accelerate") is not None
 
 
 def is_onnxruntime_available():
-    """Not strict (will pass if either `onnxruntime` or `onnxruntime-gpu` is installed)."""
+    """Not strict (will pass if either `onnxruntime`, `onnxruntime-gpu` or `onnxruntime-training` is installed)."""
     try:
         # Try to import the source file of onnxruntime - if you run the tests from `tests` the function gets
         # confused since there a folder named `onnxruntime` in `tests`. Therefore, `_onnxruntime_available`
@@ -38,22 +40,6 @@ def is_onnxruntime_available():
     except:
         return False
     return _onnxruntime_available
-
-
-def is_onnxruntime_strict_available():
-    tokenizers_parallelism = os.environ.get("TOKENIZERS_PARALLELISM", "")
-    os.environ["TOKENIZERS_PARALLELISM"] = "false"
-    result = subprocess.check_output(["pip list | grep 'onnxruntime ' || true"], shell=True).decode("utf-8") != ""
-    os.environ["TOKENIZERS_PARALLELISM"] = tokenizers_parallelism
-    return result
-
-
-def is_onnxruntime_gpu_available():
-    tokenizers_parallelism = os.environ.get("TOKENIZERS_PARALLELISM", "")
-    os.environ["TOKENIZERS_PARALLELISM"] = "false"
-    result = subprocess.check_output(["pip list | grep onnxruntime-gpu || true"], shell=True).decode("utf-8") != ""
-    os.environ["TOKENIZERS_PARALLELISM"] = tokenizers_parallelism
-    return result
 
 
 def is_pydantic_available():


### PR DESCRIPTION
# What does this PR do?

This adds more precise error messages with guidance to the user when the ONNX Runtime configuration is badly installed for some execution provider (notably CUDA, Tensorrt).

Note the fuzzy stuff with tokenizers env variable to avoid the warnings https://github.com/huggingface/transformers/issues/5486 , not sure how to do it better.

I did not add tests as this would require to install / uninstall pip packages to run (or have several docker images, on for each case), not sure if I should? What do you think?

Note that there remains an issue: in case `onnxruntime-gpu` is indeed installed but the dependencies are not met, ONNX Runtime will show `CUDAExecutionProvider` and `TensorrtExecutionProvider` in `get_available_providers()` but initializing the inference session with them will fail anyway, **only with a warning message in C++**. I'm wondering if we should not redirect the warning in Python (tried https://stackoverflow.com/questions/24277488/in-python-how-to-capture-the-stdout-from-a-c-shared-library-to-a-variable , is there better?) to raise an error with a better message.

Related issues https://github.com/huggingface/optimum/issues/511 https://github.com/huggingface/optimum/issues/416