### PR TITLE
Better error message when wrong task is given to exporters

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -628,7 +628,8 @@ class TasksManager:
             task_to_automodel = TasksManager._TASKS_TO_TF_AUTOMODELS
         if task not in task_to_automodel:
             raise KeyError(
-                f"Unknown task: {task}. Possible values are {list(TasksManager._TASKS_TO_AUTOMODELS.values())}"
+                f"Unknown task: {task}. Possible values are: "
+                + ", ".join([f"`{key}`: for {task_to_automodel[key].__name__}" for key in task_to_automodel])
             )
         return task_to_automodel[task]
 


### PR DESCRIPTION
Goes from

```
KeyError: "Unknown task: text-classification. Possible values are [<class 'transformers.models.auto.modeling_auto.AutoModel'>, <class 
'transformers.models.auto.modeling_auto.AutoModelForMaskedLM'>, <class 'transformers.models.auto.modeling_auto.AutoModelForCausalLM'>, <class 
'transformers.models.auto.modeling_auto.AutoModelForSeq2SeqLM'>, <class 'transformers.models.auto.modeling_auto.AutoModelForSequenceClassification'>, <class 
'transformers.models.auto.modeling_auto.AutoModelForTokenClassification'>, <class 'transformers.models.auto.modeling_auto.AutoModelForMultipleChoice'>, 
<class 'transformers.models.auto.modeling_auto.AutoModelForObjectDetection'>, <class 'transformers.models.auto.modeling_auto.AutoModelForQuestionAnswering'>,
<class 'transformers.models.auto.modeling_auto.AutoModelForImageClassification'>, <class 
'transformers.models.auto.modeling_auto.AutoModelForImageSegmentation'>, <class 'transformers.models.auto.modeling_auto.AutoModelForMaskedImageModeling'>, 
<class 'transformers.models.auto.modeling_auto.AutoModelForSemanticSegmentation'>, <class 
'transformers.models.auto.modeling_auto.AutoModelForSpeechSeq2Seq'>]"
```

to

```
KeyError: 'Unknown task: text-classification. Possible values are: `default`: for AutoModel, `masked-lm`: for AutoModelForMaskedLM, `causal-lm`: for 
AutoModelForCausalLM, `seq2seq-lm`: for AutoModelForSeq2SeqLM, `sequence-classification`: for AutoModelForSequenceClassification, `token-classification`: for
AutoModelForTokenClassification, `multiple-choice`: for AutoModelForMultipleChoice, `object-detection`: for AutoModelForObjectDetection, 
`question-answering`: for AutoModelForQuestionAnswering, `image-classification`: for AutoModelForImageClassification, `image-segmentation`: for 
AutoModelForImageSegmentation, `masked-im`: for AutoModelForMaskedImageModeling, `semantic-segmentation`: for AutoModelForSemanticSegmentation, 
`speech2seq-lm`: for AutoModelForSpeechSeq2Seq'
```
