### PR TITLE
Support custom shapes for dummy inputs

### DIFF
--- a/.github/workflows/test_dummy_inputs.yml
+++ b/.github/workflows/test_dummy_inputs.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        python -m unittest discover -s --exitfirst utils -p 'test_*.py'
+        python -m unittest discover -s utils -p 'test_*.py'

--- a/.github/workflows/test_dummy_inputs.yml
+++ b/.github/workflows/test_dummy_inputs.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+name: Dummy inputs / Python - Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9]
+        os: [ubuntu-20.04, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[tests]
+    - name: Test with unittest
+      working-directory: tests
+      run: |
+        python -m unittest discover -s --exitfirst utils -p 'test_*.py'

--- a/docs/source/exporters/onnx/package_reference/configuration.mdx
+++ b/docs/source/exporters/onnx/package_reference/configuration.mdx
@@ -32,18 +32,17 @@ They specify which input generators should be used for the dummy inputs, but rem
 
 ## Base classes
 
-[[autodoc]] exporters.onnx.base.OnnxConfig
+[[autodoc]] exporters.onnx.OnnxConfig
     - inputs
     - outputs
     - generate_dummy_inputs
 
-[[autodoc]] exporters.onnx.base.OnnxConfigWithPast
+[[autodoc]] exporters.onnx.OnnxConfigWithPast
     - with_past
 
-[[autodoc]] exporters.onnx.base.OnnxSeq2SeqConfigWithPast
+[[autodoc]] exporters.onnx.OnnxSeq2SeqConfigWithPast
     - get_encoder_onnx_config
     - get_decoder_onnx_config
-
 
 ## Middle-end classes
 

--- a/docs/source/exporters/onnx/package_reference/configuration.mdx
+++ b/docs/source/exporters/onnx/package_reference/configuration.mdx
@@ -33,6 +33,9 @@ They specify which input generators should be used for the dummy inputs, but rem
 ## Base classes
 
 [[autodoc]] exporters.onnx.base.OnnxConfig
+    - inputs
+    - outputs
+    - generate_dummy_inputs
 
 [[autodoc]] exporters.onnx.base.OnnxConfigWithPast
 

--- a/docs/source/exporters/onnx/package_reference/configuration.mdx
+++ b/docs/source/exporters/onnx/package_reference/configuration.mdx
@@ -38,8 +38,11 @@ They specify which input generators should be used for the dummy inputs, but rem
     - generate_dummy_inputs
 
 [[autodoc]] exporters.onnx.base.OnnxConfigWithPast
+    - with_past
 
 [[autodoc]] exporters.onnx.base.OnnxSeq2SeqConfigWithPast
+    - get_encoder_onnx_config
+    - get_decoder_onnx_config
 
 
 ## Middle-end classes

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -341,7 +341,7 @@ class OnnxConfig(ExportConfig, ABC):
 
 class OnnxConfigWithPast(OnnxConfig, ABC):
     """
-    Inherits from [`~OnnxConfig`]. A base class to handle the ONNX configuration of decoder-only models.
+    Inherits from [`~exporters.onnx.OnnxConfig`]. A base class to handle the ONNX configuration of decoder-only models.
     """
 
     PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = True
@@ -456,7 +456,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
 class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
     """
-    Inherits from [`~OnnxConfigWithPast`]. A base class to handle the ONNX configuration of encoder-decoder models.
+    Inherits from [`~exporters.onnx.OnnxConfigWithPast`]. A base class to handle the ONNX configuration of encoder-decoder models.
     """
 
     PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = False

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -340,6 +340,10 @@ class OnnxConfig(ExportConfig, ABC):
 
 
 class OnnxConfigWithPast(OnnxConfig, ABC):
+    """
+    Inherits from [`~OnnxConfig`]. A base class to handle the ONNX configuration of decoder-only models.
+    """
+
     PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = True
 
     def __init__(
@@ -451,6 +455,10 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
 
 class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
+    """
+    Inherits from [`~OnnxConfigWithPast`]. A base class to handle the ONNX configuration of encoder-decoder models.
+    """
+
     PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = False
 
     @property

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -286,7 +286,7 @@ class OnnxConfig(ExportConfig, ABC):
             input_was_inserted = False
             for dummy_input_gen in dummy_inputs_generators:
                 if dummy_input_gen.supports_input(input_name):
-                    dummy_inputs[input_name] = dummy_input_gen.generate(input_name, framework=framework, **kwargs)
+                    dummy_inputs[input_name] = dummy_input_gen.generate(input_name, framework=framework)
                     input_was_inserted = True
                     break
             if not input_was_inserted:

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Common ONNX configuration classes that handle most of the features for building model specific configurations."""
 
-import logging
 from typing import TYPE_CHECKING, List, Mapping
 
 from ...utils import (
@@ -25,6 +24,7 @@ from ...utils import (
     DummySeq2SeqPastKeyValuesGenerator,
     DummyTextInputGenerator,
     DummyVisionInputGenerator,
+    logging,
 )
 from .base import OnnxConfig, OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast
 

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Common ONNX configuration classes that handle most of the features for building model specific configurations."""
 
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, List, Mapping
 
 from ...utils import (
     DummyAudioInputGenerator,

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Common ONNX configuration classes that handle most of the features for building model specific configurations."""
 
-from typing import Mapping
+from typing import TYPE_CHECKING, Mapping
 
 from ...utils import (
     DummyAudioInputGenerator,
@@ -26,6 +26,10 @@ from ...utils import (
     DummyVisionInputGenerator,
 )
 from .base import OnnxConfig, OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast
+
+
+if TYPE_CHECKING:
+    from ...utils import DummyInputGenerator
 
 
 class TextEncoderOnnxConfig(OnnxConfig):
@@ -85,7 +89,7 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
 
         return common_inputs
 
-    def create_dummy_input_generator_classes(self):
+    def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
         dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](self.task, self._normalized_config)
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task,
@@ -99,11 +103,13 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
             batch_size=dummy_text_input_generator.batch_size,
             encoder_sequence_length=dummy_text_input_generator.sequence_length,
         )
-        self.dummy_inputs_generators = [
+        dummy_inputs_generators = [
             dummy_text_input_generator,
             dummy_decoder_text_input_generator,
             dummy_seq2seq_past_key_values_generator,
         ]
+
+        return dummy_inputs_generators
 
 
 class VisionOnnxConfig(OnnxConfig):

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Common ONNX configuration classes that handle most of the features for building model specific configurations."""
 
+import logging
 from typing import TYPE_CHECKING, List, Mapping
 
 from ...utils import (
@@ -30,6 +31,8 @@ from .base import OnnxConfig, OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast
 
 if TYPE_CHECKING:
     from ...utils import DummyInputGenerator
+
+logger = logging.get_logger(__name__)
 
 
 class TextEncoderOnnxConfig(OnnxConfig):
@@ -90,18 +93,29 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
         return common_inputs
 
     def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
-        dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](self.task, self._normalized_config)
+        dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](
+            self.task, self._normalized_config, **kwargs
+        )
+
+        if self.use_past is True:
+            if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
+                logger.warning(
+                    f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."
+                )
+            kwargs["sequence_length"] = 1
+
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task,
             self._normalized_config,
             batch_size=dummy_text_input_generator.batch_size,
-            sequence_length=1 if self.use_past else 16,
+            **kwargs,
         )
         dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
             self.task,
             self._normalized_config,
             batch_size=dummy_text_input_generator.batch_size,
             encoder_sequence_length=dummy_text_input_generator.sequence_length,
+            **kwargs,
         )
         dummy_inputs_generators = [
             dummy_text_input_generator,

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -46,6 +46,7 @@ from .config import (
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
+    from ...utils import DummyInputGenerator
     from .base import PatchingSpec
 
 
@@ -304,7 +305,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         },
     )
 
