### PR TITLE
Optimum ONNX Runtime API improvement

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 """Entry point to the optimum.exporters.onnx command line."""
 
+import logging
 from argparse import ArgumentParser
 from pathlib import Path
 
-from transformers import AutoFeatureExtractor, AutoTokenizer
+from transformers import AutoTokenizer
 
-from ...utils import logging
+from ...utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
 from ..tasks import TasksManager
 from .base import OnnxConfigWithPast
 from .convert import (
@@ -30,7 +31,7 @@ from .convert import (
 )
 
 
-logger = logging.get_logger()  # pylint: disable=invalid-name
+logger = logging.get_logger(__name__)
 logger.setLevel(logging.INFO)
 
 
@@ -143,18 +144,7 @@ def main():
     # Saving the model config as this is needed sometimes.
     model.config.save_pretrained(args.output.parent)
 
-    # Saving the tokenizer / feature extractor as well.
-    try:
-        tokenizer = AutoTokenizer.from_pretrained(args.model)
-        tokenizer.save_pretrained(args.output.parent)
-    except Exception:
-        pass
-
-    try:
-        feature_extractor = AutoFeatureExtractor.from_pretrained(args.model)
-        feature_extractor.save_pretrained(args.output.parent)
-    except Exception:
-        pass
+    maybe_save_tokenizer_or_processor_or_feature_extractor(args.model, args.output.parent)
 
     if args.atol is None:
         args.atol = onnx_config.ATOL_FOR_VALIDATION

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 """Entry point to the optimum.exporters.onnx command line."""
 
-import logging
 from argparse import ArgumentParser
 from pathlib import Path
 
 from transformers import AutoTokenizer
 
+from ...utils import logging
 from ...utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
 from ..tasks import TasksManager
 from .base import OnnxConfigWithPast
@@ -31,7 +31,7 @@ from .convert import (
 )
 
 
-logger = logging.get_logger(__name__)
+logger = logging.get_logger()
 logger.setLevel(logging.INFO)
 
 

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -354,10 +354,14 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         task: str = "default",
         patching_specs: List[PatchingSpec] = None,
         use_past: bool = False,
-        use_past_in_inputs: Optional[bool] = USE_PAST_IN_INPUTS,
-        use_present_in_outputs: Optional[bool] = USE_PRESENT_IN_OUTPUTS,
+        use_past_in_inputs: Optional[bool] = None,
+        use_present_in_outputs: Optional[bool] = None,
     ):
         self.use_past = use_past
+        if use_past_in_inputs is None:
+            use_past_in_inputs = self.USE_PAST_IN_INPUTS
+        if use_present_in_outputs is None:
+            use_present_in_outputs = self.USE_PRESENT_IN_OUTPUTS
         self.use_past_in_inputs = use_past if use_past_in_inputs is None else use_past_in_inputs
         self.use_present_in_outputs = use_past if use_present_in_outputs is None else use_present_in_outputs
         super().__init__(config, task=task, patching_specs=patching_specs)

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -344,7 +344,9 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
     Inherits from [`~exporters.onnx.OnnxConfig`]. A base class to handle the ONNX configuration of decoder-only models.
     """
 
-    PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = True
+    PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH: bool = True
+    USE_PAST_IN_INPUTS: Optional[bool] = None
+    USE_PRESENT_IN_OUTPUTS: Optional[bool] = None
 
     def __init__(
         self,
@@ -352,8 +354,12 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         task: str = "default",
         patching_specs: List[PatchingSpec] = None,
         use_past: bool = False,
+        use_past_in_inputs: Optional[bool] = USE_PAST_IN_INPUTS,
+        use_present_in_outputs: Optional[bool] = USE_PRESENT_IN_OUTPUTS,
     ):
         self.use_past = use_past
+        self.use_past_in_inputs = use_past if use_past_in_inputs is None else use_past_in_inputs
+        self.use_present_in_outputs = use_past if use_present_in_outputs is None else use_present_in_outputs
         super().__init__(config, task=task, patching_specs=patching_specs)
 
     @classmethod
@@ -375,15 +381,14 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
     @property
     def outputs(self) -> Mapping[str, Mapping[int, str]]:
         common_outputs = super().outputs
-        if self.use_past:
+        if self.use_present_in_outputs:
             self.add_past_key_values(common_outputs, direction="outputs")
-
         return common_outputs
 
     @property
     def values_override(self) -> Optional[Mapping[str, Any]]:
         if hasattr(self._config, "use_cache"):
-            return {"use_cache": self.use_past}
+            return {"use_cache": self.use_past_in_inputs or self.use_present_in_outputs}
 
     @add_dynamic_docstring(text=GENERATE_DUMMY_DOCSTRING, dynamic_elements=DEFAULT_DUMMY_SHAPES)
     def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
@@ -407,7 +412,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
         if (
             self.PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH
-            and self.use_past
+            and self.use_past_in_inputs
             and "attention_mask" in dummy_inputs
         ):
             past_length = dummy_inputs["past_key_values"][0][0].shape[2]
@@ -473,7 +478,7 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
                 # We reset the value as the order in common_outputs (OrderedDict) is lost otherwise
                 else:
                     axes_names[axis_idx] = name
-        if self.use_past:
+        if self.use_present_in_outputs:
             self.add_past_key_values(common_outputs, direction="outputs")
 
         return common_outputs

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -364,6 +364,16 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
             use_present_in_outputs = self.USE_PRESENT_IN_OUTPUTS
         self.use_past_in_inputs = use_past if use_past_in_inputs is None else use_past_in_inputs
         self.use_present_in_outputs = use_past if use_present_in_outputs is None else use_present_in_outputs
+        if use_past != self.use_past_in_inputs:
+            logger.warning(
+                f"use_past = {use_past} is different than use_past_in_inputs = {use_past_in_inputs}, the value of "
+                "use_past_in_inputs will used for the inputs."
+            )
+        if use_past != self.use_present_in_outputs:
+            logger.warning(
+                f"use_past = {use_past} is different than use_present_in_outputs = {use_present_in_outputs}, the value "
+                "of use_present_in_outputs value will used for the outputs."
+            )
         super().__init__(config, task=task, patching_specs=patching_specs)
 
     @classmethod

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -53,7 +53,7 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
         common_inputs = {"input_ids": {0: "batch_size", 1: "sequence_length"}}
-        if self.use_past:
+        if self.use_past_in_inputs:
             self.add_past_key_values(common_inputs, direction="inputs")
             common_inputs["attention_mask"] = {0: "batch_size", 1: "past_sequence_length + sequence_length"}
         else:
@@ -79,7 +79,7 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
             "input_ids": {0: "batch_size", 1: "encoder_sequence_length"},
             "attention_mask": {0: "batch_size", 1: "encoder_sequence_length"},
         }
-        if self.use_past:
+        if self.use_past_in_inputs:
             common_inputs["attention_mask"][1] = "past_encoder_sequence_length + sequence_length"
             common_inputs["decoder_input_ids"] = {0: "batch_size"}
             # common_inputs["decoder_attention_mask"] = {0: "batch", 1: "past_decoder_sequence + sequence"}
@@ -87,7 +87,7 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
             common_inputs["decoder_input_ids"] = {0: "batch_size", 1: "decoder_sequence_length"}
             # common_inputs["decoder_attention_mask"] = {0: "batch", 1: "decoder_sequence"}
 
-        if self.use_past:
+        if self.use_past_in_inputs:
             self.add_past_key_values(common_inputs, direction="inputs")
 
         return common_inputs
@@ -97,7 +97,7 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
             self.task, self._normalized_config, **kwargs
         )
 
-        if self.use_past is True:
+        if self.use_past_in_inputs is True:
             if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
                 logger.warning(
                     f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -400,7 +400,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             self.task, self._normalized_config, **kwargs
         )
 
-        if self.use_past is True:
+        if self.use_past_in_inputs is True:
             if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
                 logger.warning(
                     f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."
@@ -432,14 +432,14 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             "input_ids": {0: "batch_size", 1: "encoder_sequence_length"},
             "attention_mask": {0: "batch_size", 1: "encoder_sequence_length"},
         }
-        if self.use_past:
+        if self.use_past_in_inputs:
             common_inputs["decoder_input_ids"] = {0: "batch_size"}
             # common_inputs["decoder_attention_mask"] = {0: "batch", 1: "past_decoder_sequence + sequence"}
         else:
             common_inputs["decoder_input_ids"] = {0: "batch_size", 1: "decoder_sequence_length"}
             # common_inputs["decoder_attention_mask"] = {0: "batch", 1: "decoder_sequence"}
 
-        if self.use_past:
+        if self.use_past_in_inputs:
             self.add_past_key_values(common_inputs, direction="inputs")
         return common_inputs
 
@@ -449,7 +449,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             "input_ids": {0: "batch_size", 1: "encoder_sequence_length"},
             "attention_mask": {0: "batch_size", 1: "encoder_sequence_length"},
         }
-        if self.use_past:
+        if self.use_past_in_inputs:
             for i in range(self._normalized_config.decoder_num_layers):
                 common_inputs[f"past_key_values.{i}.key"] = {
                     0: "batch_size",
@@ -485,7 +485,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             common_outputs = super().outputs
         else:
             common_outputs = super(OnnxConfigWithPast, self).outputs
-            if self.use_past:
+            if self.use_present_in_outputs:
                 for i in range(self._normalized_config.encoder_num_layers):
                     common_outputs[f"present.{i}.key"] = {0: "batch_size", 2: "past_sequence_length + sequence_length"}
                     common_outputs[f"present.{i}.value"] = {

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Utility functions."""
 
-from ctypes import c_float, sizeof
-from enum import Enum
 from typing import TYPE_CHECKING, Dict, Tuple, Union
 
 import packaging

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -132,10 +132,10 @@ class OptimizedModel(ABC):
 
     def push_to_hub(
         self,
-        save_directory: str = None,
-        repository_id: Optional[str] = None,
+        save_directory: str,
+        repository_id: str,
         private: Optional[bool] = None,
-        use_auth_token: Optional[Union[bool, str]] = None,
+        use_auth_token: Union[bool, str] = True,
     ) -> str:
         if isinstance(use_auth_token, str):
             huggingface_token = use_auth_token

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -75,6 +75,7 @@ class OptimizedModel(ABC):
         super().__init__()
         self.model = model
         self.config = config
+        self._preprocessors = []
 
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
@@ -117,6 +118,8 @@ class OptimizedModel(ABC):
         os.makedirs(save_directory, exist_ok=True)
 
         self.config.save_pretrained(save_directory)
+        for preprocessor in self._preprocessors:
+            preprocessor.save_pretrained(save_directory)
         self._save_pretrained(save_directory, **kwargs)
 
         if push_to_hub:

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -26,10 +26,10 @@ import transformers
 from transformers import AutoModelForCausalLM, PretrainedConfig
 from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
-from huggingface_hub import HfApi, HfFolder, get_hf_file_metadata, hf_hub_download, hf_hub_url
 
 import onnxruntime
 from ..utils import NormalizedConfigManager, check_if_transformers_greater
+from huggingface_hub import HfApi, HfFolder, get_hf_file_metadata, hf_hub_download, hf_hub_url
 
 from ..exporters import TasksManager
 from ..exporters.onnx import export

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -28,11 +28,11 @@ from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
 
 import onnxruntime
-from ..utils import NormalizedConfigManager, check_if_transformers_greater
 from huggingface_hub import HfApi, HfFolder, get_hf_file_metadata, hf_hub_download, hf_hub_url
 
 from ..exporters import TasksManager
 from ..exporters.onnx import export
+from ..utils import NormalizedConfigManager, check_if_transformers_greater
 from ..utils.save_utils import maybe_load_preprocessors, maybe_save_tokenizer_or_processor_or_feature_extractor
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -638,7 +638,7 @@ class ORTModelDecoder(ORTModel):
         task: Optional[str] = None,
     ) -> "ORTModelDecoder":
         if task is None:
-            task = cls.get_task()
+            task = cls._AUTOMODELS_TO_TASKS[cls.auto_model_class]
 
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -14,25 +14,26 @@
 """Classes handling causal-lm related architectures in ONNX Runtime."""
 
 import logging
-import os
+import re
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 import transformers
 from transformers import AutoModelForCausalLM, PretrainedConfig
-from transformers.file_utils import add_start_docstrings_to_model_forward, default_cache_path
+from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
-from transformers.onnx import FeaturesManager, export
-from transformers.onnx.utils import get_preprocessor
+from huggingface_hub import HfApi, HfFolder, get_hf_file_metadata, hf_hub_download, hf_hub_url
 
 import onnxruntime
-from huggingface_hub import hf_hub_download
-
-from ..onnx.configuration import DecoderOnnxConfigWithPast
 from ..utils import NormalizedConfigManager, check_if_transformers_greater
+
+from ..exporters import TasksManager
+from ..exporters.onnx import export
+from ..utils.save_utils import maybe_load_preprocessors, maybe_save_tokenizer_or_processor_or_feature_extractor
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
 from .utils import ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, get_provider_for_device, parse_device
@@ -130,8 +131,11 @@ class ORTDecoder:
         self.session_outputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
         self.session_input_names = list(self.session_inputs.keys())
         self.session_output_names = list(self.session_outputs.keys())
