### PR TITLE
Enable to push some sections to the end of the TOC in the doc

### DIFF
--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -83,6 +83,16 @@ def rename_copy_subpackage_html_paths(subpackage: str, subpackage_path: Path, op
 def main():
     args = parser.parse_args()
     optimum_path = Path("optimum-doc-build")
+    # Load optimum table of contents
+    base_toc_path = next(optimum_path.rglob("_toctree.yml"))
+    with open(base_toc_path, "r") as f:
+        base_toc = yaml.safe_load(f)
+
+    # Pop specific sections to add them after subpackages
+    sections_to_pop = {"Utilities": None}
+    for i, section in enumerate(base_toc[:]):
+        if section["title"] in sections_to_pop.keys():
+            sections_to_pop[section["title"]] = base_toc.pop(i)
 
     # Copy and rename all files from subpackages' docs to Optimum doc
     for subpackage in args.subpackages:
@@ -96,10 +106,6 @@ def main():
             args.version,
         )
 
-        # Load optimum table of contents
-        base_toc_path = next(optimum_path.rglob("_toctree.yml"))
-        with open(base_toc_path, "r") as f:
-            base_toc = yaml.safe_load(f)
         # Load subpackage table of contents
         subpackage_toc_path = next(subpackage_path.rglob("_toctree.yml"))
         with open(subpackage_toc_path, "r") as f:
@@ -108,8 +114,13 @@ def main():
         rename_subpackage_toc(subpackage, subpackage_toc)
         # Update optimum table of contents
         base_toc.extend(subpackage_toc)
-        with open(base_toc_path, "w") as f:
-            yaml.safe_dump(base_toc, f, allow_unicode=True)
+
+    # Add popped sections at the end
+    for section in sections_to_pop.values():
+        base_toc.extend(section)
+    # Write final table of contents
+    with open(base_toc_path, "w") as f:
+        yaml.safe_dump(base_toc, f, allow_unicode=True)
 
 
 if __name__ == "__main__":

--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -1,9 +1,13 @@
 import argparse
+import logging
 import shutil
 from pathlib import Path
 from typing import Dict
 
 import yaml
+
+
+logger = logging.getLogger()
 
 
 parser = argparse.ArgumentParser(
@@ -116,8 +120,11 @@ def main():
         base_toc.extend(subpackage_toc)
 
     # Add popped sections at the end
-    for section in sections_to_pop.values():
-        base_toc.extend(section)
+    for title, section in sections_to_pop.items():
+        if section is not None:
+            base_toc.extend(section)
+        else:
+            logger.warning(f"Section '{title}' is None so it is not added to the table of contents.")
     # Write final table of contents
     with open(base_toc_path, "w") as f:
         yaml.safe_dump(base_toc, f, allow_unicode=True)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In the documentation, the tables of contents of subpackages are added at the tend of the table of content of Optimum. This PR enables to specify which sections should be moved after the sections of subpackages.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