-    def create_dummy_input_generator_classes(self):
+    def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
         dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](self.task, self._normalized_config)
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task,
@@ -320,11 +321,13 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2][task](
             self.task, self._normalized_config, batch_size=dummy_text_input_generator.batch_size, **kwargs
         )
-        self.dummy_inputs_generators = [
+        dummy_inputs_generators = [
             dummy_text_input_generator,
             dummy_decoder_text_input_generator,
             dummy_seq2seq_past_key_values_generator,
         ]
+
+        return dummy_inputs_generators
 
     @property
     def inputs_for_default_and_seq2seq_lm(self):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Model specific ONNX configurations."""
-import logging
 import random
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Tuple
 
@@ -31,6 +30,7 @@ from ...utils import (
     NormalizedTextAndVisionConfig,
     NormalizedTextConfig,
     NormalizedVisionConfig,
+    logging,
 )
 from .base import OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast
 from .config import (

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -31,17 +31,17 @@ from transformers.onnx.utils import get_preprocessor
 
 import onnxruntime
 from huggingface_hub import hf_hub_download
-from optimum.onnx.configuration import DecoderOnnxConfigWithPast
+from ..onnx.configuration import DecoderOnnxConfigWithPast
 
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
 from .utils import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
-    ORTConfigManager,
     get_provider_for_device,
     parse_device,
 )
+from ..utils.normalized_config import NormalizedConfigManager
 
 
 logger = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class ORTDecoder:
     ):
         self.session = session
         self.config = config
-        self.normalized_config = ORTConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
         self._device = device
         self.use_io_binding = use_io_binding
         self.session_inputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_inputs())}

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -31,17 +31,12 @@ from transformers.onnx.utils import get_preprocessor
 
 import onnxruntime
 from huggingface_hub import hf_hub_download
-from ..onnx.configuration import DecoderOnnxConfigWithPast
 
+from ..onnx.configuration import DecoderOnnxConfigWithPast
+from ..utils.normalized_config import NormalizedConfigManager
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
-from .utils import (
-    ONNX_DECODER_NAME,
-    ONNX_DECODER_WITH_PAST_NAME,
-    get_provider_for_device,
-    parse_device,
-)
-from ..utils.normalized_config import NormalizedConfigManager
+from .utils import ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, get_provider_for_device, parse_device
 
 
 logger = logging.getLogger(__name__)
@@ -121,7 +116,9 @@ class ORTDecoder:
     ):
         self.session = session
         self.config = config
-        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(
+            self.config
+        )
         self._device = device
         self.use_io_binding = use_io_binding
         self.session_inputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_inputs())}

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -33,7 +33,7 @@ import onnxruntime
 from huggingface_hub import hf_hub_download
 
 from ..onnx.configuration import DecoderOnnxConfigWithPast
-from ..utils.normalized_config import NormalizedConfigManager
+from ..utils import NormalizedConfigManager
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
 from .utils import ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, get_provider_for_device, parse_device

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -37,6 +37,7 @@ from huggingface_hub import hf_hub_download
 from ..exporters.onnx.model_configs import SpeechSeq2SeqDecoderOnnxConfig, SpeechSeq2SeqEncoderOnnxConfig
 from ..onnx.configuration import DecoderOnnxConfig, EncoderOnnxConfig
 from ..onnx.modeling_seq2seq import _DecoderWithLMhead
+from ..utils.normalized_config import NormalizedConfigManager
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
 from .utils import (
@@ -48,7 +49,6 @@ from .utils import (
     parse_device,
     validate_provider_availability,
 )
-from ..utils.normalized_config import NormalizedConfigManager
 
 
 if TYPE_CHECKING:
@@ -670,7 +670,9 @@ class ORTEncoder:
         self._device = device
         self.use_io_binding = use_io_binding
         self.main_input_name = main_input_name
-        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(
+            self.config
+        )
         self.input_names = {input_key.name: idx for idx, input_key in enumerate(self.session.get_inputs())}
         self.output_names = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None
@@ -860,7 +862,9 @@ class ORTDecoder:
     ):
         self.session = session
         self.config = config
-        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(
+            self.config
+        )
         self._device = device
         self.use_io_binding = use_io_binding
         self.session_inputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_inputs())}

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -35,6 +35,7 @@ from huggingface_hub import hf_hub_download
 
 from ..exporters.onnx.convert import export_encoder_decoder_model as export
 from ..exporters.tasks import TasksManager
+from ..utils import NormalizedConfigManager
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
 from .utils import (
@@ -46,7 +47,6 @@ from .utils import (
     parse_device,
     validate_provider_availability,
 )
-from ..utils import NormalizedConfigManager
 
 
 if TYPE_CHECKING:

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -43,12 +43,12 @@ from .utils import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
     ONNX_ENCODER_NAME,
-    ORTConfigManager,
     get_device_for_provider,
     get_provider_for_device,
     parse_device,
     validate_provider_availability,
 )
+from ..utils.normalized_config import NormalizedConfigManager
 
 
 if TYPE_CHECKING:
@@ -670,7 +670,7 @@ class ORTEncoder:
         self._device = device
         self.use_io_binding = use_io_binding
         self.main_input_name = main_input_name
-        self.normalized_config = ORTConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
         self.input_names = {input_key.name: idx for idx, input_key in enumerate(self.session.get_inputs())}
         self.output_names = {output_key.name: idx for idx, output_key in enumerate(self.session.get_outputs())}
         self.name_to_np_type = TypeHelper.get_io_numpy_type_map(self.session) if self.use_io_binding else None
@@ -860,7 +860,7 @@ class ORTDecoder:
     ):
         self.session = session
         self.config = config
-        self.normalized_config = ORTConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.config.model_type)(self.config)
         self._device = device
         self.use_io_binding = use_io_binding
         self.session_inputs = {output_key.name: idx for idx, output_key in enumerate(self.session.get_inputs())}

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -37,7 +37,7 @@ from huggingface_hub import hf_hub_download
 from ..exporters.onnx.model_configs import SpeechSeq2SeqDecoderOnnxConfig, SpeechSeq2SeqEncoderOnnxConfig
 from ..onnx.configuration import DecoderOnnxConfig, EncoderOnnxConfig
 from ..onnx.modeling_seq2seq import _DecoderWithLMhead
-from ..utils.normalized_config import NormalizedConfigManager
+from ..utils import NormalizedConfigManager
 from .io_binding import TypeHelper
 from .modeling_ort import ORTModel
 from .utils import (

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -28,7 +28,7 @@ from ..utils import CONFIG_NAME
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForSeq2SeqLM
-from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
+from .utils import ONNX_WEIGHTS_NAME, NormalizedConfigManager, ORTConfigManager
 
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class ORTOptimizer:
         self.onnx_model_path = onnx_model_path
         self.config = config
         self.model_type = self.config.model_type
-        self.normalized_config = ORTConfigManager.get_normalized_config_class(self.model_type)(self.config)
+        self.normalized_config = NormalizedConfigManager.get_normalized_config_class(self.model_type)(self.config)
 
     @classmethod
     def from_pretrained(

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -24,11 +24,11 @@ from onnx import load_model
 from onnxruntime.transformers.onnx_model_bert import BertOnnxModel
 from onnxruntime.transformers.optimizer import optimize_model
 
-from ..utils import CONFIG_NAME
+from ..utils import CONFIG_NAME, NormalizedConfigManager
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForSeq2SeqLM
-from .utils import ONNX_WEIGHTS_NAME, NormalizedConfigManager, ORTConfigManager
+from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
 
 
 if TYPE_CHECKING:

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -86,7 +86,7 @@ class ORTConfigManager:
     @classmethod
     def get_model_ort_type(cls, model_type: str) -> str:
         cls.check_supported_model(model_type)
-        return cls._conf[model_type][1]
+        return cls._conf[model_type]
 
     @classmethod
     def check_supported_model(cls, model_type: str):
@@ -100,7 +100,7 @@ class ORTConfigManager:
     @classmethod
     def check_optimization_supported_model(cls, model_type: str):
         supported_model_types_for_optimization = ["bert", "gpt2", "bart"]
-        if (model_type not in cls._conf) or (cls._conf[model_type][1] not in supported_model_types_for_optimization):
+        if (model_type not in cls._conf) or (cls._conf[model_type] not in supported_model_types_for_optimization):
             raise KeyError(
                 f"ONNX Runtime doesn't support the graph optimization of {model_type} yet. Only {supported_model_types_for_optimization} are supported. "
                 f"If you want to support {model_type} please propose a PR or open up an issue in ONNX Runtime:https://github.com/microsoft/onnxruntime."

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -49,6 +49,7 @@ def _is_gpu_available():
     else:
         return False
 
+
 class ORTConfigManager:
     """
     A class that contains all the information needed by ONNX Runtime optimization for a given model type.

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -49,60 +49,39 @@ def _is_gpu_available():
     else:
         return False
 
-
-BartLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
-    num_attention_heads="encoder_attention_heads",
-    hidden_size="d_model",
-)
-GPT2LikeNormalizedTextConfig = NormalizedTextConfig.with_args(num_attention_heads="n_head", hidden_size="n_embd")
-T5LikeNormalizedTextConfig = NormalizedTextConfig.with_args(
-    num_attention_heads="num_heads",
-    hidden_size="d_model",
-)
-WhisperLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
-    hidden_size="d_model",
-)
-
-
 class ORTConfigManager:
     """
     A class that contains all the information needed by ONNX Runtime optimization for a given model type.
 
     Attributes:
-        _conf (`Dict[str, tuple]`):
-            A dictionary mapping each supported model type to a tuple containing the number of attention heads
-            and the hidden size model config attribute names as well as the corresponding ONNX Runtime model type.
+        _conf (`Dict[str]`):
+            A dictionary mapping each supported model type to the corresponding ONNX Runtime model type.
     """
 
     # Contribution note: Please add new models in alphabetical order
     _conf = {
-        "albert": (NormalizedTextConfig, "bert"),
-        "bart": (BartLikeNormalizedTextConfig, "bart"),
-        "bert": (NormalizedTextConfig, "bert"),
-        "big_bird": (NormalizedTextConfig, "bert"),
-        "bigbird_pegasus": (BartLikeNormalizedTextConfig, None),  # bug in `fusion_skiplayernorm.py`
-        "camembert": (NormalizedTextConfig, "bert"),
-        "codegen": (GPT2LikeNormalizedTextConfig, "gpt2"),
-        "deberta": (NormalizedTextConfig, "bert"),
-        "deberta-v2": (NormalizedTextConfig, "bert"),
-        "distilbert": (NormalizedTextConfig.with_args(num_attention_heads="n_heads", hidden_size="dim"), "bert"),
-        "electra": (NormalizedTextConfig, "bert"),
-        "gpt2": (GPT2LikeNormalizedTextConfig, "gpt2"),
-        "gpt_neo": (NormalizedTextConfig.with_args(num_attention_heads="num_heads"), "gpt2"),
-        "marian": (BartLikeNormalizedTextConfig, "bart"),
-        "mbart": (BartLikeNormalizedTextConfig, "bart"),
-        "mt5": (T5LikeNormalizedTextConfig, "bart"),
-        "m2m_100": (BartLikeNormalizedTextConfig, "bart"),
-        "roberta": (NormalizedTextConfig, "bert"),
-        "t5": (T5LikeNormalizedTextConfig, "t5"),
-        "whisper": (WhisperLikeNormalizedTextConfig, "whisper"),
-        "xlm-roberta": (NormalizedTextConfig, "bert"),
+        "albert": "bert",
+        "bart": "bart",
+        "bert": "bert",
+        "big_bird": "bert",
+        "bigbird_pegasus": None,  # bug in `fusion_skiplayernorm.py`
+        "camembert": "bert",
+        "codegen": "gpt2",
+        "deberta": "bert",
+        "deberta-v2": "bert",
+        "distilbert": "bert",
+        "electra": "bert",
+        "gpt2": "gpt2",
+        "gpt_neo": "gpt2",
+        "marian": "bart",
+        "mbart": "bart",
+        "mt5": "bart",
+        "m2m_100": "bart",
+        "roberta": "bert",
+        "t5": "t5",
+        "whisper": "whisper",
+        "xlm-roberta": "bert",
     }