-        self.key_value_input_names = [key for key in self.session_input_names if "key_values" in key]
-        self.key_value_output_names = [key for key in self.session_output_names if "key_values" in key]
+        # TODO: make this less hacky.
+        self.key_value_input_names = [key for key in self.session_input_names if (".key" in key) or (".value" in key)]
+        self.key_value_output_names = [
+            key for key in self.session_output_names if (".key" in key) or (".value" in key)
+        ]
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None
 
     def prepare_output_buffer(
@@ -321,21 +325,21 @@ class ORTModelDecoder(ORTModel):
 
     def __init__(
         self,
-        config: transformers.PretrainedConfig,
         decoder_session: onnxruntime.InferenceSession,
+        config: transformers.PretrainedConfig,
         decoder_with_past_session: Optional[onnxruntime.InferenceSession] = None,
         use_io_binding: bool = True,
-        model_save_dir: str = "",
-        last_decoder_model_name: str = ONNX_DECODER_NAME,
-        last_decoder_with_past_model_name: str = ONNX_DECODER_WITH_PAST_NAME,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        preprocessors: Optional[List] = None,
+        **kwargs
     ):
         """
         Args:
-            decoder_session (`onnxruntime.InferenceSession`):
-                The ONNX Runtime inference session associated to the decoder.
             config (`transformers.PretrainedConfig`):
                 An instance of the configuration associated to the model. Initializing with a config file does
                 not load the weights associated with the model, only the configuration.
+            decoder_session (`onnxruntime.InferenceSession`):
+                The ONNX Runtime inference session associated to the decoder.
             decoder_with_past_session (`Optional[onnxruntime.InferenceSession]`, *optional*):
                 The ONNX Runtime inference session associated to the decoder with past key values.
             use_io_binding (`bool`, *optional*, defaults to `True`):
@@ -343,26 +347,40 @@ class ORTModelDecoder(ORTModel):
                 `True` if the device is CUDA, otherwise defaults to `False`.
             model_save_dir (`str`, *optional*, defaults to `""`):
                 The directory under which the model exported to ONNX was saved.
-            last_decoder_model_name (`str`, *optional*, defaults to `optimum.onnxruntime.utils.ONNX_DECODER_NAME`):
-                The name of the ONNX file containing the decoder part of the model.
-            last_decoder_with_past_model_name (`str`, *optional*, defaults to `optimum.onnxruntime.utils.ONNX_DECODER_WITH_PAST_NAME`):
-                The name of the ONNX file containing the decoder with past key/values part of the model.
+            preprocessors (`Optional[List]`, defaults to `None`):
+                The list of the preprocessors (tokenizer, processor, feature_extractor) to save alongside the ORTModel.
         """
+        # TODO: remove at version 2.0
+        def show_deprecated_argument(arg_name):
+            if kwargs.pop(arg_name, None) is not None:
+                logger.warning(
+                    f"The {arg_name} argument to create an {self.__class__.__name__} is deprecated, and not used "
+                    "anymore."
+                )
+
+        show_deprecated_argument("last_decoder_model_name:")
+        show_deprecated_argument("last_decoder_with_past_model_name")
+        if kwargs:
+            raise ValueError(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
+            )
+
         super().__init__(
             decoder_session,
             config,
             use_io_binding=use_io_binding,
             model_save_dir=model_save_dir,
-            latest_model_name=last_decoder_model_name,
         )
-        self.decoder_file_name = last_decoder_model_name
-        self.decoder_file_with_past_name = last_decoder_with_past_model_name
-
         self.use_cache = decoder_with_past_session is not None
         self.decoder = ORTDecoder(
-            session=self.model, config=self.config, device=self._device, use_io_binding=self.use_io_binding
+            session=decoder_session, config=self.config, device=self._device, use_io_binding=self.use_io_binding
         )
+        self.decoder_model_path = Path(decoder_session._model_path)
+        self.decoder_model_name = self.decoder_model_path.name
+
         self.decoder_with_past = None
+        self.decoder_with_past_model_path = None
+        self.decoder_with_past_model_name = None
         if self.use_cache:
             self.decoder_with_past = ORTDecoder(
                 session=decoder_with_past_session,
@@ -370,6 +388,8 @@ class ORTModelDecoder(ORTModel):
                 device=self._device,
                 use_io_binding=self.use_io_binding,
             )
+            self.decoder_with_past_model_path = Path(decoder_with_past_session._model_path)
+            self.decoder_with_past_model_name = self.decoder_with_past_model_path.name
 
     @staticmethod
     def load_model(
@@ -447,14 +467,13 @@ class ORTModelDecoder(ORTModel):
                 The decoder with past key values model file name overwriting the default file name, allowing to save
                 the decoder model with a different name.
         """
-        src_file_names = [self.decoder_file_name]
+        src_paths = [self.decoder_model_path]
         dst_file_names = [decoder_file_name]
         if self.use_cache:
-            src_file_names.append(self.decoder_file_with_past_name)
+            src_paths.append(self.decoder_with_past_model_path)
             dst_file_names.append(decoder_with_past_file_name)
 
-        for src_file_name, dst_file_name in zip(src_file_names, dst_file_names):
-            src_path = self.model_save_dir.joinpath(src_file_name)
+        for src_path, dst_file_name in zip(src_paths, dst_file_names):
             dst_path = Path(save_directory).joinpath(dst_file_name)
             shutil.copyfile(src_path, dst_path)
 
@@ -465,74 +484,139 @@ class ORTModelDecoder(ORTModel):
         config: "PretrainedConfig",
         use_auth_token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
-        force_download: bool = True,
+        force_download: bool = False,
         cache_dir: Optional[str] = None,
         decoder_file_name: str = ONNX_DECODER_NAME,
         decoder_with_past_file_name: str = ONNX_DECODER_WITH_PAST_NAME,
         subfolder: str = "",
         local_files_only: bool = False,
         use_cache: bool = True,
-        use_io_binding: bool = True,
         provider: str = "CPUExecutionProvider",
         session_options: Optional[onnxruntime.SessionOptions] = None,
         provider_options: Optional[Dict[str, Any]] = None,
+        use_io_binding: bool = True,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
     ):
-        file_names = {}
-        # Load model from a local directory
-        if os.path.isdir(os.path.join(model_id, subfolder)):
-            decoder_with_past_path = (
-                os.path.join(model_id, subfolder, decoder_with_past_file_name) if use_cache else None
+        model_path = Path(model_id)
+
+        def validate_filename(filename):
+            if model_path.is_dir():
+                return (model_path / subfolder / filename).is_file()
+            succeeded = True
+            try:
+                get_hf_file_metadata(hf_hub_url(model_id, filename, subfolder=subfolder, revision=revision))
+            except Exception:
+                succeeded = False
+            return succeeded
+
+        def infer_filename(pattern: str, argument_name: str, fail_if_not_found: bool = True) -> str:
+            pattern = re.compile(f"{subfolder}/{pattern}" if subfolder != "" else pattern)
+            if model_path.is_dir():
+                path = model_path
+                files = model_path.glob("**/*.onnx")
+                onnx_files = [p for p in files if re.search(pattern, str(p))]
+            else:
+                path = model_id
+                if isinstance(use_auth_token, bool):
+                    token = HfFolder().get_token()
+                else:
+                    token = use_auth_token
+                repo_files = map(Path, HfApi().list_repo_files(model_id, revision=revision, token=token))
+                if subfolder != "":
+                    path = f"{path}/{subfolder}"
+                onnx_files = [p for p in repo_files if re.match(pattern, str(p))]
+
+            if fail_if_not_found and len(onnx_files) == 0:
+                raise FileNotFoundError(f"Could not find any ONNX model file in {path}")
+            elif len(onnx_files) > 1:
+                if argument_name is not None:
+                    raise RuntimeError(
+                        f"Too many ONNX model files were found in {path}, specify which one to load by using the "
+                        f"{argument_name} argument."
+                    )
+            return onnx_files[0].name
+
+        if not validate_filename(decoder_file_name):
+            decoder_file_name = infer_filename(r"(.*)?decoder((?!with_past).)*?\.onnx", "decoder_file_name")
+        if not validate_filename(decoder_with_past_file_name):
+            decoder_with_past_file_name = infer_filename(
+                r"(.*)?decoder(.*)?with_past(.*)?\.onnx", "decoder_with_past_file_name", fail_if_not_found=False
             )
+
+        decoder_regular_onnx_filenames = ORTModelDecoder._generate_regular_names_for_filename(ONNX_DECODER_NAME)
+        decoder_with_past_regular_onnx_filenames = ORTModelDecoder._generate_regular_names_for_filename(
+            ONNX_DECODER_WITH_PAST_NAME
+        )
+
+        if decoder_file_name not in decoder_regular_onnx_filenames:
+            logger.warning(
+                f"The ONNX file {decoder_file_name} is not a regular name used in optimum.onnxruntime, the "
+                "ORTModelForConditionalGeneration might not behave as expected."
+            )
+        if decoder_with_past_file_name not in decoder_with_past_regular_onnx_filenames:
+            logger.warning(
+                f"The ONNX file {decoder_with_past_file_name} is not a regular name used in optimum.onnxruntime, "
+                "the ORTModelForConditionalGeneration might not behave as expected."
+            )
+
+        decoder_with_past_path = model_path / decoder_with_past_file_name if use_cache else None
+
+        preprocessors = None
+        if model_path.is_dir():
             model = cls.load_model(
-                decoder_path=os.path.join(model_id, subfolder, decoder_file_name),
+                decoder_path=model_path / decoder_file_name,
                 decoder_with_past_path=decoder_with_past_path,
                 provider=provider,
                 session_options=session_options,
                 provider_options=provider_options,
             )
-            model_save_dir = Path(model_id).joinpath(subfolder)
-            file_names["last_decoder_model_name"] = decoder_file_name
-            file_names["last_decoder_with_past_model_name"] = decoder_with_past_file_name
-        # Load model from hub
+            new_model_save_dir = model_path
+            preprocessors = maybe_load_preprocessors(model_id)
         else:
-            default_file_names = [ONNX_DECODER_NAME]
-            model_file_names = [decoder_file_name]
-            if use_cache:
-                default_file_names.append(ONNX_DECODER_WITH_PAST_NAME)
-                model_file_names.append(decoder_with_past_file_name)
-            # Download the decoder and decoder_with_past forming the model
-            for file_name, default_file_name in zip(model_file_names, default_file_names):
+            attribute_name_to_filename = {
+                "last_decoder_model_name": decoder_file_name,
+                "last_decoder_with_past_model_name": decoder_with_past_file_name if use_cache else None,
+            }
+            paths = {}
+            for attr_name, filename in attribute_name_to_filename.items():
+                if filename is None:
+                    continue
                 model_cache_path = hf_hub_download(
                     repo_id=model_id,
                     subfolder=subfolder,
-                    filename=file_name,
+                    filename=filename,
                     use_auth_token=use_auth_token,
                     revision=revision,
                     cache_dir=cache_dir,
                     force_download=force_download,
                     local_files_only=local_files_only,
                 )
-                file_names[f"last_{default_file_name.split('.')[0]}_name"] = Path(model_cache_path).name
-            model_save_dir = Path(model_cache_path).parent
+                paths[attr_name] = Path(model_cache_path).name
+            new_model_save_dir = Path(model_cache_path).parent
+            preprocessors = maybe_load_preprocessors(model_id, subfolder=subfolder)
 
-            last_decoder_with_past_name = file_names.get("last_decoder_with_past_model_name", None)
+            last_decoder_with_past_name = paths.get("last_decoder_with_past_model_name", None)
             if last_decoder_with_past_name is not None:
-                last_decoder_with_past_name = model_save_dir.joinpath(last_decoder_with_past_name)
+                last_decoder_with_past_name = new_model_save_dir / last_decoder_with_past_name
+
             model = cls.load_model(
-                decoder_path=model_save_dir.joinpath(file_names["last_decoder_model_name"]),
+                decoder_path=new_model_save_dir / paths["last_decoder_model_name"],
                 decoder_with_past_path=last_decoder_with_past_name,
                 provider=provider,
                 session_options=session_options,
                 provider_options=provider_options,
             )
 
+        if model_save_dir is None:
+            model_save_dir = new_model_save_dir
+
         return cls(
+            model[0],
             config,
-            *model,
+            decoder_with_past_session=model[1],
             use_io_binding=use_io_binding,
             model_save_dir=model_save_dir,
-            last_decoder_model_name=file_names["last_decoder_model_name"],
-            last_decoder_with_past_model_name=file_names.get("last_decoder_with_past_model_name", None),
+            preprocessors=preprocessors,
         )
 
     @classmethod
@@ -540,46 +624,70 @@ class ORTModelDecoder(ORTModel):
         cls,
         model_id: str,
         config: "PretrainedConfig",
-        subfolder: Optional[str] = "",
-        save_dir: Union[str, Path] = default_cache_path,
         use_auth_token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
+        revision: str = "main",
         force_download: bool = True,
         cache_dir: Optional[str] = None,
+        subfolder: str = "",
+        local_files_only: bool = False,
         use_cache: bool = True,
-        **kwargs,
+        provider: str = "CPUExecutionProvider",
+        session_options: Optional[onnxruntime.SessionOptions] = None,
+        provider_options: Optional[Dict[str, Any]] = None,
+        use_io_binding: bool = True,
     ):
-        # Create local save dir in cache dir
-        save_dir = Path(save_dir).joinpath(model_id)
-        save_dir.mkdir(parents=True, exist_ok=True)
-        preprocessor = get_preprocessor(model_id)
-        framework = FeaturesManager.determine_framework(os.path.join(model_id, subfolder))
-        model_class = FeaturesManager.get_model_class_for_feature(cls.export_feature, framework)
-        model = model_class.from_pretrained(model_id, subfolder=subfolder, config=config, cache_dir=cache_dir)
+        save_dir = TemporaryDirectory()
+        save_dir_path = Path(save_dir.name)
 
-        # Export the decoder without the past key values
-        onnx_config = DecoderOnnxConfigWithPast(model.config, task=cls.export_feature, use_past=False)
-        onnx_opset = onnx_config.default_onnx_opset
-        export(
-            preprocessor=preprocessor,
-            model=model,
-            config=onnx_config,
-            opset=onnx_opset,
-            output=save_dir.joinpath(ONNX_DECODER_NAME),
+        model = TasksManager.get_model_from_task(
+            cls.export_feature,
+            model_id,
+            subfolder=subfolder,
+            revision=revision,
+            cache_dir=cache_dir,
+            config=config,
+            use_auth_token=use_auth_token,
+            local_files_only=local_files_only,
+            force_download=force_download,
         )
 
-        # Export the decoder with the past key values
+        model_type = model.config.model_type.replace("_", "-")
+        model_name = getattr(model, "name", None)
+
+        onnx_config_constructor = TasksManager.get_exporter_config_constructor(
+            model_type, "onnx", task=cls.export_feature, model_name=model_name
+        )
+        onnx_config = onnx_config_constructor(model.config, use_present_in_outputs=True)
+
+        export(
+            model,
+            onnx_config,
+            onnx_config.DEFAULT_ONNX_OPSET,
+            save_dir_path.joinpath(ONNX_DECODER_NAME),
+        )
+
         if use_cache:
-            onnx_config_with_past = DecoderOnnxConfigWithPast(model.config, task=cls.export_feature, use_past=True)
+            onnx_config = onnx_config_constructor(model.config, use_past=True)
             export(
-                preprocessor=preprocessor,
-                model=model,
-                config=onnx_config_with_past,
-                opset=onnx_opset,
-                output=save_dir.joinpath(ONNX_DECODER_WITH_PAST_NAME),
+                model,
+                onnx_config,
+                onnx_config.DEFAULT_ONNX_OPSET,
+                save_dir_path.joinpath(ONNX_DECODER_WITH_PAST_NAME),
             )
 
-        return cls._from_pretrained(save_dir, config=config, use_cache=use_cache, **kwargs)
+        config.save_pretrained(save_dir_path)
+        maybe_save_tokenizer_or_processor_or_feature_extractor(model_id, save_dir_path, src_subfolder=subfolder)
+
+        return cls._from_pretrained(
+            save_dir_path,
+            config,
+            use_cache=use_cache,
+            provider=provider,
+            session_options=session_options,
+            provider_options=provider_options,
+            use_io_binding=use_io_binding,
+            model_save_dir=save_dir,
+        )
 
     def to(self, device: Union[torch.device, str, int]):
         """
@@ -612,8 +720,6 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
     ONNX model with a causal language modeling head for ONNX Runtime inference.
     """
 
-    # Used to export the model to ONNX
-    export_feature = "causal-lm"
     auto_model_class = AutoModelForCausalLM
     main_input_name = "input_ids"
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -147,7 +147,7 @@ class ORTModel(OptimizedModel):
     @classproperty
     def export_feature(cls):
         logger.warning(f"{cls.__name__}.export_feature is deprecated, and will be removed in optimum 2.0.")
-        return _AUTOMODELS_TO_TASKS.get(cls.auto_model_class, None)
+        return cls._AUTOMODELS_TO_TASKS.get(cls.auto_model_class, None)
 
     def __init__(
         self,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -46,6 +46,7 @@ from huggingface_hub import HfApi, HfFolder, hf_hub_download
 from ..exporters import TasksManager
 from ..exporters.onnx import export
 from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
+from ..utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
 from .io_binding import TypeHelper
 from .utils import (
     ONNX_WEIGHTS_NAME,
@@ -142,8 +143,7 @@ class ORTModel(OptimizedModel):
         model_save_dir: Optional[str] = None,
         latest_model_name: str = "model.onnx",
     ):
-        self.model = model
-        self.config = config
+        super().__init__(model, config)
         self.use_io_binding = use_io_binding
         self.model_save_dir = model_save_dir
         self.latest_model_name = latest_model_name

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -398,7 +398,8 @@ class ORTModel(OptimizedModel):
             output=save_dir.joinpath(ONNX_WEIGHTS_NAME),
         )
 
-        return cls._from_pretrained(save_dir.as_posix(), config, **kwargs)
+        model_dir = save_dir if subfolder == "" else save_dir.parent
+        return cls._from_pretrained(model_dir, config, subfolder=subfolder, **kwargs)
 
     @classmethod
     @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -107,6 +107,8 @@ ONNX_IMAGE_INPUTS_DOCSTRING = r"""
             Pixel values can be obtained from encoded images using [`AutoFeatureExtractor`](https://huggingface.co/docs/transformers/autoclass_tutorial#autofeatureextractor).
 """
 
+_AUTOMODELS_TO_TASKS = {cls_: task for task, cls_ in TasksManager._TASKS_TO_AUTOMODELS.items()}
+
 
 class ORTModel(OptimizedModel):
     """
@@ -382,19 +384,7 @@ class ORTModel(OptimizedModel):
         provider_options: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> "ORTModel":
-        # Reads pipeline task from ORTModelForXXX class if available else tries to extract from hub
-        if cls.export_feature is not None:
-            task = cls.export_feature
-        else:
-            pass
-            # # TODO: Do we want to actually support that?
-            # # TODO: load from subfolder?
-            # task = TasksManager.infer_task_from_model(model_id, revision=revision)
-            # # TODO: is it still needed?
-            # if task in ["sentiment-analysis", "text-classification", "zero-shot-classification"]:
-            #     task = "sequence-classification"
-            # elif task in ["feature-extraction", "fill-mask"]:
-            #     task = "default"
+        task = _AUTOMODELS_TO_TASKS[cls.auto_model_class]
 
         kwargs_to_get_model = {
             "subfolder": subfolder,
@@ -515,8 +505,6 @@ class ORTModelForFeatureExtraction(ORTModel):
     Feature Extraction model for ONNX.
     """
 
-    # used in from_transformers to export model to onnx
-    export_feature = "default"
     auto_model_class = AutoModel
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
@@ -688,7 +676,6 @@ class ORTModelForQuestionAnswering(ORTModel):
     Question Answering model for ONNX.
     """
 
-    export_feature = "question-answering"
     auto_model_class = AutoModelForQuestionAnswering
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
@@ -888,7 +875,6 @@ class ORTModelForSequenceClassification(ORTModel):
     Sequence Classification model for ONNX.
     """
 
-    export_feature = "sequence-classification"
     auto_model_class = AutoModelForSequenceClassification
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
@@ -1059,7 +1045,6 @@ class ORTModelForTokenClassification(ORTModel):
     Token Classification model for ONNX.
     """
 
-    export_feature = "token-classification"
     auto_model_class = AutoModelForTokenClassification
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
@@ -1225,7 +1210,6 @@ class ORTModelForMultipleChoice(ORTModel):
     Multiple choice model for ONNX.
     """
 
-    export_feature = "multiple-choice"
     auto_model_class = AutoModelForMultipleChoice
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
@@ -1395,7 +1379,6 @@ class ORTModelForImageClassification(ORTModel):
     Image Classification model for ONNX.
     """
 
-    export_feature = "image-classification"
     auto_model_class = AutoModelForImageClassification
 
     def __init__(self, model=None, config=None, use_io_binding=True, **kwargs):
@@ -1526,8 +1509,8 @@ class ORTModelForCustomTasks(ORTModel):
     Onnx Model for any custom tasks.
     """
 
-    export_feature = "default"
     auto_model_class = AutoModel
+    # TODO: support providing a task
 
     def __init__(self, model=None, config=None, **kwargs):
         super().__init__(model, config, **kwargs)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -298,6 +298,10 @@ class ORTModel(OptimizedModel):
         return [filename, f"{name}_quantized.{extension}", f"{name}_optimized.{extension}"]
 
     @classmethod
+    def get_task(cls):
+        return _AUTOMODELS_TO_TASKS[cls.auto_model_class]
+
+    @classmethod
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],
@@ -404,7 +408,7 @@ class ORTModel(OptimizedModel):
         task: Optional[str] = None,
     ) -> "ORTModel":
         if task is None:
-            task = _AUTOMODELS_TO_TASKS[cls.auto_model_class]
+            task = cls.get_task()
 
         kwargs_to_get_model = {
             "subfolder": subfolder,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -47,7 +47,7 @@ from huggingface_hub import HfApi, HfFolder, hf_hub_download
 from ..exporters import TasksManager
 from ..exporters.onnx import export
 from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
-from ..utils.save_utils import maybe_load_preprocessors, maybe_save_tokenizer_or_processor_or_feature_extractor
+from ..utils.save_utils import maybe_load_preprocessors, maybe_save_preprocessors
 from .io_binding import TypeHelper
 from .utils import (
     ONNX_WEIGHTS_NAME,
@@ -440,7 +440,7 @@ class ORTModel(OptimizedModel):
             output=tmp_dir_path / ONNX_WEIGHTS_NAME,
         )
         config.save_pretrained(tmp_dir_path)
-        maybe_save_tokenizer_or_processor_or_feature_extractor(model_id, tmp_dir_path, src_subfolder=subfolder)
+        maybe_save_preprocessors(model_id, tmp_dir_path, src_subfolder=subfolder)
 
         return cls._from_pretrained(
             tmp_dir_path,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -14,7 +14,6 @@
 """ORTModelForXXX classes, allowing to run ONNX Models with ONNX Runtime using the same API as Transformers."""
 
 import logging
-import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
@@ -42,7 +41,7 @@ from transformers.modeling_outputs import (
 )
 
 import onnxruntime as ort
-from huggingface_hub import hf_hub_download, get_hf_file_metadata, hf_hub_url, HfApi, HfFolder
+from huggingface_hub import HfApi, HfFolder, hf_hub_download
 
 from ..exporters import TasksManager
 from ..exporters.onnx import export
@@ -299,7 +298,7 @@ class ORTModel(OptimizedModel):
                     token = use_auth_token
                 repo_files = map(Path, HfApi().list_repo_files(model_id, revision=revision, token=token))
                 pattern = "*.onnx" if subfolder == "" else f"{subfolder}/*.onnx"
-                onnx_files = [p.match(pattern) for p in repo_files]
+                onnx_files = [p for p in repo_files if p.match(pattern)]
 
             if len(onnx_files) == 0:
                 raise FileNotFoundError(f"Could not find any ONNX model file in {model_path}")

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -17,7 +17,6 @@ Transformers.
 """
 
 import logging
-import os
 import re
 import shutil
 from abc import ABC, abstractmethod
@@ -27,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from transformers import AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq, AutoTokenizer
+from transformers import AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq
 from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.generation_utils import GenerationMixin
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
@@ -40,12 +39,13 @@ from ..exporters.tasks import TasksManager
 from ..utils import NormalizedConfigManager, check_if_transformers_greater
 from ..utils.save_utils import maybe_load_preprocessors, maybe_save_tokenizer_or_processor_or_feature_extractor
 from .io_binding import TypeHelper
+from .modeling_decoder import ORTDecoder
 from .modeling_ort import ORTModel
 from .utils import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
     ONNX_ENCODER_NAME,
-    get_device_for_provider,
+    ORTConfigManager,
     get_provider_for_device,
     parse_device,
     validate_provider_availability,
@@ -201,6 +201,484 @@ AUTOMATIC_SPEECH_RECOGNITION_EXAMPLE = r"""
 """
 
 
+class ORTEncoder:
+    """
+    Encoder model for ONNX Runtime inference.
+
+    Args:
+        session (`ort.InferenceSession`):
+            The ONNX Runtime inference session associated to the encoder.
+    """
+
+    def __init__(
+        self,
+        session: ort.InferenceSession,
+        config: "PretrainedConfig",
+        device: torch.device,
+        use_io_binding: bool = True,
+        main_input_name: str = "input_ids",
+    ):
+        self.session = session
+        self.config = config
+        self._device = device
+        self.use_io_binding = use_io_binding
+        self.main_input_name = main_input_name
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(
+            self.config
+        )
+        self.input_names = {input_key.name: idx for idx, input_key in enumerate(self.session.get_inputs())}
+        self.output_names = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
+        self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None
+
+    def prepare_output_buffer(self, batch_size, sequence_length):
+        """Prepare the buffer of output(`last_hidden_state`) with a 1D tensor on shape: (batch_size, sequence_length, hidden_size)."""
+        ort_type = TypeHelper.get_output_type(self.session, "last_hidden_state")
+        torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
+
+        hidden_size = self.normalized_config.hidden_size
+        output_shape = (batch_size, sequence_length, hidden_size)
+        output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
+
+        return output_shape, output_buffer
+
+    def prepare_io_binding(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+    ):
+        io_binding = self.session.io_binding()
+
+        # bind input ids
+        input_ids = input_ids.contiguous()
+        io_binding.bind_input(
+            "input_ids",
+            input_ids.device.type,
+            self._device.index,
+            self.name_to_np_type["input_ids"],
+            tuple(input_ids.shape),
+            input_ids.data_ptr(),
+        )
+        if "attention_mask" in self.input_names:
+            # bind attention mask
+            attention_mask = attention_mask.contiguous()
+            io_binding.bind_input(
+                "attention_mask",
+                attention_mask.device.type,
+                self._device.index,
+                self.name_to_np_type["attention_mask"],
+                tuple(attention_mask.shape),
+                attention_mask.data_ptr(),
+            )
+
+        # bind last_hidden_state
+        output_shape, output_buffer = self.prepare_output_buffer(
+            batch_size=input_ids.size(0),
+            sequence_length=input_ids.size(1),
+        )
+        io_binding.bind_output(
+            "last_hidden_state",
+            output_buffer.device.type,
+            self._device.index,
+            self.name_to_np_type["last_hidden_state"],
+            output_shape,
+            output_buffer.data_ptr(),
+        )
+        output_shapes = {"last_hidden_state": output_shape}
+        output_buffers = {"last_hidden_state": output_buffer}
+
+        return io_binding, output_shapes, output_buffers
+
+    @add_start_docstrings_to_model_forward(SEQ2SEQ_ENCODER_INPUTS_DOCSTRING)
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.LongTensor,
+        **kwargs,
+    ) -> BaseModelOutput:
+
+        if self._device.type == "cuda" and self.use_io_binding:
+            io_binding, output_shapes, output_buffers = self.prepare_io_binding(input_ids, attention_mask)
+
+            # run inference with binding & synchronize in case of multiple CUDA streams
+            io_binding.synchronize_inputs()
+            self.session.run_with_iobinding(io_binding)
+            io_binding.synchronize_outputs()
+
+            # converts output to namedtuple for pipelines post-processing
+            return BaseModelOutput(
+                last_hidden_state=output_buffers["last_hidden_state"].view(output_shapes["last_hidden_state"])
+            )
+        else:
+            onnx_inputs = {"input_ids": input_ids.cpu().detach().numpy()}
+
+            # Add the attention_mask inputs when needed
+            if "attention_mask" in self.input_names:
+                onnx_inputs["attention_mask"] = attention_mask.cpu().detach().numpy()
+
+            # Run inference
+            outputs = self.session.run(None, onnx_inputs)
+            last_hidden_state = torch.from_numpy(outputs[self.output_names["last_hidden_state"]]).to(self._device)
+
+            return BaseModelOutput(last_hidden_state=last_hidden_state)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+class ORTEncoderForWhisper(ORTEncoder):
+    """
+    Encoder model for ONNX Runtime inference for Whisper model.
+
+    Args:
+        session (`ort.InferenceSession`):
+            The ONNX Runtime inference session associated to the encoder.
+    """
+
+    def prepare_io_binding(
+        self,
+        input_features: torch.FloatTensor = None,
+    ):
+        io_binding = self.session.io_binding()
+
+        # bind input features
+        input_features = input_features.contiguous()
+        io_binding.bind_input(
+            "input_features",
+            input_features.device.type,
+            self._device.index,
+            self.name_to_np_type["input_features"],
+            tuple(input_features.shape),
+            input_features.data_ptr(),
+        )
+
+        # bind logits
+        output_shape, output_buffer = self.prepare_output_buffer(
+            batch_size=input_features.size(0),
+            sequence_length=input_features.size(2) // 2,
+        )
+        io_binding.bind_output(
+            "last_hidden_state",
+            output_buffer.device.type,
+            self._device.index,
+            self.name_to_np_type["last_hidden_state"],
+            output_shape,
+            output_buffer.data_ptr(),
+        )
+        output_shapes = {"last_hidden_state": output_shape}
+        output_buffers = {"last_hidden_state": output_buffer}
+
+        return io_binding, output_shapes, output_buffers
+
+    @add_start_docstrings_to_model_forward(WHISPER_ENCODER_INPUTS_DOCSTRING)
+    def forward(
+        self,
+        input_features: torch.FloatTensor,
+        **kwargs,
+    ) -> BaseModelOutput:
+        if self._device.type == "cuda" and self.use_io_binding:
+            io_binding, output_shapes, output_buffers = self.prepare_io_binding(input_features)
+
+            # run inference with binding & synchronize in case of multiple CUDA streams
+            io_binding.synchronize_inputs()
+            self.session.run_with_iobinding(io_binding)
+            io_binding.synchronize_outputs()
+
+            # converts output to namedtuple for pipelines post-processing
+            return BaseModelOutput(
+                last_hidden_state=output_buffers["last_hidden_state"].view(output_shapes["last_hidden_state"])
+            )
+        else:
+            onnx_inputs = {"input_features": input_features.cpu().detach().numpy()}
+
+            # Run inference
+            outputs = self.session.run(None, onnx_inputs)
+            last_hidden_state = torch.from_numpy(outputs[self.output_names["last_hidden_state"]]).to(self._device)
+
+            return BaseModelOutput(last_hidden_state=last_hidden_state)
+
+
+class ORTDecoderForSeq2Seq(ORTDecoder):
+    """
+    Decoder model with a language modeling head on top for ONNX Runtime inference.
+    """
+
+    def prepare_output_buffer(
+        self,
+        output_name,
+        batch_size=None,
+        sequence_length=None,
+        encoder_sequence_length=None,
+        past_sequence_length=None,
+        is_self_attn=False,
+    ):
+        """
+        Prepare the buffer of outputs(`logits`/`key_values`/`loss`) with 1D tensors.
+        """
+        ort_type = TypeHelper.get_output_type(self.session, output_name)
+        torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
+        if output_name == "loss":
+            output_shape = (1,)
+            output_buffer = torch.empty(1, dtype=torch_type, device=self._device).contiguous()
+        elif output_name == "logits":
+            output_shape = (batch_size, sequence_length, self.normalized_config.vocab_size)
+            output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
+        elif ".key" in output_name or ".value" in output_name:
+            num_attention_heads = self.normalized_config.num_attention_heads
+            hidden_size = self.normalized_config.hidden_size
+            embed_size_per_head = hidden_size // num_attention_heads
+            if is_self_attn:
+                if past_sequence_length is not None:
+                    sequence_length += past_sequence_length
+                output_shape = (batch_size, num_attention_heads, sequence_length, embed_size_per_head)
+            else:
+                output_shape = (batch_size, num_attention_heads, encoder_sequence_length, embed_size_per_head)
+
+            output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
+
+        return output_shape, output_buffer
+
+    def prepare_io_binding(
+        self,
+        input_ids: torch.LongTensor,
+        encoder_hidden_states: torch.FloatTensor,
+        encoder_attention_mask: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        labels: Optional[torch.LongTensor] = None,
+    ):
+        io_binding = self.session.io_binding()
+
+        # bind input ids
+        input_ids = input_ids.contiguous()
+        io_binding.bind_input(
+            "input_ids",
+            input_ids.device.type,
+            self._device.index,
+            self.name_to_np_type["input_ids"],
+            list(input_ids.size()),
+            input_ids.data_ptr(),
+        )
+
+        # bind encoder attention mask
+        if "encoder_attention_mask" in self.session_input_names:
+            encoder_attention_mask = encoder_attention_mask.contiguous()
+            io_binding.bind_input(
+                "encoder_attention_mask",
+                encoder_attention_mask.device.type,
+                self._device.index,
+                self.name_to_np_type["encoder_attention_mask"],
+                list(encoder_attention_mask.size()),
+                encoder_attention_mask.data_ptr(),
+            )
+
+        # bind encoder hidden states
+        if "encoder_hidden_states" in self.session_input_names:
+            encoder_hidden_states = encoder_hidden_states.contiguous()
+            io_binding.bind_input(
+                "encoder_hidden_states",
+                encoder_hidden_states.device.type,
+                self._device.index,
+                self.name_to_np_type["encoder_hidden_states"],
+                list(encoder_hidden_states.size()),
+                encoder_hidden_states.data_ptr(),
+            )
+
+        # bind past key values
+        if past_key_values is not None:
+            for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
+                past_key_value = past_key_value.contiguous()
+                io_binding.bind_input(
+                    input_name,
+                    past_key_value.device.type,
+                    self._device.index,
+                    self.name_to_np_type[input_name],
+                    list(past_key_value.size()),
+                    past_key_value.data_ptr(),
+                )
+
+        # bind labels
+        if "labels" in self.session_input_names:
+            labels = labels.contiguous()
+            io_binding.bind_input(
+                "labels",
+                labels.device.type,
+                self._device.index,
+                self.name_to_np_type["labels"],
+                list(labels.size()),
+                labels.data_ptr(),
+            )
+
+        # bind outputs
+        # bind logits
+        logits_shape, logits_buffer = self.prepare_output_buffer(
+            output_name="logits",
+            batch_size=input_ids.size(0),
+            sequence_length=input_ids.size(1),
+        )
+        io_binding.bind_output(
+            "logits",
+            logits_buffer.device.type,
+            self._device.index,
+            self.name_to_np_type["logits"],
+            logits_shape,
+            logits_buffer.data_ptr(),
+        )
+        output_shapes = {"logits": logits_shape}
+        output_buffers = {"logits": logits_buffer}
+        # bind loss
+        if "loss" in self.session_output_names:
+            loss_shape, loss_buffer = self.prepare_output_buffer(output_name="loss")
+            io_binding.bind_output(
+                "loss",
+                loss_buffer.device.type,
+                self._device.index,
+                self.name_to_np_type["loss"],
+                loss_shape,
+                loss_buffer.data_ptr(),
+            )
+            output_shapes["loss"] = loss_shape
+            output_buffers["loss"] = loss_buffer
+
+        # bind past key values
+        num_pkv = 4  # number of self-attention and cross-attention per decoder layer
+        for pkv_names_per_layer in [
+            self.key_value_output_names[i : i + num_pkv] for i in range(0, len(self.key_value_output_names), num_pkv)
+        ]:
+            # bind a self attention and a cross-attention each time(2)
+            for i in range(2):
+                # bind self-attention past key values(2)
+                self_name = pkv_names_per_layer[i]
+                self_pkv_shape, self_pkv_buffer = self.prepare_output_buffer(
+                    output_name=self_name,
+                    batch_size=input_ids.size(0),
+                    sequence_length=input_ids.size(1),
+                    past_sequence_length=past_key_values[0].size(2)
+                    if past_key_values
+                    else None,  # sequence length of self-attention key for layer.0
+                    is_self_attn=True,
+                )
+                io_binding.bind_output(
+                    self_name,
+                    self_pkv_buffer.device.type,
+                    self._device.index,
+                    self.name_to_np_type[self_name],
+                    self_pkv_shape,
+                    self_pkv_buffer.data_ptr(),
+                )
+                # set -1 for sequence_length as it could be larger than the real sequence_length for creating buffer
+                self_pkv_shape = self_pkv_shape[:2] + (-1,) + self_pkv_shape[3:]
+                output_shapes[self_name] = self_pkv_shape
+                output_buffers[self_name] = self_pkv_buffer
+
+                # bind cross-attention past key values(2)
+                cross_name = pkv_names_per_layer[i + 2]
+                cross_pkv_shape, cross_pkv_buffer = self.prepare_output_buffer(
+                    output_name=cross_name,
+                    batch_size=input_ids.size(0),
+                    encoder_sequence_length=encoder_hidden_states.size(1),
+                )
+                io_binding.bind_output(
+                    cross_name,
+                    cross_pkv_buffer.device.type,
+                    self._device.index,
+                    self.name_to_np_type[cross_name],
+                    cross_pkv_shape,
+                    cross_pkv_buffer.data_ptr(),
+                )
+                # set -1 for sequence_length as it could be larger than the real sequence_length for creating buffer
+                cross_pkv_shape = cross_pkv_shape[:2] + (-1,) + cross_pkv_shape[3:]
+                output_shapes[cross_name] = cross_pkv_shape
+                output_buffers[cross_name] = cross_pkv_buffer
+
+        return io_binding, output_shapes, output_buffers
+
+    @add_start_docstrings_to_model_forward(DECODER_INPUTS_DOCSTRING)
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        encoder_hidden_states: torch.FloatTensor,
+        encoder_attention_mask: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        labels: Optional[torch.LongTensor] = None,
+    ) -> Seq2SeqLMOutput:
+        # Flatten the past_key_values
+        if past_key_values is not None:
+            past_key_values = [past_key_value for pkv_per_layer in past_key_values for past_key_value in pkv_per_layer]
+
+        if self._device.type == "cuda" and self.use_io_binding:
+            io_binding, output_shapes, output_buffers = self.prepare_io_binding(
+                input_ids, encoder_hidden_states, encoder_attention_mask, past_key_values, labels
+            )
+
+            # run inference with binding & synchronize in case of multiple CUDA streams
+            io_binding.synchronize_inputs()
+            self.session.run_with_iobinding(io_binding)
+            io_binding.synchronize_outputs()
+
+            # Tuple of length equal to : number of layer * number of past_key_value per decoder layer (2 corresponds to the
+            # self-attention layer and 2 to the cross-attention layer)
+            past_key_values = tuple()
+            for name in self.key_value_output_names:
+                past_key_values += (output_buffers[name].view(output_shapes[name]),)
+
+            # Tuple of tuple of length `n_layers`, with each tuple of length equal to the number of self-attention and
+            # cross-attention per decoder layer
+            num_pkv = 4
+            past_key_values = tuple(past_key_values[i : i + num_pkv] for i in range(0, len(past_key_values), num_pkv))
+
+            logits = output_buffers["logits"].view(output_shapes["logits"])
+
+            loss = None
+            if "loss" in self.session_output_names:
+                loss = output_buffers["loss"].view(output_shapes["loss"])
+        else:
+            onnx_inputs = {
+                "input_ids": input_ids.cpu().detach().numpy(),
+            }
+
+            # Add the encoder_attention_mask inputs when needed
+            if "encoder_attention_mask" in self.session_input_names:
+                onnx_inputs["encoder_attention_mask"] = encoder_attention_mask.cpu().detach().numpy()
+
+            # Add the encoder_hidden_states inputs when needed
+            if "encoder_hidden_states" in self.session_input_names:
+                onnx_inputs["encoder_hidden_states"] = encoder_hidden_states.cpu().detach().numpy()
+
+            if past_key_values is not None:
+                # Add the past_key_values to the decoder inputs
+                for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
+                    onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
+
+            if "labels" in self.session_input_names:
+                # TODO: Any preprocessing like  `self._shift_right(labels)`?
+                onnx_inputs["labels"] = labels.cpu().detach().numpy()
+
+            # Run inference
+            outputs = self.session.run(None, onnx_inputs)
+
+            # Tuple of length equal to : number of layer * number of past_key_value per decoder layer (2 corresponds to the
+            # self-attention layer and 2 to the cross-attention layer)
+            past_key_values = tuple(
+                torch.from_numpy(outputs[self.session_outputs[key]]).to(self._device)
+                for key in self.key_value_output_names
+            )
+
+            # Tuple of tuple of length `n_layers`, with each tuple of length equal to the number of self-attention and
+            # cross-attention per decoder layer
+            num_pkv = 4
+            past_key_values = tuple(past_key_values[i : i + num_pkv] for i in range(0, len(past_key_values), num_pkv))
+            logits = torch.from_numpy(outputs[self.session_outputs["logits"]]).to(self._device)
+
+            loss = None
+            if "loss" in self.session_output_names:
+                loss = torch.from_numpy(outputs[self.session_outputs["loss"]]).to(self._device)
+
+        # converts output to namedtuple for pipelines post-processing
+        return Seq2SeqLMOutput(loss=loss, logits=logits, past_key_values=past_key_values)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
 class ORTModelForConditionalGeneration(ORTModel, ABC):
     """
     Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
@@ -219,9 +697,9 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             The list of execution providers the model is running on.
         encoder (`ORTEncoder`):
             The encoder model.
-        decoder (`ORTDecoder`):
+        decoder (`ORTDecoderForSeq2Seq`):
             The decoder model.
-        decoder_with_past (`Optional[ORTDecoder]`):
+        decoder_with_past (`Optional[ORTDecoderForSeq2Seq]`):
             The decoder model handling the past key/values if `use_cache=True`, else `None`.
 
     Other attributes:
@@ -301,7 +779,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         self.encoder_model_path = Path(encoder_session._model_path)
         self.encoder_model_name = self.encoder_model_path.name
 
-        self.decoder = ORTDecoder(
+        self.decoder = ORTDecoderForSeq2Seq(
             session=decoder_session, config=self.config, device=self._device, use_io_binding=self.use_io_binding
         )
         self.decoder_model_path = Path(decoder_session._model_path)
@@ -315,7 +793,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         self.decoder_with_past_model_path = None
         self.decoder_with_past_model_name = None
         if self.use_cache:
-            self.decoder_with_past = ORTDecoder(
+            self.decoder_with_past = ORTDecoderForSeq2Seq(
                 session=decoder_with_past_session,
                 config=self.config,
                 device=self._device,
@@ -608,12 +1086,16 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         session_options: Optional[ort.SessionOptions] = None,
         provider_options: Optional[Dict[str, Any]] = None,
         use_io_binding: bool = True,
-    ):
+        task: Optional[str] = None,
+    ) -> "ORTModelForConditionalGeneration":
+        if task is None:
+            task = cls.get_task()
+
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
 
         model = TasksManager.get_model_from_task(
-            cls.export_feature,
+            task,
             model_id,
             subfolder=subfolder,
             revision=revision,
@@ -628,7 +1110,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         model_name = getattr(model, "name", None)
 
         onnx_config_constructor = TasksManager.get_exporter_config_constructor(
-            model_type, "onnx", task=cls.export_feature, model_name=model_name
+            model_type, "onnx", task=task, model_name=model_name
         )
         onnx_config = onnx_config_constructor(model.config, use_past=use_cache)
         onnx_opset = onnx_config.DEFAULT_ONNX_OPSET
@@ -686,515 +1168,11 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         return self
 
 
-class ORTEncoder:
-    """
-    Encoder model for ONNX Runtime inference.
-
-    Args:
-        session (`ort.InferenceSession`):
-            The ONNX Runtime inference session associated to the encoder.
-    """
-
-    def __init__(
-        self,
-        session: ort.InferenceSession,
-        config: "PretrainedConfig",
-        device: torch.device,
-        use_io_binding: bool = True,
-        main_input_name: str = "input_ids",
-    ):
-        self.session = session
-        self.config = config
-        self._device = device
-        self.use_io_binding = use_io_binding
-        self.main_input_name = main_input_name
-        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(
-            self.config
-        )
-        self.input_names = {input_key.name: idx for idx, input_key in enumerate(self.session.get_inputs())}
-        self.output_names = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
-        self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None
-
-    def prepare_output_buffer(self, batch_size, sequence_length):
-        """Prepare the buffer of output(`last_hidden_state`) with a 1D tensor on shape: (batch_size, sequence_length, hidden_size)."""
-        ort_type = TypeHelper.get_output_type(self.session, "last_hidden_state")
-        torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
-
-        hidden_size = self.normalized_config.hidden_size
-        output_shape = (batch_size, sequence_length, hidden_size)
-        output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
-
-        return output_shape, output_buffer
-
-    def prepare_io_binding(
-        self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-    ):
-        io_binding = self.session.io_binding()
-
-        # bind input ids
-        input_ids = input_ids.contiguous()
-        io_binding.bind_input(
-            "input_ids",
-            input_ids.device.type,
-            self._device.index,
-            self.name_to_np_type["input_ids"],
-            tuple(input_ids.shape),
-            input_ids.data_ptr(),
-        )
-        if "attention_mask" in self.input_names:
-            # bind attention mask
-            attention_mask = attention_mask.contiguous()
-            io_binding.bind_input(
-                "attention_mask",
-                attention_mask.device.type,
-                self._device.index,
-                self.name_to_np_type["attention_mask"],
-                tuple(attention_mask.shape),
-                attention_mask.data_ptr(),
-            )
-
-        # bind last_hidden_state
-        output_shape, output_buffer = self.prepare_output_buffer(
-            batch_size=input_ids.size(0),
-            sequence_length=input_ids.size(1),
-        )
-        io_binding.bind_output(
-            "last_hidden_state",
-            output_buffer.device.type,
-            self._device.index,
-            self.name_to_np_type["last_hidden_state"],
-            output_shape,
-            output_buffer.data_ptr(),
-        )
-        output_shapes = {"last_hidden_state": output_shape}
-        output_buffers = {"last_hidden_state": output_buffer}
-
-        return io_binding, output_shapes, output_buffers
-
-    @add_start_docstrings_to_model_forward(SEQ2SEQ_ENCODER_INPUTS_DOCSTRING)
-    def forward(
-        self,
-        input_ids: torch.LongTensor,
-        attention_mask: torch.LongTensor,
-        **kwargs,
-    ) -> BaseModelOutput:
-
-        if self._device.type == "cuda" and self.use_io_binding:
-            io_binding, output_shapes, output_buffers = self.prepare_io_binding(input_ids, attention_mask)
-
-            # run inference with binding & synchronize in case of multiple CUDA streams
-            io_binding.synchronize_inputs()
-            self.session.run_with_iobinding(io_binding)
-            io_binding.synchronize_outputs()
-
-            # converts output to namedtuple for pipelines post-processing
-            return BaseModelOutput(
-                last_hidden_state=output_buffers["last_hidden_state"].view(output_shapes["last_hidden_state"])
-            )
-        else:
-            onnx_inputs = {"input_ids": input_ids.cpu().detach().numpy()}
-
-            # Add the attention_mask inputs when needed
-            if "attention_mask" in self.input_names:
-                onnx_inputs["attention_mask"] = attention_mask.cpu().detach().numpy()
-
-            # Run inference
-            outputs = self.session.run(None, onnx_inputs)
-            last_hidden_state = torch.from_numpy(outputs[self.output_names["last_hidden_state"]]).to(self._device)
-
-            return BaseModelOutput(last_hidden_state=last_hidden_state)
-
-    def __call__(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
-
-
-class ORTEncoderForWhisper(ORTEncoder):
-    """
-    Encoder model for ONNX Runtime inference for Whisper model.
-
-    Args:
-        session (`ort.InferenceSession`):
-            The ONNX Runtime inference session associated to the encoder.
-    """
-
-    def prepare_io_binding(
-        self,
-        input_features: torch.FloatTensor = None,
-    ):
-        io_binding = self.session.io_binding()
-
-        # bind input features
-        input_features = input_features.contiguous()
-        io_binding.bind_input(
-            "input_features",
-            input_features.device.type,
-            self._device.index,
-            self.name_to_np_type["input_features"],
-            tuple(input_features.shape),
-            input_features.data_ptr(),
-        )
-
-        # bind logits
-        output_shape, output_buffer = self.prepare_output_buffer(
-            batch_size=input_features.size(0),
-            sequence_length=input_features.size(2) // 2,
-        )
-        io_binding.bind_output(
-            "last_hidden_state",
-            output_buffer.device.type,
-            self._device.index,
-            self.name_to_np_type["last_hidden_state"],
-            output_shape,
-            output_buffer.data_ptr(),
-        )
-        output_shapes = {"last_hidden_state": output_shape}
-        output_buffers = {"last_hidden_state": output_buffer}
-
-        return io_binding, output_shapes, output_buffers
-
-    @add_start_docstrings_to_model_forward(WHISPER_ENCODER_INPUTS_DOCSTRING)
-    def forward(
-        self,
-        input_features: torch.FloatTensor,
-        **kwargs,
-    ) -> BaseModelOutput:
-        if self._device.type == "cuda" and self.use_io_binding:
-            io_binding, output_shapes, output_buffers = self.prepare_io_binding(input_features)
-
-            # run inference with binding & synchronize in case of multiple CUDA streams
-            io_binding.synchronize_inputs()
-            self.session.run_with_iobinding(io_binding)
-            io_binding.synchronize_outputs()
-
-            # converts output to namedtuple for pipelines post-processing
-            return BaseModelOutput(
-                last_hidden_state=output_buffers["last_hidden_state"].view(output_shapes["last_hidden_state"])
-            )
-        else:
-            onnx_inputs = {"input_features": input_features.cpu().detach().numpy()}
-
-            # Run inference
-            outputs = self.session.run(None, onnx_inputs)
-            last_hidden_state = torch.from_numpy(outputs[self.output_names["last_hidden_state"]]).to(self._device)
-
-            return BaseModelOutput(last_hidden_state=last_hidden_state)
-
-
-class ORTDecoder:
-    """
-    Decoder model with a language modeling head on top for ONNX Runtime inference.
-
-    Args:
-        session (`ort.InferenceSession`):
-            The ONNX Runtime inference session associated to the decoder.
-    """
-
-    def __init__(
-        self,
-        session: ort.InferenceSession,
-        config: "PretrainedConfig",
-        device: torch.device,
-        use_io_binding: bool = True,
-    ):
-        self.session = session
-        self.config = config
-        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(
-            self.config
-        )
-        self._device = device
-        self.use_io_binding = use_io_binding
-        self.session_inputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_inputs())}
-        self.session_outputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
-        self.session_input_names = list(self.session_inputs.keys())
-        self.session_output_names = list(self.session_outputs.keys())
-        self.key_value_input_names = [key for key in self.session_input_names if (".key" in key or ".value" in key)]
-        self.key_value_output_names = [key for key in self.session_output_names if (".key" in key or ".value" in key)]
-        self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None
-
-    def prepare_output_buffer(
-        self,
-        output_name,
-        batch_size=None,
-        sequence_length=None,
-        encoder_sequence_length=None,
-        past_sequence_length=None,
-        is_self_attn=False,
-    ):
-        """
-        Prepare the buffer of outputs(`logits`/`key_values`/`loss`) with 1D tensors.
-        """
-        ort_type = TypeHelper.get_output_type(self.session, output_name)
-        torch_type = TypeHelper.ort_type_to_torch_type(ort_type)
-        if output_name == "loss":
-            output_shape = (1,)
-            output_buffer = torch.empty(1, dtype=torch_type, device=self._device).contiguous()
-        elif output_name == "logits":
-            output_shape = (batch_size, sequence_length, self.normalized_config.vocab_size)
-            output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
-        elif ".key" in output_name or ".value" in output_name:
-            num_attention_heads = self.normalized_config.num_attention_heads
-            hidden_size = self.normalized_config.hidden_size
-            embed_size_per_head = hidden_size // num_attention_heads
-            if is_self_attn:
-                if past_sequence_length is not None:
-                    sequence_length += past_sequence_length
-                output_shape = (batch_size, num_attention_heads, sequence_length, embed_size_per_head)
-            else:
-                output_shape = (batch_size, num_attention_heads, encoder_sequence_length, embed_size_per_head)
-
-            output_buffer = torch.empty(np.prod(output_shape), dtype=torch_type, device=self._device).contiguous()
-
-        return output_shape, output_buffer
-
-    def prepare_io_binding(
-        self,
-        input_ids: torch.LongTensor,
-        encoder_hidden_states: torch.FloatTensor,
-        encoder_attention_mask: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
-        labels: Optional[torch.LongTensor] = None,
-    ):
-        io_binding = self.session.io_binding()
-
-        # bind input ids
-        input_ids = input_ids.contiguous()
-        io_binding.bind_input(
-            "input_ids",
-            input_ids.device.type,
-            self._device.index,
-            self.name_to_np_type["input_ids"],
-            list(input_ids.size()),
-            input_ids.data_ptr(),
-        )
-
-        # bind encoder attention mask
-        if "encoder_attention_mask" in self.session_input_names:
-            encoder_attention_mask = encoder_attention_mask.contiguous()
-            io_binding.bind_input(
-                "encoder_attention_mask",
-                encoder_attention_mask.device.type,
-                self._device.index,
-                self.name_to_np_type["encoder_attention_mask"],
-                list(encoder_attention_mask.size()),
-                encoder_attention_mask.data_ptr(),
-            )
-
-        # bind encoder hidden states
-        if "encoder_hidden_states" in self.session_input_names:
-            encoder_hidden_states = encoder_hidden_states.contiguous()
-            io_binding.bind_input(
-                "encoder_hidden_states",
-                encoder_hidden_states.device.type,
-                self._device.index,
-                self.name_to_np_type["encoder_hidden_states"],
-                list(encoder_hidden_states.size()),
-                encoder_hidden_states.data_ptr(),
-            )
-
-        # bind past key values
-        if past_key_values is not None:
-            for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
-                past_key_value = past_key_value.contiguous()
-                io_binding.bind_input(
-                    input_name,
-                    past_key_value.device.type,
-                    self._device.index,
-                    self.name_to_np_type[input_name],
-                    list(past_key_value.size()),
-                    past_key_value.data_ptr(),
-                )
-
-        # bind labels
-        if "labels" in self.session_input_names:
-            labels = labels.contiguous()
-            io_binding.bind_input(
-                "labels",
-                labels.device.type,
-                self._device.index,
-                self.name_to_np_type["labels"],
-                list(labels.size()),
-                labels.data_ptr(),
-            )
-
-        # bind outputs
-        # bind logits
-        logits_shape, logits_buffer = self.prepare_output_buffer(
-            output_name="logits",
-            batch_size=input_ids.size(0),
-            sequence_length=input_ids.size(1),
-        )
-        io_binding.bind_output(
-            "logits",
-            logits_buffer.device.type,
-            self._device.index,
-            self.name_to_np_type["logits"],
-            logits_shape,
-            logits_buffer.data_ptr(),
-        )
-        output_shapes = {"logits": logits_shape}
-        output_buffers = {"logits": logits_buffer}
-        # bind loss
-        if "loss" in self.session_output_names:
-            loss_shape, loss_buffer = self.prepare_output_buffer(output_name="loss")
-            io_binding.bind_output(
-                "loss",
-                loss_buffer.device.type,
-                self._device.index,
-                self.name_to_np_type["loss"],
-                loss_shape,
-                loss_buffer.data_ptr(),
-            )
-            output_shapes["loss"] = loss_shape
-            output_buffers["loss"] = loss_buffer
-
-        # bind past key values
-        num_pkv = 4  # number of self-attention and cross-attention per decoder layer
-        for pkv_names_per_layer in [
-            self.key_value_output_names[i : i + num_pkv] for i in range(0, len(self.key_value_output_names), num_pkv)
-        ]:
-            # bind a self attention and a cross-attention each time(2)
-            for i in range(2):
-                # bind self-attention past key values(2)
-                self_name = pkv_names_per_layer[i]
-                self_pkv_shape, self_pkv_buffer = self.prepare_output_buffer(
-                    output_name=self_name,
-                    batch_size=input_ids.size(0),
-                    sequence_length=input_ids.size(1),
-                    past_sequence_length=past_key_values[0].size(2)
-                    if past_key_values
-                    else None,  # sequence length of self-attention key for layer.0
-                    is_self_attn=True,
-                )
-                io_binding.bind_output(
-                    self_name,
-                    self_pkv_buffer.device.type,
-                    self._device.index,
-                    self.name_to_np_type[self_name],
-                    self_pkv_shape,
-                    self_pkv_buffer.data_ptr(),
-                )
-                # set -1 for sequence_length as it could be larger than the real sequence_length for creating buffer
-                self_pkv_shape = self_pkv_shape[:2] + (-1,) + self_pkv_shape[3:]
-                output_shapes[self_name] = self_pkv_shape
-                output_buffers[self_name] = self_pkv_buffer
-
-                # bind cross-attention past key values(2)
-                cross_name = pkv_names_per_layer[i + 2]
-                cross_pkv_shape, cross_pkv_buffer = self.prepare_output_buffer(
-                    output_name=cross_name,
-                    batch_size=input_ids.size(0),
-                    encoder_sequence_length=encoder_hidden_states.size(1),
-                )
-                io_binding.bind_output(
-                    cross_name,
-                    cross_pkv_buffer.device.type,
-                    self._device.index,
-                    self.name_to_np_type[cross_name],
-                    cross_pkv_shape,
-                    cross_pkv_buffer.data_ptr(),
-                )
-                # set -1 for sequence_length as it could be larger than the real sequence_length for creating buffer
-                cross_pkv_shape = cross_pkv_shape[:2] + (-1,) + cross_pkv_shape[3:]
-                output_shapes[cross_name] = cross_pkv_shape
-                output_buffers[cross_name] = cross_pkv_buffer
-
-        return io_binding, output_shapes, output_buffers
-
-    @add_start_docstrings_to_model_forward(DECODER_INPUTS_DOCSTRING)
-    def forward(
-        self,
-        input_ids: torch.LongTensor,
-        encoder_hidden_states: torch.FloatTensor,
-        encoder_attention_mask: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
-        labels: Optional[torch.LongTensor] = None,
-    ) -> Seq2SeqLMOutput:
-        # Flatten the past_key_values
-        if past_key_values is not None:
-            past_key_values = [past_key_value for pkv_per_layer in past_key_values for past_key_value in pkv_per_layer]
-
-        if self._device.type == "cuda" and self.use_io_binding:
-            io_binding, output_shapes, output_buffers = self.prepare_io_binding(
-                input_ids, encoder_hidden_states, encoder_attention_mask, past_key_values, labels
-            )
-
-            # run inference with binding & synchronize in case of multiple CUDA streams
-            io_binding.synchronize_inputs()
-            self.session.run_with_iobinding(io_binding)
-            io_binding.synchronize_outputs()
-
-            # Tuple of length equal to : number of layer * number of past_key_value per decoder layer (2 corresponds to the
-            # self-attention layer and 2 to the cross-attention layer)
-            past_key_values = tuple()
-            for name in self.key_value_output_names:
-                past_key_values += (output_buffers[name].view(output_shapes[name]),)
-
-            # Tuple of tuple of length `n_layers`, with each tuple of length equal to the number of self-attention and
-            # cross-attention per decoder layer
-            num_pkv = 4
-            past_key_values = tuple(past_key_values[i : i + num_pkv] for i in range(0, len(past_key_values), num_pkv))
-
-            logits = output_buffers["logits"].view(output_shapes["logits"])
-
-            loss = None
-            if "loss" in self.session_output_names:
-                loss = output_buffers["loss"].view(output_shapes["loss"])
-        else:
-            onnx_inputs = {
-                "input_ids": input_ids.cpu().detach().numpy(),
-            }
-
-            # Add the encoder_attention_mask inputs when needed
-            if "encoder_attention_mask" in self.session_input_names:
-                onnx_inputs["encoder_attention_mask"] = encoder_attention_mask.cpu().detach().numpy()
-
-            # Add the encoder_hidden_states inputs when needed
-            if "encoder_hidden_states" in self.session_input_names:
-                onnx_inputs["encoder_hidden_states"] = encoder_hidden_states.cpu().detach().numpy()
-
-            if past_key_values is not None:
-                # Add the past_key_values to the decoder inputs
-                for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
-                    onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
-
-            if "labels" in self.session_input_names:
-                # TODO: Any preprocessing like  `self._shift_right(labels)`?
-                onnx_inputs["labels"] = labels.cpu().detach().numpy()
-
-            # Run inference
-            outputs = self.session.run(None, onnx_inputs)
-            # Tuple of length equal to : number of layer * number of past_key_value per decoder layer (2 corresponds to the
-            # self-attention layer and 2 to the cross-attention layer)
-            past_key_values = tuple(
-                torch.from_numpy(outputs[self.session_outputs[key]]).to(self._device)
-                for key in self.key_value_output_names
-            )
-
-            # Tuple of tuple of length `n_layers`, with each tuple of length equal to the number of self-attention and
-            # cross-attention per decoder layer
-            num_pkv = 4
-            past_key_values = tuple(past_key_values[i : i + num_pkv] for i in range(0, len(past_key_values), num_pkv))
-            logits = torch.from_numpy(outputs[self.session_outputs["logits"]]).to(self._device)
-
-            loss = None
-            if "loss" in self.session_output_names:
-                loss = torch.from_numpy(outputs[self.session_outputs["loss"]]).to(self._device)
-
-        # converts output to namedtuple for pipelines post-processing
-        return Seq2SeqLMOutput(loss=loss, logits=logits, past_key_values=past_key_values)
-
-    def __call__(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
-
-
 class ORTModelForSeq2SeqLM(ORTModelForConditionalGeneration, GenerationMixin):
     """
     Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
     """
 
-    export_feature = "seq2seq-lm"
     auto_model_class = AutoModelForSeq2SeqLM
     main_input_name = "input_ids"
 
@@ -1303,7 +1281,6 @@ class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin
     Speech Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
     """
 
-    export_feature = "speech2seq-lm"
     auto_model_class = AutoModelForSpeechSeq2Seq
     main_input_name = "input_features"
 

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -248,6 +248,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         use_io_binding: bool = True,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         preprocessors: Optional[List] = None,
+        **kwargs,
     ):
         """
         Args:
@@ -268,6 +269,22 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             preprocessors (`Optional[List]`, defaults to `None`):
                 The list of the preprocessors (tokenizer, processor, feature_extractor) to save alongside the ORTModel.
         """
+        # TODO: remove at version 2.0
+        def show_deprecated_argument(arg_name):
+            if kwargs.pop(arg_name, None) is not None:
+                logger.warning(
+                    f"The {arg_name} argument to create an {self.__class__.__name__} is deprecated, and not used "
+                    "anymore."
+                )
+
+        show_deprecated_argument("last_encoder_model_name")
+        show_deprecated_argument("last_decoder_model_name")
+        show_deprecated_argument("last_decoder_with_past_model_name")
+        if kwargs:
+            raise ValueError(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
+            )
+
         ABC.__init__(self)
 
         ORTModel.__init__(
@@ -620,9 +637,9 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             model,
             onnx_config,
             onnx_opset,
-            save_dir.joinpath(ONNX_ENCODER_NAME),
-            save_dir.joinpath(ONNX_DECODER_NAME),
-            save_dir.joinpath(ONNX_DECODER_WITH_PAST_NAME),
+            save_dir_path.joinpath(ONNX_ENCODER_NAME),
+            save_dir_path.joinpath(ONNX_DECODER_NAME),
+            save_dir_path.joinpath(ONNX_DECODER_WITH_PAST_NAME),
         )
 
         config.save_pretrained(save_dir_path)

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -961,8 +961,10 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
                     path = f"{path}/{subfolder}"
                 onnx_files = [p for p in repo_files if re.match(pattern, str(p))]
 
-            if fail_if_not_found and len(onnx_files) == 0:
-                raise FileNotFoundError(f"Could not find any ONNX model file in {path}")
+            if len(onnx_files) == 0:
+                if fail_if_not_found:
+                    raise FileNotFoundError(f"Could not find any ONNX model file in {path}")
+                return None
             elif len(onnx_files) > 1:
                 if argument_name is not None:
                     raise RuntimeError(
@@ -977,7 +979,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             decoder_file_name = infer_filename(r"(.*)?decoder((?!with_past).)*?\.onnx", "decoder_file_name")
         if not validate_filename(decoder_with_past_file_name):
             decoder_with_past_file_name = infer_filename(
-                r"(.*)?decoder(.*)?with_past(.*)?\.onnx", "decoder_with_past_file_name", fail_if_not_found=False
+                r"(.*)?decoder(.*)?with_past(.*)?\.onnx", "decoder_with_past_file_name", fail_if_not_found=use_cache
             )
 
         encoder_regular_onnx_filenames = ORTModelForConditionalGeneration._generate_regular_names_for_filename(

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -1089,7 +1089,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         task: Optional[str] = None,
     ) -> "ORTModelForConditionalGeneration":
         if task is None:
-            task = cls.get_task()
+            task = cls._AUTOMODELS_TO_TASKS[cls.auto_model_class]
 
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -76,16 +76,15 @@ class ORTOptimizer:
         config = None
         if isinstance(model_or_path, ORTModel):
             if isinstance(model_or_path, ORTModelForSeq2SeqLM):
-                model_save_dir = model_or_path.model_path.parent
-                onnx_model_path = [
-                    model_save_dir.joinpath(model_or_path.encoder_file_name),
-                    model_save_dir.joinpath(model_or_path.decoder_file_name),
+                onnx_model_path += [
+                    Path(model_or_path.encoder_session._model_path),
+                    Path(model_or_path.decoder_session._model_path)
                 ]
                 # Add the decoder with past key/values if present
                 if model_or_path.use_cache:
-                    onnx_model_path.append(model_save_dir.joinpath(model_or_path.decoder_file_with_past_name))
+                    onnx_model_path.append(Path(model_or_path.decoder_with_past_session._model_path))
             else:
-                onnx_model_path = [model_or_path.model_path]
+                onnx_model_path.append(Path(model_or_path.model._model_path))
             config = model_or_path.config
         elif os.path.isdir(model_or_path):
             file_names = [ONNX_WEIGHTS_NAME] if file_names is None else file_names

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -77,14 +77,14 @@ class ORTOptimizer:
         if isinstance(model_or_path, ORTModel):
             if isinstance(model_or_path, ORTModelForSeq2SeqLM):
                 onnx_model_path += [
-                    Path(model_or_path.encoder_session._model_path),
-                    Path(model_or_path.decoder_session._model_path)
+                    model_or_path.encoder_model_path,
+                    model_or_path.decoder_model_path,
                 ]
                 # Add the decoder with past key/values if present
                 if model_or_path.use_cache:
-                    onnx_model_path.append(Path(model_or_path.decoder_with_past_session._model_path))
+                    onnx_model_path.append(model_or_path.decoder_with_past_model_path)
             else:
-                onnx_model_path.append(Path(model_or_path.model._model_path))
+                onnx_model_path.append(model_or_path.model_path)
             config = model_or_path.config
         elif os.path.isdir(model_or_path):
             file_names = [ONNX_WEIGHTS_NAME] if file_names is None else file_names

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -48,7 +48,7 @@ class ORTOptimizer:
         Args:
             onnx_model_path (`List[os.PathLike]`):
                 The paths of the onnx models to optimize.
-            config ([`~PretrainedConfig`]):
+            config ([`~transformers.PretrainedConfig`]):
                 An instance of the configuration associated to the model to optimize.
         """
         super().__init__()
@@ -67,8 +67,8 @@ class ORTOptimizer:
                 The path to a local directory hosting the model to optimize or an instance of an `ORTModel` to quantize.
                 Can be either:
                     - A path to a local *directory* containing the model to optimize.
-                    - An instance of ORTModel.
-            file_names(`List[str]`, *optional*):
+                    - An instance of [`~optimum.onnxruntime.ORTModel`].
+            file_names(`Optional[List[str]]`, *optional*):
                 The list of file names of the models to optimize.
         """
         onnx_model_path = []
@@ -110,7 +110,7 @@ class ORTOptimizer:
         Optimizes a model given the optimization specifications defined in `optimization_config`.
 
         Args:
-            optimization_config (`OptimizationConfig`):
+            optimization_config ([`~optimum.onnxruntime.OptimizationConfig`]):
                 The configuration containing the parameters related to optimization.
             save_dir (`Union[str, os.PathLike]`):
                 The path used to save the optimized model.

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -76,7 +76,7 @@ class ORTOptimizer:
         config = None
         if isinstance(model_or_path, ORTModel):
             if isinstance(model_or_path, ORTModelForSeq2SeqLM):
-                model_save_dir = model_or_path.model_save_dir
+                model_save_dir = model_or_path.model_path.parent
                 onnx_model_path = [
                     model_save_dir.joinpath(model_or_path.encoder_file_name),
                     model_save_dir.joinpath(model_or_path.decoder_file_name),
@@ -85,7 +85,7 @@ class ORTOptimizer:
                 if model_or_path.use_cache:
                     onnx_model_path.append(model_save_dir.joinpath(model_or_path.decoder_file_with_past_name))
             else:
-                onnx_model_path = [model_or_path.model_save_dir.joinpath(model_or_path.latest_model_name)]
+                onnx_model_path = [model_or_path.model_path]
             config = model_or_path.config
         elif os.path.isdir(model_or_path):
             file_names = [ONNX_WEIGHTS_NAME] if file_names is None else file_names

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -25,6 +25,7 @@ from onnxruntime.transformers.onnx_model_bert import BertOnnxModel
 from onnxruntime.transformers.optimizer import optimize_model
 
 from ..utils import CONFIG_NAME, NormalizedConfigManager
+from ..utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForSeq2SeqLM
@@ -126,6 +127,9 @@ class ORTOptimizer:
         save_dir = Path(save_dir)
         save_dir.mkdir(parents=True, exist_ok=True)
         ORTConfigManager.check_optimization_supported_model(self.model_type)
+
+        self.config.save_pretrained(save_dir)
+        maybe_save_tokenizer_or_processor_or_feature_extractor(self.onnx_model_path[0].parent, save_dir)
 
         # Create and save the configuration summarizing all the parameters related to optimization
         ort_config = ORTConfig(

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -25,7 +25,7 @@ from onnxruntime.transformers.onnx_model_bert import BertOnnxModel
 from onnxruntime.transformers.optimizer import optimize_model
 
 from ..utils import CONFIG_NAME, NormalizedConfigManager
-from ..utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
+from ..utils.save_utils import maybe_save_preprocessors
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForSeq2SeqLM
@@ -128,7 +128,7 @@ class ORTOptimizer:
         ORTConfigManager.check_optimization_supported_model(self.model_type)
 
         self.config.save_pretrained(save_dir)
-        maybe_save_tokenizer_or_processor_or_feature_extractor(self.onnx_model_path[0].parent, save_dir)
+        maybe_save_preprocessors(self.onnx_model_path[0].parent, save_dir)
 
         # Create and save the configuration summarizing all the parameters related to optimization
         ort_config = ORTConfig(

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -97,13 +97,14 @@ class ORTQuantizer(OptimumQuantizer):
         """
         super().__init__()
         self.onnx_model_path = onnx_model_path
+        import pdb; pdb.set_trace()
         self.config = config
         if self.config is None:
             try:
                 self.config = AutoConfig.from_pretrained(self.onnx_model_path.parent)
             except OSError:
                 LOGGER.warning(
-                    f"Could not load the config for {self.onnx_augmented_model_name} automatically, this might make "
+                    f"Could not load the config for {self.onnx_model_path} automatically, this might make "
                     "the quantized model harder to use because it will not be able to be loaded by an ORTModel without "
                     "having to specify the configuration explicitly."
                 )

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -11,16 +11,17 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+"""Classes handling quantization with ONNX Runtime."""
 
 import logging
 import os
-from abc import ABC
 from collections import defaultdict
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 from datasets import Dataset, load_dataset
 from packaging.version import Version, parse
+from transformers import AutoConfig
 
 import onnx
 from onnxruntime import __version__ as ort_version
@@ -36,12 +37,13 @@ from optimum.onnxruntime.utils import ONNX_WEIGHTS_NAME
 from optimum.quantization_base import OptimumQuantizer
 
 
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+
 LOGGER = logging.getLogger(__name__)
 
 
 class ORTCalibrationDataReader(CalibrationDataReader):
-    """ """
-
     __slots__ = ["batch_size", "dataset", "_dataset_iter"]
 
     def __init__(self, dataset: Dataset, batch_size: int = 1):
@@ -83,65 +85,72 @@ class ORTQuantizer(OptimumQuantizer):
     Handles the ONNX Runtime quantization process for models shared on huggingface.co/models.
     """
 
-    def __init__(self, onnx_model_path: List[Path]):
+    def __init__(self, onnx_model_path: Path, config: Optional["PretrainedConfig"] = None):
         """
         Args:
             onnx_model_path (`Path`):
                 Path to the onnx model files you want to quantize.
+            config (`Optional[PretrainedConfig]`, *optional*):
+                The configuration of the model.
         """
         super().__init__()
         self.onnx_model_path = onnx_model_path
+        self.config = config
+        if self.config is None:
+            try:
+                self.config = AutoConfig.from_pretrained(self.onnx_model_path.parent)
+            except OSError:
+                LOGGER.warn(
+                    f"Could not load the config for {self.onnx_augmented_model_name} automatically, this might makei "
+                    "the quantized model harder to use because it will not be able to be loaded by an ORTModel without "
+                    "having to specify the configuration explicitly."
+                )
         self._calibrator = None
 
     @classmethod
     def from_pretrained(
         cls,
-        model_or_path: Union[str, Path],
+        model_or_path: Union["ORTModel", str, Path],
         file_name: Optional[str] = None,
     ) -> "ORTQuantizer":
         """
-        Instantiate a `ORTQuantizer` from a pretrained pytorch model and preprocessor.
+        Instantiates a `ORTQuantizer` from a an ONNX model file or an `ORTModel`.
 
         Args:
-            model_or_path (`Union[str, Path]`):
+            model_or_path (`Union[ORTModel, str, Path]`):
                 Can be either:
                     - A path to a saved exported ONNX Intermediate Representation (IR) model, e.g., `./my_model_directory/.
-                    - Or a `ORTModelForXX` class, e.g., `ORTModelForQuestionAnswering`.
-            file_name(`Union[str, List[str]]`, *optional*):
+                    - Or an `ORTModelForXX` class, e.g., `ORTModelForQuestionAnswering`.
+            file_name(`Optional[str]`, *optional*):
                 Overwrites the default model file name from `"model.onnx"` to `file_name`.
                 This allows you to load different model files from the same repository or directory.
         Returns:
             An instance of `ORTQuantizer`.
         """
-        # define the file name for the quantizable models
         if file_name is None:
             if isinstance(model_or_path, ORTModel):
                 if isinstance(model_or_path, ORTModelForConditionalGeneration):
                     raise ValueError(
                         "ORTQuantizer does not support multi-file quantization. Please create separate ORTQuantizer instances for each model/file."
                     )
-                model_file_name = model_or_path.latest_model_name
+                file_name = model_or_path.latest_model_name
             else:
-                model_file_name = ONNX_WEIGHTS_NAME
-        else:
-            model_file_name = file_name
+                file_name = ONNX_WEIGHTS_NAME
 
-        # create ORTQuantizer based on the provided input
+        path = None
         if isinstance(model_or_path, ORTModel):
-            return cls(model_or_path.model_save_dir.joinpath(model_file_name))
-        # load from local path
+            path = model_or_path.model_save_dir.joinpath(file_name)
         elif os.path.isdir(model_or_path):
-            if not isinstance(model_or_path, Path):
-                model_or_path = Path(model_or_path)
-            return cls(model_or_path.joinpath(model_file_name))
+            path = model_or_path = Path(model_or_path).joinpath(file_name)
         else:
             raise ValueError(f"Unable to load model from {model_or_path}.")
+        return cls(path)
 
     def fit(
         self,
         dataset: Dataset,
         calibration_config: CalibrationConfig,
-        onnx_augmented_model_name: str = "augmented_model.onnx",
+        onnx_augmented_model_name: Union[str, Path] = "augmented_model.onnx",
         operators_to_quantize: Optional[List[NodeType]] = None,
         batch_size: int = 1,
         use_external_data_format: bool = False,
@@ -149,24 +158,24 @@ class ORTQuantizer(OptimumQuantizer):
         force_symmetric_range: bool = False,
     ) -> Dict[str, Tuple[float, float]]:
         """
-        Perform the calibration step and collect the quantization ranges.
+        Performs the calibration step and collect the quantization ranges.
 
         Args:
             dataset (`Dataset`):
                 The dataset to use when performing the calibration step.
             calibration_config (`CalibrationConfig`):
                 The configuration containing the parameters related to the calibration step.
-            onnx_augmented_model_name (`Union[str, os.PathLike]`):
+            onnx_augmented_model_name (`Union[str, Path]`, *optional*, defaults to `"augmented_model.onnx"`):
                 The path used to save the augmented model used to collect the quantization ranges.
-            operators_to_quantize (`list`, *optional*):
+            operators_to_quantize (`Optional[List[NodeType]]`, *optional*):
                 List of the operators types to quantize.
-            batch_size (`int`, defaults to 1):
+            batch_size (`int`, *optional*, defaults to 1):
                 The batch size to use when collecting the quantization ranges values.
             use_external_data_format (`bool`, defaults to `False`):
                 Whether to use external data format to store model which size is >= 2Gb.
             use_gpu (`bool`, defaults to `False`):
                 Whether to use the GPU when collecting the quantization ranges values.
-            force_symmetric_range (`bool`, defaults to `False`):
+            force_symmetric_range (`bool`, *optional*, defaults to `False`):
                 Whether to make the quantization ranges symmetric.
 
         Returns:
@@ -195,7 +204,7 @@ class ORTQuantizer(OptimumQuantizer):
         self,
         dataset: Dataset,
         calibration_config: CalibrationConfig,
-        onnx_augmented_model_name: str = "augmented_model.onnx",
+        onnx_augmented_model_name: Union[str, Path] = "augmented_model.onnx",
         operators_to_quantize: Optional[List[NodeType]] = None,
         batch_size: int = 1,
         use_external_data_format: bool = False,
@@ -203,24 +212,24 @@ class ORTQuantizer(OptimumQuantizer):
         force_symmetric_range: bool = False,
     ):
         """
-        Perform the calibration step and collect the quantization ranges.
+        Performs the calibration step and collect the quantization ranges.
 
         Args:
             dataset (`Dataset`):
                 The dataset to use when performing the calibration step.
             calibration_config (`CalibrationConfig`):
                 The configuration containing the parameters related to the calibration step.
-            onnx_augmented_model_name (`Union[str, os.PathLike]`):
+            onnx_augmented_model_name (`Union[str, Path]`, *optional*, defaults to `"augmented_model.onnx"`):
                 The path used to save the augmented model used to collect the quantization ranges.
-            operators_to_quantize (`list`, *optional*):
+            operators_to_quantize (`Optional[List[NodeType]]`, *optional*):
                 List of the operators types to quantize.
-            batch_size (`int`, defaults to 1):
+            batch_size (`int`, *optional*, defaults to 1):
                 The batch size to use when collecting the quantization ranges values.
-            use_external_data_format (`bool`, defaults to `False`):
+            use_external_data_format (`bool`, *optional*, defaults to `False`):
                 Whether uto se external data format to store model which size is >= 2Gb.
-            use_gpu (`bool`, defaults to `False`):
+            use_gpu (`bool`, *optional*, defaults to `False`):
                 Whether to use the GPU when collecting the quantization ranges values.
-            force_symmetric_range (`bool`, defaults to `False`):
+            force_symmetric_range (`bool`, *optional*, defaults to `False`):
                 Whether to make the quantization ranges symmetric.
 
         Returns:
@@ -267,21 +276,21 @@ class ORTQuantizer(OptimumQuantizer):
         preprocessor: Optional[QuantizationPreprocessor] = None,
     ) -> Path:
         """
-        Quantize a model given the optimization specifications defined in `quantization_config`.
+        Quantizes a model given the optimization specifications defined in `quantization_config`.
 
         Args:
             quantization_config (`QuantizationConfig`):
                 The configuration containing the parameters related to quantization.
             save_dir (`Union[str, Path]`):
                 The directory where the quantized model should be saved.
-            file_suffix (`str`, *optional*, defaults to `"quantized"`):
+            file_suffix (`Optional[str]`, *optional*, defaults to `"quantized"`):
                 The file_suffix used to save the quantized model.
-            calibration_tensors_range (`Dict[NodeName, Tuple[float, float]]`, *optional*):
+            calibration_tensors_range (`Optional[Dict[NodeName, Tuple[float, float]]]`, *optional*):
                 The dictionary mapping the nodes name to their quantization ranges, used and required only when applying
                 static quantization.
-            use_external_data_format (`bool`, defaults to `False`):
+            use_external_data_format (`bool`, *optional*, defaults to `False`):
                 Whether to use external data format to store model which size is >= 2Gb.
-            preprocessor (`QuantizationPreprocessor`, *optional*):
+            preprocessor (`Optional[QuantizationPreprocessor]`, *optional*):
                 The preprocessor to use to collect the nodes to include or exclude from quantization.
 
         Returns:
@@ -388,6 +397,9 @@ class ORTQuantizer(OptimumQuantizer):
         ort_config = ORTConfig(quantization=quantization_config, use_external_data_format=use_external_data_format)
         ort_config.save_pretrained(save_dir)
 
+        if self.config is not None:
+            self.config.save_pretrained(save_dir)
+
         return Path(save_dir)
 
     def get_calibration_dataset(
@@ -402,25 +414,25 @@ class ORTQuantizer(OptimumQuantizer):
         use_auth_token: bool = False,
     ) -> Dataset:
         """
-        Create the calibration `datasets.Dataset` to use for the post-training static quantization calibration step
+        Creates the calibration `datasets.Dataset` to use for the post-training static quantization calibration step.
 
         Args:
             dataset_name (`str`):
                 The dataset repository name on the Hugging Face Hub or path to a local directory containing data files
                 to load to use for the calibration step.
-            num_samples (`int`, defaults to 100):
+            num_samples (`int`, *optional*, defaults to 100):
                 The maximum number of samples composing the calibration dataset.
-            dataset_config_name (`str`, *optional*):
+            dataset_config_name (`Optional[str]`, *optional*):
                 The name of the dataset configuration.
-            dataset_split (`str`, *optional*):
+            dataset_split (`Optional[str]`, *optional*):
                 Which split of the dataset to use to perform the calibration step.
-            preprocess_function (`Callable`, *optional*):
+            preprocess_function (`Optional[Callable]`, *optional*):
                 Processing function to apply to each example after loading dataset.
-            preprocess_batch (`bool`, defaults to `True`):
+            preprocess_batch (`bool`, *optional*, defaults to `True`):
                 Whether the `preprocess_function` should be batched.
-            seed (`int`, defaults to 2016):
+            seed (`int`, *optional*, defaults to 2016):
                 The random seed to use when shuffling the calibration dataset.
-            use_auth_token (`bool`, defaults to `False`):
+            use_auth_token (`bool`, *optional*, defaults to `False`):
                 Whether to use the token generated when running `transformers-cli login` (necessary for some datasets
                 like ImageNet).
         Returns:

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -28,13 +28,16 @@ from onnxruntime import __version__ as ort_version
 from onnxruntime.quantization import CalibrationDataReader, QuantFormat, QuantizationMode, QuantType
 from onnxruntime.quantization.onnx_quantizer import ONNXQuantizer
 from onnxruntime.quantization.qdq_quantizer import QDQQuantizer
-from optimum.onnxruntime import ORTQuantizableOperator
-from optimum.onnxruntime.configuration import CalibrationConfig, NodeName, NodeType, ORTConfig, QuantizationConfig
-from optimum.onnxruntime.modeling_ort import ORTModel
-from optimum.onnxruntime.modeling_seq2seq import ORTModelForConditionalGeneration
-from optimum.onnxruntime.preprocessors import QuantizationPreprocessor
-from optimum.onnxruntime.utils import ONNX_WEIGHTS_NAME
-from optimum.quantization_base import OptimumQuantizer
+
+
+from ..utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
+from . import ORTQuantizableOperator
+from .configuration import CalibrationConfig, NodeName, NodeType, ORTConfig, QuantizationConfig
+from .modeling_ort import ORTModel
+from .modeling_seq2seq import ORTModelForConditionalGeneration
+from .preprocessors import QuantizationPreprocessor
+from .utils import ONNX_WEIGHTS_NAME
+from ..quantization_base import OptimumQuantizer
 
 
 if TYPE_CHECKING:
@@ -100,8 +103,8 @@ class ORTQuantizer(OptimumQuantizer):
             try:
                 self.config = AutoConfig.from_pretrained(self.onnx_model_path.parent)
             except OSError:
-                LOGGER.warn(
-                    f"Could not load the config for {self.onnx_augmented_model_name} automatically, this might makei "
+                LOGGER.warning(
+                    f"Could not load the config for {self.onnx_augmented_model_name} automatically, this might make "
                     "the quantized model harder to use because it will not be able to be loaded by an ORTModel without "
                     "having to specify the configuration explicitly."
                 )
@@ -399,6 +402,8 @@ class ORTQuantizer(OptimumQuantizer):
 
         if self.config is not None:
             self.config.save_pretrained(save_dir)
+
+        maybe_save_tokenizer_or_processor_or_feature_extractor(self.onnx_model_path.parent, save_dir)
 
         return Path(save_dir)
 

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -29,7 +29,7 @@ from onnxruntime.quantization import CalibrationDataReader, QuantFormat, Quantiz
 from onnxruntime.quantization.onnx_quantizer import ONNXQuantizer
 from onnxruntime.quantization.qdq_quantizer import QDQQuantizer
 
-
+from ..quantization_base import OptimumQuantizer
 from ..utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
 from . import ORTQuantizableOperator
 from .configuration import CalibrationConfig, NodeName, NodeType, ORTConfig, QuantizationConfig
@@ -37,7 +37,6 @@ from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForConditionalGeneration
 from .preprocessors import QuantizationPreprocessor
 from .utils import ONNX_WEIGHTS_NAME
-from ..quantization_base import OptimumQuantizer
 
 
 if TYPE_CHECKING:

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -130,9 +130,13 @@ class ORTQuantizer(OptimumQuantizer):
             An instance of `ORTQuantizer`.
         """
         ort_quantizer_error_message = "ORTQuantizer does not support multi-file quantization. Please create separate ORTQuantizer instances for each model/file."
+
+        if isinstance(model_or_path, str):
+            model_or_path = Path(model_or_path)
+
         if isinstance(model_or_path, ORTModelForConditionalGeneration):
             raise ValueError(ort_quantizer_error_message)
-        elif isinstance(model_or_path, (str, Path)):
+        elif isinstance(model_or_path, Path):
             onnx_files = list(model_or_path.glob("*.onnx"))
             if len(onnx_files) == 0:
                 raise FileNotFoundError(f"Could not find any ONNX model file in {model_or_path}")

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -97,9 +97,6 @@ class ORTQuantizer(OptimumQuantizer):
         """
         super().__init__()
         self.onnx_model_path = onnx_model_path
-        import pdb
-
-        pdb.set_trace()
         self.config = config
         if self.config is None:
             try:

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -97,7 +97,9 @@ class ORTQuantizer(OptimumQuantizer):
         """
         super().__init__()
         self.onnx_model_path = onnx_model_path
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
         self.config = config
         if self.config is None:
             try:
@@ -138,7 +140,9 @@ class ORTQuantizer(OptimumQuantizer):
             if len(onnx_files) == 0:
                 raise FileNotFoundError(f"Could not find any ONNX model file in {model_or_path}")
             elif len(onnx_files) > 1:
-                raise RuntimeError(f"Found too many ONNX model files in {model_or_path}. {ort_quantizer_error_message}")
+                raise RuntimeError(
+                    f"Found too many ONNX model files in {model_or_path}. {ort_quantizer_error_message}"
+                )
             file_name = onnx_files[0].name
 
         path = None

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -30,13 +30,12 @@ from onnxruntime.quantization.onnx_quantizer import ONNXQuantizer
 from onnxruntime.quantization.qdq_quantizer import QDQQuantizer
 
 from ..quantization_base import OptimumQuantizer
-from ..utils.save_utils import maybe_save_tokenizer_or_processor_or_feature_extractor
+from ..utils.save_utils import maybe_save_preprocessors
 from . import ORTQuantizableOperator
 from .configuration import CalibrationConfig, NodeName, NodeType, ORTConfig, QuantizationConfig
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForConditionalGeneration
 from .preprocessors import QuantizationPreprocessor
-from .utils import ONNX_WEIGHTS_NAME
 
 
 if TYPE_CHECKING:
@@ -409,7 +408,7 @@ class ORTQuantizer(OptimumQuantizer):
         if self.config is not None:
             self.config.save_pretrained(save_dir)
 
-        maybe_save_tokenizer_or_processor_or_feature_extractor(self.onnx_model_path.parent, save_dir)
+        maybe_save_preprocessors(self.onnx_model_path.parent, save_dir)
 
         return Path(save_dir)
 

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -31,8 +31,6 @@ from ..utils import NormalizedTextConfig
 logger = logging.get_logger(__name__)
 
 ONNX_WEIGHTS_NAME = "model.onnx"
-OPTIMIZED_ONNX_WEIGHTS_NAME = "optimized_model.onnx"
-QUANTIZED_ONNX_WEIGHTS_NAME = "q8_model.onnx"
 
 ONNX_ENCODER_NAME = "encoder_model.onnx"
 ONNX_DECODER_NAME = "decoder_model.onnx"

--- a/optimum/utils/save_utils.py
+++ b/optimum/utils/save_utils.py
@@ -15,10 +15,11 @@
 """Utilities related to saving files."""
 
 import logging
-from typing import Union
 from pathlib import Path
+from typing import Union
 
-from transformers import AutoTokenizer, AutoFeatureExtractor, AutoProcessor
+from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
+
 
 logger = logging.getLogger(__name__)
 

--- a/optimum/utils/save_utils.py
+++ b/optimum/utils/save_utils.py
@@ -43,9 +43,7 @@ def maybe_load_preprocessors(src_name_or_path: Union[str, Path], subfolder: str 
     return preprocessors
 
 
-def maybe_save_tokenizer_or_processor_or_feature_extractor(
-    src_name_or_path: Union[str, Path], dest_dir: Union[str, Path], src_subfolder: str = ""
-):
+def maybe_save_preprocessors(src_name_or_path: Union[str, Path], dest_dir: Union[str, Path], src_subfolder: str = ""):
     """
     Saves the tokenizer, the processor and the feature extractor when found in `src_dir` in `dest_dir`.
 

--- a/optimum/utils/save_utils.py
+++ b/optimum/utils/save_utils.py
@@ -16,7 +16,7 @@
 
 import logging
 from pathlib import Path
-from typing import Union, List
+from typing import List, Union
 
 from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
 
@@ -43,7 +43,9 @@ def maybe_load_preprocessors(src_name_or_path: Union[str, Path], subfolder: str 
     return preprocessors
 
 
-def maybe_save_tokenizer_or_processor_or_feature_extractor(src_name_or_path: Union[str, Path], dest_dir: Union[str, Path], src_subfolder: str = ""):
+def maybe_save_tokenizer_or_processor_or_feature_extractor(
+    src_name_or_path: Union[str, Path], dest_dir: Union[str, Path], src_subfolder: str = ""
+):
     """
     Saves the tokenizer, the processor and the feature extractor when found in `src_dir` in `dest_dir`.
 

--- a/optimum/utils/save_utils.py
+++ b/optimum/utils/save_utils.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities related to saving files."""
+
+import logging
+from typing import Union
+from pathlib import Path
+
+from transformers import AutoTokenizer, AutoFeatureExtractor, AutoProcessor
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_save_tokenizer_or_processor_or_feature_extractor(src_dir: Union[str, Path], dest_dir: Union[str, Path]):
+    """
+    Saves the tokenizer, the processor and the feature extractor when found in `src_dir` in `dest_dir`.
+
+    Args:
+        src_dir (`Union[str, Path]`):
+            The source directory from which to copy the files.
+        dest_dir (`Union[str, Path]`):
+            The destination directory to copy the files to.
+    """
+    if not isinstance(src_dir, Path):
+        src_dir = Path(src_dir)
+    if not isinstance(dest_dir, Path):
+        dest_dir = Path(dest_dir)
+
+    dest_dir.mkdir(exist_ok=True)
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(src_dir)
+        tokenizer.save_pretrained(dest_dir)
+    except Exception:
+        pass
+
+    try:
+        processor = AutoProcessor.from_pretrained(src_dir)
+        processor.save_pretrained(dest_dir)
+    except Exception:
+        pass
+
+    try:
+        feature_extractor = AutoFeatureExtractor.from_pretrained(src_dir)
+        feature_extractor.save_pretrained(dest_dir)
+    except Exception:
+        pass

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -450,7 +450,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
 
             model = ORTModel.from_pretrained(tmpdirname, file_name=test_model_name)
 
-            self.assertEqual(model.latest_model_name, test_model_name)
+            self.assertEqual(model.model_name, test_model_name)
 
     @require_hf_token
     def test_save_model_from_hub(self):

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -41,7 +41,6 @@ from transformers.testing_utils import get_gpu_count, require_torch_gpu
 import onnxruntime
 import requests
 from huggingface_hub.constants import default_cache_path
-from huggingface_hub.utils import EntryNotFoundError
 from optimum.onnxruntime import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
@@ -226,7 +225,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
             ORTModelForSeq2SeqLM.from_pretrained(self.ONNX_SEQ2SEQ_MODEL_ID, provider="FooExecutionProvider")
 
     def test_load_model_from_hub_without_onnx_model(self):
-        with self.assertRaises(EntryNotFoundError):
+        with self.assertRaises(FileNotFoundError):
             ORTModel.from_pretrained(self.FAIL_ONNX_MODEL_ID)
 
     def test_model_on_cpu(self):

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -18,15 +18,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import numpy as np
 import torch
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoTokenizer
 
 import onnx
-from onnxruntime import InferenceSession
 from optimum.onnxruntime import ORTConfig, ORTModelForSequenceClassification, ORTOptimizer
-from optimum.onnxruntime.configuration import AutoQuantizationConfig, OptimizationConfig
-from optimum.onnxruntime.modeling_ort import ORTModelForSequenceClassification
+from optimum.onnxruntime.configuration import OptimizationConfig
 from optimum.onnxruntime.modeling_seq2seq import ORTModelForSeq2SeqLM
 from parameterized import parameterized
 
@@ -96,9 +93,6 @@ class ORTOptimizerTest(unittest.TestCase):
             optimizer.optimize(optimization_config=optimization_config, save_dir=tmp_dir)
             optimized_model = model_cls.from_pretrained(
                 tmp_dir,
-                encoder_file_name="encoder_model_optimized.onnx",
-                decoder_file_name="decoder_model_optimized.onnx",
-                decoder_with_past_file_name="decoder_with_past_model_optimized.onnx" if use_cache else None,
                 from_transformers=False,
                 use_cache=use_cache,
             )

--- a/tests/onnxruntime/test_quantization.py
+++ b/tests/onnxruntime/test_quantization.py
@@ -54,7 +54,7 @@ class ORTQuantizerTest(unittest.TestCase):
     def test_fail_from_pretrained_method(self):
         with self.assertRaises(Exception) as context:
             ORTQuantizer.from_pretrained("bert-base-cased")
-        self.assertIn("Unable to load model from bert-base-cased", str(context.exception))
+        self.assertIn("Could not find any ONNX model file in bert-base-cased", str(context.exception))
 
         with self.assertRaises(Exception) as context:
             model = ORTModelForSeq2SeqLM.from_pretrained("optimum/t5-small")


### PR DESCRIPTION
# What does this PR do?

- `ORTModel`, `ORTModelDecoder` and `ORTModelForConditionalGeneration` can load any ONNX model files regardless of their names, allowing to load optimized and quantized models without having to specify the `file_name` argument.
- `ORTModel._from_transformers` now downloads and loads the model in a temporary directory instead of the cache, which was not a right place to store it.  
- `ORTQuantizer` saves both the model configuration and the tokenizer / processor / feature extractor, making the exported directory usable end-to-end.
- `ORTOptimizer` was already saving the model configuration but not the tokenize / processor / feature extractor, it does now.
- `OnnxConfigWithPast` now has two class atributes (that will be used when no value is specified in the `__init__` to avoid having to overwrite the `__init__` just for that) : 
   - `USE_PAST_FOR_INPUTS`: if True, past key values will be in the inputs of the model
   -  `USE_PRESENT_FOR_OUTPUTS`: if True, present key values will be in the outputs of the model
   - **This is useful for decoder and encoder-decoder models (cc @mht-sharma)**

Those features combined allow the following:

```python
from transformers import AutoTokenizer
from optimum.onnxruntime import (
    ORTQuantizer,
    ORTOptimizer,
    ORTConfig,
    AutoQuantizationConfig,
    AutoOptimizationConfig,
    ORTModelForSequenceClassification
)
model_name = "distilbert-base-uncased-finetuned-sst-2-english" 

model = ORTModelForSequenceClassification.from_pretrained(model_name, from_transformers=True)
optimizer = ORTOptimizer.from_pretrained(model)

optimizer.optimize(
AutoOptimizationConfig.with_optimization_level("O2"), "optimized_model"
)

quantizer = ORTQuantizer.from_pretrained(model)
quantizer.quantize(
     AutoQuantizationConfig.avx512_vnni(is_static=False), "quantized_model"
)

optimized_model = ORTModelForSequenceClassification.from_pretrained("optimized_model")
quantized_model = ORTModelForSequenceClassification.from_pretrained("quantized_model")

tokenizer = AutoTokenizer.from_pretrained("optimized_model")
inputs = tokenizer("This is easier now!", return_tensors="pt")

print(model(**inputs))
print(optimized_model(**inputs))
print(quantized_model(**inputs))
```
This was not possible before.