### PR TITLE
Fold sections by default in the documentation's side-bar

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -11,12 +11,14 @@
     - local: concept_guides/quantization
       title: Quantization
     title: Conceptual guides
+    isExpanded: false
   - sections:
     - local: package_reference/modeling_base
       title: Optimized models
     - local: package_reference/benchmark
       title: Benchmark
     title: Reference
+    isExpanded: false
   title: Overview
 - sections:
   - local: onnxruntime/overview
@@ -58,6 +60,7 @@
       title: Trainer
     title: Reference
   title: ONNX Runtime
+  isExpanded: false
 - sections:
   - local: exporters/overview
     title: Overview
@@ -80,6 +83,7 @@
       title: Reference
     title: "ONNX"
   title: Exporters
+  isExpanded: false
 - sections:
   - local: torch_fx/overview
     title: Overview
@@ -100,6 +104,7 @@
       title: Optimization
     title: Reference
   title: Torch FX
+  isExpanded: false
 - sections:
   - local: bettertransformer/overview
     title: Overview
@@ -110,9 +115,11 @@
       title: How to add support for new architectures?
     title: Tutorials
   title: BetterTransformer integration
+  isExpanded: false
 - sections:
   - local: utils/dummy_input_generators
     title: Dummy input generators
   - local: utils/normalized_config
     title: Normalized configurations
   title: Utilities
+  isExpanded: false


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In the side-bar of the documentation of Optimum, all sections are currently unfolded (see [here](https://huggingface.co/docs/optimum/index)). This looks overwhelming and it would be clearer if main sections are folded.

With this PR, only the "Overview" section is unfolded so that the "Installation" and "Quick tour" subsections are visible and easily accessible.

This will need to be done for the doc of subpackages too.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