-
-    @classmethod
-    def get_normalized_config_class(cls, model_type: str) -> Type:
-        cls.check_supported_model(model_type)
-        return cls._conf[model_type][0]
 
     @classmethod
     def get_model_ort_type(cls, model_type: str) -> str:

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -63,6 +63,7 @@ def check_if_pytorch_greater(target_version: str, message: str):
 
 
 from .input_generators import (  # noqa
+    DEFAULT_DUMMY_SHAPES,
     DummyAudioInputGenerator,
     DummyBboxInputGenerator,
     DummyDecoderTextInputGenerator,

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -74,6 +74,7 @@ from .input_generators import (  # noqa
 )
 from .normalized_config import (  # noqa
     NormalizedConfig,
+    NormalizedConfigManager,
     NormalizedSeq2SeqConfig,
     NormalizedTextAndVisionConfig,
     NormalizedTextConfig,

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -66,6 +66,7 @@ from .input_generators import (  # noqa
     DummyAudioInputGenerator,
     DummyBboxInputGenerator,
     DummyDecoderTextInputGenerator,
+    DummyInputGenerator,
     DummyPastKeyValuesGenerator,
     DummySeq2SeqDecoderTextInputGenerator,
     DummySeq2SeqPastKeyValuesGenerator,

--- a/optimum/utils/doc.py
+++ b/optimum/utils/doc.py
@@ -29,3 +29,16 @@ def generate_doc_dataclass(cls) -> str:
         doc += f"{attribute.metadata['description']}\n"  # argument description
     cls.__doc__ = (cls.__doc__ if cls.__doc__ is not None else "") + "\n\n" + "".join(doc)
     return cls
+
+
+def add_dynamic_docstring(
+    *docstr,
+    text,
+    dynamic_elements,
+):
+    def docstring_decorator(fn):
+        func_doc = (fn.__doc__ or "") + "".join(docstr)
+        fn.__doc__ = func_doc + text.format(**dynamic_elements)
+        return fn
+
+    return docstring_decorator

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -50,9 +50,9 @@ DEFAULT_DUMMY_SHAPES = {
     "sequence_length": 16,
     "num_choices": 4,
     # image
-    "num_channels": 3,
     "width": 224,
     "height": 224,
+    "num_channels": 3,
     # audio
     "feature_size": 80,
     "nb_max_frames": 3000,

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -510,8 +510,8 @@ class DummyVisionInputGenerator(DummyInputGenerator):
         normalized_config: NormalizedVisionConfig,
         batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
         num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
-        width: int = 224,
-        height: int = 224,
+        width: int = DEFAULT_DUMMY_SHAPES["width"],
+        height: int = DEFAULT_DUMMY_SHAPES["height"],
     ):
         self.task = task
         # Some vision models can take any input sizes, in this case we use the values provided as parameters.

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -52,7 +52,7 @@ DEFAULT_DUMMY_SHAPES = {
     # image
     "num_channels": 3,
     "width": 224,
-    "heigh": 224,
+    "height": 224,
     # audio
     "feature_size": 80,
     "nb_max_frames": 3000,
@@ -518,7 +518,7 @@ class DummyVisionInputGenerator(DummyInputGenerator):
         if normalized_config.has_attribute("image_size"):
             self.image_size = normalized_config.image_size
         else:
-            self.image_size = (width, height)
+            self.image_size = (height, width)
         if normalized_config.has_attribute("num_channels"):
             self.num_channels = normalized_config.num_channels
         else:

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Callable, Type
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
+
 class NormalizedConfig:
     """
     Handles the normalization of [`PretrainedConfig`] attribute names, allowing to access attributes in a general way.
@@ -93,6 +94,7 @@ class NormalizedTextAndVisionConfig(NormalizedTextConfig, NormalizedVisionConfig
         elif self.VISION_CONFIG is not None and attr_name.upper() in dir(NormalizedVisionConfig):
             attr_name = f"{self.VISION_CONFIG}.{attr_name}"
         return super().__getattr__(attr_name)
+
 
 BartLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="encoder_attention_heads",
@@ -191,10 +193,12 @@ class NormalizedConfigManager:
         "mbart": BartLikeNormalizedTextConfig,
         "mt5": T5LikeNormalizedTextConfig,
         "m2m_100": BartLikeNormalizedTextConfig,
+        "resnet": NormalizedVisionConfig,
         "roberta": NormalizedTextConfig,
         "t5": T5LikeNormalizedTextConfig,
         "whisper": WhisperLikeNormalizedTextConfig,
         "xlm-roberta": NormalizedTextConfig,
+        "yolos": NormalizedVisionConfig,
     }
 
     @classmethod

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -15,12 +15,11 @@
 """Normalization configuration classes."""
 
 import functools
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Type
 
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
-
 
 class NormalizedConfig:
     """
@@ -94,3 +93,120 @@ class NormalizedTextAndVisionConfig(NormalizedTextConfig, NormalizedVisionConfig
         elif self.VISION_CONFIG is not None and attr_name.upper() in dir(NormalizedVisionConfig):
             attr_name = f"{self.VISION_CONFIG}.{attr_name}"
         return super().__getattr__(attr_name)
+
+BartLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
+    num_attention_heads="encoder_attention_heads",
+    hidden_size="d_model",
+)
+GPT2LikeNormalizedTextConfig = NormalizedTextConfig.with_args(num_attention_heads="n_head", hidden_size="n_embd")
+T5LikeNormalizedTextConfig = NormalizedTextConfig.with_args(
+    num_attention_heads="num_heads",
+    hidden_size="d_model",
+)
+WhisperLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
+    hidden_size="d_model",
+)
+
+
+class NormalizedConfigManager:
+    """
+    A class that contains all the information needed by ONNX Runtime optimization for a given model type.
+    Attributes:
+        _conf (`Dict[str, tuple]`):
+            A dictionary mapping each supported model type to a tuple containing the number of attention heads
+            and the hidden size model config attribute names as well as the corresponding ONNX Runtime model type.
+    """
+
+    """
+    We should make sure to have all model types, i.e. at least
+        ['albert',
+        'bart',
+        'beit',
+        'bert',
+        'big-bird',
+        'bigbird-pegasus',
+        'blenderbot',
+        'blenderbot-small',
+        'bloom',
+        'camembert',
+        'clip',
+        'codegen',
+        'convbert',
+        'convnext',
+        'data2vec-text',
+        'data2vec-vision',
+        'deberta',
+        'deberta-v2',
+        'deit',
+        'detr',
+        'distilbert',
+        'electra',
+        'flaubert',
+        'gpt2',
+        'gptj',
+        'gpt-neo',
+        'groupvit',
+        'ibert',
+        'layoutlm',
+        'layoutlmv3',
+        'levit',
+        'longt5',
+        'marian',
+        'mbart',
+        'mobilebert',
+        'mobilevit',
+        'mt5',
+        'm2m-100',
+        'owlvit',
+        'perceiver',
+        'resnet',
+        'roberta',
+        'roformer',
+        'segformer',
+        'squeezebert',
+        't5',
+        'vit',
+        'whisper',
+        'xlm',
+        'xlm-roberta',
+        'yolos']
+    """
+
+    # Contribution note: Please add new models in alphabetical order
+    _conf = {
+        "albert": NormalizedTextConfig,
+        "bart": BartLikeNormalizedTextConfig,
+        "bert": NormalizedTextConfig,
+        "big_bird": NormalizedTextConfig,
+        "bigbird_pegasus": BartLikeNormalizedTextConfig,
+        "camembert": NormalizedTextConfig,
+        "codegen": GPT2LikeNormalizedTextConfig,
+        "deberta": NormalizedTextConfig,
+        "deberta-v2": NormalizedTextConfig,
+        "distilbert": NormalizedTextConfig.with_args(num_attention_heads="n_heads", hidden_size="dim"),
+        "electra": NormalizedTextConfig,
+        "gpt2": GPT2LikeNormalizedTextConfig,
+        "gpt_neo": NormalizedTextConfig.with_args(num_attention_heads="num_heads"),
+        "marian": BartLikeNormalizedTextConfig,
+        "mbart": BartLikeNormalizedTextConfig,
+        "mt5": T5LikeNormalizedTextConfig,
+        "m2m_100": BartLikeNormalizedTextConfig,
+        "roberta": NormalizedTextConfig,
+        "t5": T5LikeNormalizedTextConfig,
+        "whisper": WhisperLikeNormalizedTextConfig,
+        "xlm-roberta": NormalizedTextConfig,
+    }
+
+    @classmethod
+    def check_supported_model(cls, model_type: str):
+        if model_type not in cls._conf:
+            model_types = ", ".join(cls._conf.keys())
+            raise KeyError(
+                f"{model_type} model type is not supported yet. Only {model_types} are supported. "
+                f"If you want to support {model_type} please propose a PR or open up an issue."
+            )
+
+    @classmethod
+    def get_normalized_config_class(cls, model_type: str) -> Type:
+        cls.check_supported_model(model_type)
+        return cls._conf[model_type]

--- a/tests/utils/test_dummpy_input_generators.py
+++ b/tests/utils/test_dummpy_input_generators.py
@@ -16,7 +16,6 @@
 from contextlib import nullcontext
 from unittest import TestCase
 
-import pytest
 from transformers import AutoConfig
 
 from parameterized import parameterized

--- a/tests/utils/test_dummpy_input_generators.py
+++ b/tests/utils/test_dummpy_input_generators.py
@@ -1,0 +1,171 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+from unittest import TestCase
+
+import pytest
+from transformers import AutoConfig
+
+from parameterized import parameterized
+
+
+TEXT_ENCODER_MODELS = {"distilbert": "distilbert-base-cased"}
+
+VISION_MODELS = {"resnet": "hf-internal-testing/tiny-random-resnet"}
+
+SEQ2SEQ_MODELS = {"t5": "t5-small"}
+
+AUDIO_MODELS = {"whisper": "openai/whisper-tiny.en"}
+
+DUMMY_SHAPES = {
+    "batch_size": [2, 4],
+    "sequence_length": [16, 18],
+    "num_choices": [4, 6],
+    # image
+    "num_channels": [3, 1],
+    "width": [224, 150],
+    "height": [224, 150],
+    # audio
+    "feature_size": [40, 10],
+    "nb_max_frames": [300, 500],
+    "audio_sequence_length": [16000, 8000],
+}
+
+import itertools
+from typing import Any, Dict, Iterable
+
+import torch
+from transformers import AutoConfig
+
+from optimum.utils import DummyAudioInputGenerator, DummyTextInputGenerator, DummyVisionInputGenerator
+from optimum.utils.normalized_config import NormalizedConfigManager
+
+
+def grid_parameters(parameters: Dict[str, Iterable[Any]]) -> Iterable[Dict[str, Any]]:
+    """
+    Generate an iterable over the grid of all combinations of parameters
+    """
+    for params in itertools.product(*parameters.values()):
+        yield list(params)
+
+
+class GenerateDummy(TestCase):
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_name": TEXT_ENCODER_MODELS.values(),
+                "batch_size": DUMMY_SHAPES["batch_size"],
+                "num_choices": DUMMY_SHAPES["num_choices"],
+                "sequence_length": DUMMY_SHAPES["sequence_length"],
+            }
+        )
+    )
+    def test_text_models(self, model_name: str, batch_size: int, num_choices: int, sequence_length: int):
+        # isn't this very verbose?
+        config = AutoConfig.from_pretrained(model_name)
+        normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
+        normalized_config = normalized_config_class(config)
+
+        input_generator = DummyTextInputGenerator(
+            task="text-classification",
+            normalized_config=normalized_config,
+            batch_size=batch_size,
+            num_choices=num_choices,
+            sequence_length=sequence_length,
+        )
+        generated_tensor = input_generator.generate("input_ids")
+        assert generated_tensor.shape == torch.Size((batch_size, sequence_length))
+
+        generated_tensor = input_generator.generate("attention_mask")
+        assert generated_tensor.shape == torch.Size((batch_size, sequence_length))
+
+        input_generator = DummyTextInputGenerator(
+            task="multiple-choice",
+            normalized_config=normalized_config,
+            batch_size=batch_size,
+            num_choices=num_choices,
+            sequence_length=sequence_length,
+        )
+        generated_tensor = input_generator.generate("input_ids")
+        assert generated_tensor.shape == torch.Size((batch_size, num_choices, sequence_length))
+
+        generated_tensor = input_generator.generate("attention_mask")
+        assert generated_tensor.shape == torch.Size((batch_size, num_choices, sequence_length))
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_name": VISION_MODELS.values(),
+                "batch_size": DUMMY_SHAPES["batch_size"],
+                "num_channels": DUMMY_SHAPES["num_channels"],
+                "height": DUMMY_SHAPES["height"],
+                "width": DUMMY_SHAPES["width"],
+            }
+        )
+    )
+    def test_vision_models(self, model_name: str, batch_size: int, num_channels: int, height: int, width: int):
+        # isn't this very verbose?
+        config = AutoConfig.from_pretrained(model_name)
+        normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
+        normalized_config = normalized_config_class(config)
+
+        input_generator = DummyVisionInputGenerator(
+            task="image-classification",
+            normalized_config=normalized_config,
+            batch_size=batch_size,
+            num_channels=num_channels,
+            height=height,
+            width=width,
+        )
+        with self.assertRaises(AssertionError) if num_channels != normalized_config.num_channels else nullcontext():
+            generated_tensor = input_generator.generate("pixel_values")
+            assert generated_tensor.shape == torch.Size((batch_size, num_channels, height, width))
+
+            generated_tensor = input_generator.generate("pixel_mask")
+            assert generated_tensor.shape == torch.Size((batch_size, height, width))
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_name": AUDIO_MODELS.values(),
+                "batch_size": DUMMY_SHAPES["batch_size"],
+                "feature_size": DUMMY_SHAPES["feature_size"],
+                "nb_max_frames": DUMMY_SHAPES["nb_max_frames"],
+                "audio_sequence_length": DUMMY_SHAPES["audio_sequence_length"],
+            }
+        )
+    )
+    def test_audio_models(
+        self, model_name: str, batch_size: int, feature_size: int, nb_max_frames: int, audio_sequence_length: int
+    ):
+        # isn't this very verbose?
+        config = AutoConfig.from_pretrained(model_name)
+        normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
+        normalized_config = normalized_config_class(config)
+
+        input_generator = DummyAudioInputGenerator(
+            task="image-classification",
+            normalized_config=normalized_config,
+            batch_size=batch_size,
+            feature_size=feature_size,
+            nb_max_frames=nb_max_frames,
+            sequence_length=audio_sequence_length,
+        )
+        generated_tensor = input_generator.generate("input_values")
+        assert generated_tensor.shape == torch.Size((batch_size, audio_sequence_length))
+
+        generated_tensor = input_generator.generate("input_features")
+        assert generated_tensor.shape == torch.Size((batch_size, feature_size, nb_max_frames))


### PR DESCRIPTION
As per title, this is part of the effort to make ONNX export more reliable (reference https://github.com/huggingface/optimum/issues/503 )

Next PRs will come to:
* Allow custom shapes during `torch.onnx.export`
* More extensive testing of exported models with `optimum.exporters`
* Include log information in the ONNX export, some info on the supported/unsupported shapes / inputs

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

