### PR TITLE
enable FP16Optimizer for fp16 deepspeed training.

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -446,6 +446,7 @@ class ORTTrainer(Trainer):
             self.deepspeed = deepspeed_engine
             if args.fp16:
                 from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
+
                 self.optimizer = FP16_Optimizer(optimizer)
             else:
                 self.optimizer = optimizer
@@ -1493,8 +1494,9 @@ class ORTTrainer(Trainer):
 
             if args.fp16:
                 from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
+
                 self.optimizer = FP16_Optimizer(self.optimizer)
-      
+
         # Multi-gpu training (should be after apex fp16 initialization)
         if self.args.n_gpu > 1:
             model = nn.DataParallel(model)
@@ -1617,11 +1619,7 @@ class ORTTrainer(Trainer):
                 optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
 
             if self.sharded_ddp == ShardedDDPOption.SIMPLE:
-                self.optimizer = OSS(
-                    params=optimizer_grouped_parameters,
-                    optim=optimizer_cls,
-                    **optimizer_kwargs,
-                )
+                self.optimizer = OSS(params=optimizer_grouped_parameters, optim=optimizer_cls, **optimizer_kwargs,)
             else:
                 self.optimizer = optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)
                 if optimizer_cls.__name__ == "Adam8bit":

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1619,7 +1619,11 @@ class ORTTrainer(Trainer):
                 optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
 
             if self.sharded_ddp == ShardedDDPOption.SIMPLE:
-                self.optimizer = OSS(params=optimizer_grouped_parameters, optim=optimizer_cls, **optimizer_kwargs,)
+                self.optimizer = OSS(
+                    params=optimizer_grouped_parameters,
+                    optim=optimizer_cls,
+                    **optimizer_kwargs,
+                )
             else:
                 self.optimizer = optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)
                 if optimizer_cls.__name__ == "Adam8bit":

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -445,14 +445,8 @@ class ORTTrainer(Trainer):
             self.model_wrapped = deepspeed_engine
             self.deepspeed = deepspeed_engine
             if args.fp16:
-                try:
-                    from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
-
-                    self.optimizer = FP16_Optimizer(optimizer)
-                except ImportError:
-                    raise ImportError(
-                        "ORTTrainer tried to instantiate ORT FP16_Optimizer but onnxruntime-training is not correctly installed!"
-                    )
+                from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
+                self.optimizer = FP16_Optimizer(optimizer)
             else:
                 self.optimizer = optimizer
             self.lr_scheduler = lr_scheduler

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1497,6 +1497,16 @@ class ORTTrainer(Trainer):
         if self.use_apex and training:
             model, self.optimizer = amp.initialize(model, self.optimizer, opt_level=self.args.fp16_opt_level)
 
+            if args.fp16:
+                try:
+                    from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
+
+                    self.optimizer = FP16_Optimizer(self.optimizer)
+                except ImportError:
+                    raise ImportError(
+                        "ORTTrainer tried to instantiate ORT FP16_Optimizer but onnxruntime-training is not correctly installed!"
+                    )
+
         # Multi-gpu training (should be after apex fp16 initialization)
         if self.args.n_gpu > 1:
             model = nn.DataParallel(model)

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -1498,15 +1498,9 @@ class ORTTrainer(Trainer):
             model, self.optimizer = amp.initialize(model, self.optimizer, opt_level=self.args.fp16_opt_level)
 
             if args.fp16:
-                try:
-                    from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
-
-                    self.optimizer = FP16_Optimizer(self.optimizer)
-                except ImportError:
-                    raise ImportError(
-                        "ORTTrainer tried to instantiate ORT FP16_Optimizer but onnxruntime-training is not correctly installed!"
-                    )
-
+                from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
+                self.optimizer = FP16_Optimizer(self.optimizer)
+      
         # Multi-gpu training (should be after apex fp16 initialization)
         if self.args.n_gpu > 1:
             model = nn.DataParallel(model)

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -444,7 +444,17 @@ class ORTTrainer(Trainer):
             self.model = deepspeed_engine.module
             self.model_wrapped = deepspeed_engine
             self.deepspeed = deepspeed_engine
-            self.optimizer = optimizer
+            if args.fp16:
+                try:
+                    from onnxruntime.training.optim.fp16_optimizer import FP16_Optimizer
+
+                    self.optimizer = FP16_Optimizer(optimizer)
+                except ImportError:
+                    raise ImportError(
+                        "ORTTrainer tried to instantiate ORT FP16_Optimizer but onnxruntime-training is not correctly installed!"
+                    )
+            else:
+                self.optimizer = optimizer
             self.lr_scheduler = lr_scheduler
         elif not delay_optimizer_creation:
             self.create_optimizer_and_scheduler(num_training_steps=max_steps)


### PR DESCRIPTION
# What does this PR do?
This PR enables FP16 Optimizer when fp16 training is enabled.

# Benchmark validation.
This is the logs from both runs with and without fp16 training flag.

```
Roberta-large 

with fp16 optimizer :
***** train metrics *****
  epoch                    =      13.33
  train_loss               =     0.5796
  train_runtime            = 0:02:46.34
  train_samples            =       3668
  train_samples_per_second =    307.796
  train_steps_per_second   =      1.202

without fp16 optimizer
***** train metrics *****
  epoch                    =      13.33
  train_loss               =     0.5796
  train_runtime            = 0:02:54.16
  train_samples            =       3668
  train_samples_per_second =    293.974
  train_steps_per_second   =      1.148
```

-----------------------------------------------------

The recipe that I ran on this test: 
"optimum/examples/onnxruntime/training/text-classification/run_glue.py"

command used to run the recipe:
`python -m torch.distributed.launch --nproc_per_node=4 /home/adamlouly/optimum/examples/onnxruntime/training/text-classification/run_glue.py --model_name_or_path roberta-base --task_name MRPC --max_seq_length 128 --learning_rate 3e-6 --do_train --output_dir /dev/optim_al --overwrite_output_dir --max_steps 200 --logging_steps 20 --per_device_train_batch_size 64 --fp16 --deepspeed  /home/adamlouly/optimum/aml_ds_config_zero_1.json`

config json file:

`{
  "fp16": {
    "enabled": true,
    "loss_scale": 0,
    "loss_scale_window": 1000,
    "hysteresis": 2,
    "min_loss_scale": 1
  },
  "zero_optimization": {
    "stage": 1,
    "allgather_partitions": true,
    "allgather_bucket_size": 200000000,
    "overlap_comm": true,
    "reduce_scatter": true,
    "reduce_bucket_size": 200000000,
    "contiguous_gradients": false,
    "cpu_offload": false
  },
  "zero_allow_untested_optimizer": true,
  "optimizer": {
    "type": "AdamW",
    "params": {
      "lr": "auto",
      "betas": "auto",
      "eps": "auto",
      "weight_decay": "auto"
    }
  },
  "scheduler": {
    "type": "WarmupLR",
    "params": {
      "warmup_min_lr": "auto",
      "warmup_max_lr": "auto",
      "warmup_num_steps": "auto"
    }
  },
  "steps_per_print": 2000,
  "train_batch_size": "auto",
  "train_micro_batch_size_per_gpu": "auto",
  "gradient_accumulation_steps": "auto",
  "wall_clock_breakdown": false
}`