### PR TITLE
[BT] add `BetterTransformer` support for GLPN

### DIFF
--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -34,6 +34,7 @@ The list of supported model below:
 - [Electra](https://arxiv.org/abs/2003.10555)
 - [Ernie](https://arxiv.org/abs/1904.09223)
 - [FSMT](https://arxiv.org/abs/1907.06616)
+- [GLPN](https://arxiv.org/abs/2201.07436)
 - [HuBERT](https://arxiv.org/pdf/2106.07447.pdf)
 - [LayoutLM](https://arxiv.org/abs/1912.13318)
 - [MarkupLM](https://arxiv.org/abs/2110.08518)

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -19,6 +19,7 @@ from .encoder_models import (
     BertLayerBetterTransformer,
     DistilBertLayerBetterTransformer,
     FSMTEncoderLayerBetterTransformer,
+    GLPNLayerBetterTransformer,
     MBartEncoderLayerBetterTransformer,
     ViltLayerBetterTransformer,
     ViTLayerBetterTransformer,
@@ -60,20 +61,22 @@ BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     "TransformerBlock": DistilBertLayerBetterTransformer,
     # WhisperModel
     "WhisperEncoderLayer": WhisperEncoderLayerBetterTransformer,
-    # Wav2vec2 family:
+    # Wav2vec2 family
     "Wav2Vec2EncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     "HubertEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     # "UniSpeechEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     # "Data2VecAudioEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
-    # ViT Family:
+    # ViT Family
     "ViTLayer": ViTLayerBetterTransformer,
     "DeiTLayer": ViTLayerBetterTransformer,
     "ViTMAELayer": ViTLayerBetterTransformer,
     "ViTMSNLayer": ViTLayerBetterTransformer,
     "YolosLayer": ViTLayerBetterTransformer,
-    # FSMTModel:
+    # FSMTModel
     "EncoderLayer": FSMTEncoderLayerBetterTransformer,
     "ViltLayer": ViltLayerBetterTransformer,
+    # GLPNModel
+    "GLPNLayer": GLPNLayerBetterTransformer,
 }
 
 

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -27,6 +27,7 @@ ALL_VISION_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-ViTMAEModel",
     "hf-internal-testing/tiny-random-ViTMSNModel",
     "hf-internal-testing/tiny-random-deit",
+    "hf-internal-testing/tiny-random-GLPNModel"
 ]
 
 


### PR DESCRIPTION
# My very first PR
here is a quick rundown of the changes I made

1. add a new class `GLPNLayerBetterTransformer` in encoder_models.py by following the [guide](https://huggingface.co/docs/optimum/bettertransformer/tutorials/contribute)
2. import the newly created class in [optimum/bettertransformer/models/__init__.py](https://github.com/huggingface/optimum/blob/main/optimum/bettertransformer/models/__init__.py) and adjust the mapping dict to reflect the change. 
3. edit some code comments for consistency
4. add `hf-internal-testing/tiny-random-GLPNModel` 
5. add a link to GLPN Arxiv paper in the list of supported models [overview.mdx](https://github.com/huggingface/optimum/blob/main/docs/source/bettertransformer/overview.mdx)

# Question
1. I'm not sure if the conversion made is 100% correct because GLPN has Conv2d layer in the attention and linear layer which may be needed to be dealt with differently than any other models. def need help with this!

<!-- Remove if not applicable -->

Fixes #[20372](https://github.com/huggingface/transformers/issues/20372)
To : @younesbelkada @michaelbenayoun @fxmarty

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x]  Did you write any new necessary tests?

