### PR TITLE
Add BetterTransformer support for RemBERT

### DIFF
--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -39,6 +39,7 @@ The list of supported model below:
 - [MarkupLM](https://arxiv.org/abs/2110.08518)
 - [MBart](https://arxiv.org/abs/2001.08210)
 - [M2M100](https://arxiv.org/abs/2010.11125)
+- [RemBERT](https://arxiv.org/abs/2010.12821)
 - [RoBERTa](https://arxiv.org/abs/1907.11692)
 - [Splinter](https://arxiv.org/abs/2101.00438)
 - [Tapas](https://arxiv.org/abs/2211.06550)

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -29,17 +29,18 @@ from .encoder_models import (
 
 BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     # Bert Family
-    "TapasLayer": BertLayerBetterTransformer,
+    "BertGenerationLayer": BertLayerBetterTransformer,
     "BertLayer": BertLayerBetterTransformer,
-    "ElectraLayer": BertLayerBetterTransformer,
-    "Data2VecTextLayer": BertLayerBetterTransformer,
     "CamembertLayer": BertLayerBetterTransformer,
-    "MarkupLMLayer": BertLayerBetterTransformer,
-    "RobertaLayer": BertLayerBetterTransformer,
-    "SplinterLayer": BertLayerBetterTransformer,
+    "Data2VecTextLayer": BertLayerBetterTransformer,
+    "ElectraLayer": BertLayerBetterTransformer,
     "ErnieLayer": BertLayerBetterTransformer,
     "LayoutLMLayer": BertLayerBetterTransformer,
-    "BertGenerationLayer": BertLayerBetterTransformer,
+    "MarkupLMLayer": BertLayerBetterTransformer,
+    "RemBertLayer": BertLayerBetterTransformer,
+    "RobertaLayer": BertLayerBetterTransformer,
+    "SplinterLayer": BertLayerBetterTransformer,
+    "TapasLayer": BertLayerBetterTransformer,
     "XLMRobertaLayer": BertLayerBetterTransformer,
     # Albert Family
     "AlbertLayer": AlbertLayerBetterTransformer,
@@ -61,13 +62,13 @@ BETTER_TRANFORMER_LAYERS_MAPPING_DICT = {
     # WhisperModel
     "WhisperEncoderLayer": WhisperEncoderLayerBetterTransformer,
     # Wav2vec2 family:
-    "Wav2Vec2EncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     "HubertEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
+    "Wav2Vec2EncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     # "UniSpeechEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     # "Data2VecAudioEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
     # ViT Family:
-    "ViTLayer": ViTLayerBetterTransformer,
     "DeiTLayer": ViTLayerBetterTransformer,
+    "ViTLayer": ViTLayerBetterTransformer,
     "ViTMAELayer": ViTLayerBetterTransformer,
     "ViTMSNLayer": ViTLayerBetterTransformer,
     "YolosLayer": ViTLayerBetterTransformer,

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -31,25 +31,26 @@ from testing_bettertransformer_utils import BetterTransformersTestMixin
 
 
 ALL_ENCODER_MODELS_TO_TEST = [
-    "hf-internal-testing/tiny-random-DistilBertModel",
     "hf-internal-testing/tiny-random-AlbertModel",
-    "hf-internal-testing/tiny-random-RobertaModel",
-    "hf-internal-testing/tiny-xlm-roberta",
-    "hf-internal-testing/tiny-random-SplinterModel",
-    "hf-internal-testing/tiny-random-ErnieModel",
-    "hf-internal-testing/tiny-random-camembert",
-    "hf-internal-testing/tiny-random-ElectraModel",
-    "hf-internal-testing/tiny-random-LayoutLMModel",
-    "hf-internal-testing/tiny-random-Data2VecTextModel",
-    "hf-internal-testing/tiny-random-MarkupLMModel",
     "hf-internal-testing/tiny-random-BertModel",
-    "ybelkada/random-tiny-BertGenerationModel",
+    "hf-internal-testing/tiny-random-camembert",
+    "hf-internal-testing/tiny-random-Data2VecTextModel",
+    "hf-internal-testing/tiny-random-DistilBertModel",
+    "hf-internal-testing/tiny-random-ElectraModel",
+    "hf-internal-testing/tiny-random-ErnieModel",
+    "hf-internal-testing/tiny-random-LayoutLMModel",
+    "hf-internal-testing/tiny-random-MarkupLMModel",
+    "hf-internal-testing/tiny-random-rembert",
+    "hf-internal-testing/tiny-random-RobertaModel",
+    "hf-internal-testing/tiny-random-SplinterModel",
     "hf-internal-testing/tiny-random-TapasModel",
+    "hf-internal-testing/tiny-xlm-roberta",
+    "ybelkada/random-tiny-BertGenerationModel",
 ]
 
 ALL_ENCODER_DECODER_MODELS_TO_TEST = [
-    "hf-internal-testing/tiny-random-FSMTModel",
     "hf-internal-testing/tiny-random-BartModel",
+    "hf-internal-testing/tiny-random-FSMTModel",
     "hf-internal-testing/tiny-random-MBartModel",
     "hf-internal-testing/tiny-random-nllb",
 ]

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -54,7 +54,7 @@ ALL_ENCODER_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-bart",
     "hf-internal-testing/tiny-random-FSMTModel",
     "hf-internal-testing/tiny-random-mbart",
-    "hf-internal-testing/tiny-random-nllb"
+    "hf-internal-testing/tiny-random-nllb",
 ]
 
 


### PR DESCRIPTION
# What does this PR do?
Add BetterTransformer support for RemBERT (part of [#20372](https://github.com/huggingface/transformers/issues/20372))

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- ~~[ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case)~~.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Details 
- RemBERT's primary change is decoupling in/output embeddings. Since RemBERT uses the same Attention mechanism in BERT, it can use the same `BertLayerBetterTransformer`. (please correct me if I'm wrong)
- Minor code cleanup to sort model names alphabetically as the convention in transformers repo.
- All tests for encoders passed on GPU
<img width="1513" alt="Screen Shot 2022-12-04 at 3 57 10 PM" src="https://user-images.githubusercontent.com/14718778/205524416-3b3476db-480c-45cc-9c78-64dda8b42c41.png">


cc @younesbelkada, @michaelbenayoun, @fxmarty. Thanks. 