### PR TITLE
Support decoder generated with `--for-ort` from `optimum.exporters.onnx` in `ORTDecoder`

### DIFF
--- a/optimum/exporters/onnx/__init__.py
+++ b/optimum/exporters/onnx/__init__.py
@@ -15,9 +15,5 @@
 
 from .base import OnnxConfig, OnnxConfigWithPast, OnnxSeq2SeqConfigWithPast  # noqa
 from .config import TextDecoderOnnxConfig, TextEncoderOnnxConfig, TextSeq2SeqOnnxConfig  # noqa
-from .convert import (  # noqa
-    export,
-    export_encoder_decoder_model,
-    validate_encoder_decoder_model_outputs,
-    validate_model_outputs,
-)
+from .convert import export, export_models, validate_model_outputs, validate_models_outputs  # noqa
+from .utils import get_decoder_models_for_export, get_encoder_decoder_models_for_export

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -27,9 +27,9 @@ from .convert import (
     export,
     export_decoder_model,
     export_encoder_decoder_model,
+    validate_decoder_model_outputs,
     validate_encoder_decoder_model_outputs,
     validate_model_outputs,
-    validate_decoder_model_outputs,
 )
 
 

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -132,7 +132,6 @@ def main():
         )
 
     if model.config.is_encoder_decoder and args.for_ort:
-        print("onnx_config.use_past:", onnx_config.use_past)
         onnx_inputs, onnx_outputs = export_encoder_decoder_model(
             model,
             onnx_config,

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -372,7 +372,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         if use_past != self.use_present_in_outputs:
             logger.warning(
                 f"use_past = {use_past} is different than use_present_in_outputs = {use_present_in_outputs}, the value "
-                "of use_present_in_outputs value will used for the outputs."
+                "of use_present_in_outputs value will be used for the outputs."
             )
         super().__init__(config, task=task, patching_specs=patching_specs)
 

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -17,7 +17,7 @@
 from inspect import signature
 from itertools import chain
 from pathlib import Path
-from typing import Callable, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 from transformers.utils import is_tf_available, is_torch_available
@@ -72,7 +72,10 @@ def validate_models_outputs(
     onnx_named_outputs: List[str],
     atol: float,
     output_dir: Path,
-    fn_get_models_from_config: Callable,
+    fn_get_models_from_config: Callable[
+        [Union["PreTrainedModel", "TFPreTrainedModel"], OnnxConfig],
+        Dict[str, Tuple[Union["PreTrainedModel", "TFPreTrainedModel"], OnnxConfig]],
+    ],
     output_names: Optional[List[str]] = None,
 ):
     """
@@ -90,9 +93,9 @@ def validate_models_outputs(
             The absolute tolerance in terms of outputs difference between the reference and the exported model.
         output_dir (`Path`):
             Output directory where the exported ONNX models are stored.
-        fn_get_models_from_config (`Callable`):
-            Function with signature (`PreTrainedModel`, `exporters.onnx.config.OnnxConfig`) --> `Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]`
-            outputing a dictionary of submodels and downstream onnx config, for example to export the `model` in several pieces, as it is the case with encoder-decoder models.
+        fn_get_models_from_config (`Callable[[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig], Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]]]`):
+            Function outputing a dictionary of submodels and downstream onnx configurations, for example to export the `model` in several pieces,
+            as it is the case with encoder-decoder models.
         output_names (`Optional[List[str]]`, defaults to `None`):
             The names to use for the exported ONNX files. The order must be the same as the order of submodels in the ordered dict returned by `fn_get_models_from_config`.
             If None, will use the keys from the output of `fn_get_models_from_config` as names.
@@ -397,7 +400,10 @@ def export_models(
     onnx_config: OnnxConfig,
     opset: int,
     output_dir: Path,
-    fn_get_models_from_config: Callable,
+    fn_get_models_from_config: Callable[
+        [Union["PreTrainedModel", "TFPreTrainedModel"], OnnxConfig],
+        Dict[str, Tuple[Union["PreTrainedModel", "TFPreTrainedModel"], OnnxConfig]],
+    ],
     output_names: Optional[List[str]] = None,
     device: str = "cpu",
 ) -> Tuple[List[List[str]], List[List[str]]]:
@@ -415,9 +421,9 @@ def export_models(
             The version of the ONNX operator set to use.
         output_dir (`Path`):
             Output directory to store the exported ONNX models.
-        fn_get_models_from_config (`Callable`):
-            Function with signature (`PreTrainedModel`, `exporters.onnx.config.OnnxConfig`) --> `Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]`
-            outputing a dictionary of submodels and downstream onnx config, for example to export the `model` in several pieces, as it is the case with encoder-decoder models.
+        fn_get_models_from_config (`Callable[[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig], Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]]]`):
+            Function outputing a dictionary of submodels and downstream onnx configurations, for example to export the `model` in several pieces,
+            as it is the case with encoder-decoder models.
         output_names (`Optional[List[str]]`, defaults to `None`):
             The names to use for the exported ONNX files. The order must be the same as the order of submodels in the ordered dict returned by `fn_get_models_from_config`.
             If None, will use the keys from the output of `fn_get_models_from_config` as names.

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -24,7 +24,7 @@ from transformers.utils import is_tf_available, is_torch_available
 
 from ...utils import logging
 from .base import OnnxConfig
-from .utils import MIN_TORCH_VERSION, get_encoder_decoder_models_for_export, is_torch_onnx_support_available
+from .utils import MIN_TORCH_VERSION, get_encoder_decoder_models_for_export, get_decoder_models_for_export, is_torch_onnx_support_available
 
 
 if is_torch_available():
@@ -111,6 +111,52 @@ def validate_encoder_decoder_model_outputs(
         # Validate decoder with past
         model, onnx_config = models_for_validation["decoder_with_past"]
         validate_model_outputs(onnx_config, model, decoder_with_past_onnx_model, onnx_named_outputs[2], atol)
+
+
+def validate_decoder_model_outputs(
+    config: OnnxConfig,
+    reference_model: Union["PreTrainedModel", "TFPreTrainedModel"],
+    onnx_named_outputs: List[str],
+    atol: float,
+    decoder_onnx_model: Path,
+    decoder_with_past_onnx_model: Optional[Path] = None,
+):
+    """
+    Validates the export by checking that the outputs from both the reference and the exported model match.
+    The following method validates the ONNX models exported using the `export_decoder_model` method.
+
+    Args:
+        config ([`~OnnxConfig`]:
+            The configuration used to export the model.
+        reference_model ([`~PreTrainedModel`] or [`~TFPreTrainedModel`]):
+            The model used for the export.
+        onnx_named_outputs (`List[str]`):
+            The names of the outputs to check.
+        atol (`float`):
+            The absolute tolerance in terms of outputs difference between the reference and the exported model.
+        decoder_onnx_model (`Path`):
+            The path to the exported decoder ONNX model.
+        decoder_with_past_onnx_model (`Optional[Path]`, defaults to `None`):
+            The path to the exported decoder with past ONNX model. Required when `past_key_values` are exported.
+    Raises:
+        ValueError: If the outputs shapes or values do not match between the reference and the exported model.
+    """
+    models_for_validation = get_decoder_models_for_export(reference_model, config)
+
+    if len(onnx_named_outputs) != len(models_for_validation.keys()):
+        raise ValueError(
+            f"Invalid number of ONNX named outputs. Required {len(models_for_validation.keys())}, Provided {len(onnx_named_outputs)}"
+        )
+
+    # Validate decoder
+    model, onnx_config = models_for_validation["decoder"]
+    validate_model_outputs(onnx_config, model, decoder_onnx_model, onnx_named_outputs[0], atol)
+
+    if config.use_past:
+        # Validate decoder with past
+        model, onnx_config = models_for_validation["decoder_with_past"]
+        validate_model_outputs(onnx_config, model, decoder_with_past_onnx_model, onnx_named_outputs[1], atol)
+
 
 
 def validate_model_outputs(
@@ -418,6 +464,52 @@ def export_encoder_decoder_model(
     # export encoder
     model, onnx_config = models_for_export["encoder"]
     outputs.append(export(model, onnx_config, opset, encoder_output, device=device))
+
+    # export decoder
+    model, onnx_config = models_for_export["decoder"]
+    outputs.append(export(model, onnx_config, opset, decoder_output, device=device))
+
+    if config.use_past:
+        # export decoder with past
+        model, onnx_config = models_for_export["decoder_with_past"]
+        outputs.append(export(model, onnx_config, opset, decoder_with_past_output, device=device))
+
+    outputs = list(map(list, zip(*outputs)))
+    return outputs
+
+def export_decoder_model(
+    model: Union["PreTrainedModel", "TFPreTrainedModel"],
+    config: OnnxConfig,
+    opset: int,
+    decoder_output: Path,
+    decoder_with_past_output: Optional[Path] = None,
+    device: str = "cpu",
+) -> Tuple[List[List[str]], List[List[str]]]:
+    """
+    Exports a Pytorch or TensorFlow encoder decoder model to an ONNX Intermediate Representation.
+    The following method exports the encoder and decoder components of the model as separate
+    ONNX files.
+
+    Args:
+        model ([`PreTrainedModel`] or [`TFPreTrainedModel`]):
+            The model to export.
+        config ([`~exporters.onnx.config.OnnxConfig`]):
+            The ONNX configuration associated with the exported model.
+        opset (`int`):
+            The version of the ONNX operator set to use.
+        decoder_output (`Path`):
+            Directory to store the exported decoder ONNX model.
+        decoder_with_past_output (`Optional[Path]`, defaults to `None`):
+            Directory to store the exported decoder with past ONNX model. Required when `past_key_values` are exported.
+        device (`str`, *optional*, defaults to `cpu`):
+            The device on which the ONNX model will be exported. Either `cpu` or `cuda`. Only PyTorch is supported for
+            export on CUDA devices.
+    Returns:
+        `Tuple[List[List[str]], List[List[str]]]`: A tuple with an ordered list of the model's inputs, and the named
+        inputs from the ONNX configuration.
+    """
+    models_for_export = get_decoder_models_for_export(model, config)
+    outputs = []
 
     # export decoder
     model, onnx_config = models_for_export["decoder"]

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -24,7 +24,12 @@ from transformers.utils import is_tf_available, is_torch_available
 
 from ...utils import logging
 from .base import OnnxConfig
-from .utils import MIN_TORCH_VERSION, get_encoder_decoder_models_for_export, get_decoder_models_for_export, is_torch_onnx_support_available
+from .utils import (
+    MIN_TORCH_VERSION,
+    get_decoder_models_for_export,
+    get_encoder_decoder_models_for_export,
+    is_torch_onnx_support_available,
+)
 
 
 if is_torch_available():
@@ -156,7 +161,6 @@ def validate_decoder_model_outputs(
         # Validate decoder with past
         model, onnx_config = models_for_validation["decoder_with_past"]
         validate_model_outputs(onnx_config, model, decoder_with_past_onnx_model, onnx_named_outputs[1], atol)
-
 
 
 def validate_model_outputs(
@@ -476,6 +480,7 @@ def export_encoder_decoder_model(
 
     outputs = list(map(list, zip(*outputs)))
     return outputs
+
 
 def export_decoder_model(
     model: Union["PreTrainedModel", "TFPreTrainedModel"],

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -17,7 +17,7 @@
 from inspect import signature
 from itertools import chain
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 from transformers.utils import is_tf_available, is_torch_available
@@ -66,18 +66,18 @@ def check_dummy_inputs_are_allowed(
         )
 
 
-def validate_encoder_decoder_model_outputs(
-    config: OnnxConfig,
+def validate_models_outputs(
+    onnx_config: OnnxConfig,
     reference_model: Union["PreTrainedModel", "TFPreTrainedModel"],
     onnx_named_outputs: List[str],
     atol: float,
-    encoder_onnx_model: Path,
-    decoder_onnx_model: Path,
-    decoder_with_past_onnx_model: Optional[Path] = None,
+    output_dir: Path,
+    fn_get_models_from_config: Callable,
+    output_names: Optional[List[str]] = None,
 ):
     """
-    Validates the export by checking that the outputs from both the reference and the exported model match.
-    The following method validates the ONNX models exported using the `export_encoder_decoder_model` method.
+    Validates the export of several models, by checking that the outputs from both the reference and the exported model match.
+    The following method validates the ONNX models exported using the `export_models` method.
 
     Args:
         config ([`~OnnxConfig`]:
@@ -88,79 +88,43 @@ def validate_encoder_decoder_model_outputs(
             The names of the outputs to check.
         atol (`float`):
             The absolute tolerance in terms of outputs difference between the reference and the exported model.
-        encoder_onnx_model (`Path`):
-            The path to the exported encoder ONNX model.
-        decoder_onnx_model (`Path`):
-            The path to the exported decoder ONNX model.
-        decoder_with_past_onnx_model (`Optional[Path]`, defaults to `None`):
-            The path to the exported decoder with past ONNX model. Required when `past_key_values` are exported.
+        output_dir (`Path`):
+            Output directory where the exported ONNX models are stored.
+        fn_get_models_from_config (`Callable`):
+            Function with signature (`PreTrainedModel`, `exporters.onnx.config.OnnxConfig`) --> `Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]`
+            outputing a dictionary of submodels and downstream onnx config, for example to export the `model` in several pieces, as it is the case with encoder-decoder models.
+        output_names (`Optional[List[str]]`, defaults to `None`):
+            The names to use for the exported ONNX files. The order must be the same as the order of submodels in the ordered dict returned by `fn_get_models_from_config`.
+            If None, will use the keys from the output of `fn_get_models_from_config` as names.
     Raises:
         ValueError: If the outputs shapes or values do not match between the reference and the exported model.
     """
-    models_for_validation = get_encoder_decoder_models_for_export(reference_model, config)
+    models_for_validation = fn_get_models_from_config(reference_model, onnx_config)
 
     if len(onnx_named_outputs) != len(models_for_validation.keys()):
         raise ValueError(
             f"Invalid number of ONNX named outputs. Required {len(models_for_validation.keys())}, Provided {len(onnx_named_outputs)}"
         )
 
-    # Validate encoder
-    model, onnx_config = models_for_validation["encoder"]
-    validate_model_outputs(onnx_config, model, encoder_onnx_model, onnx_named_outputs[0], atol)
-
-    # Validate decoder
-    model, onnx_config = models_for_validation["decoder"]
-    validate_model_outputs(onnx_config, model, decoder_onnx_model, onnx_named_outputs[1], atol)
-
-    if config.use_past:
-        # Validate decoder with past
-        model, onnx_config = models_for_validation["decoder_with_past"]
-        validate_model_outputs(onnx_config, model, decoder_with_past_onnx_model, onnx_named_outputs[2], atol)
-
-
-def validate_decoder_model_outputs(
-    config: OnnxConfig,
-    reference_model: Union["PreTrainedModel", "TFPreTrainedModel"],
-    onnx_named_outputs: List[str],
-    atol: float,
-    decoder_onnx_model: Path,
-    decoder_with_past_onnx_model: Optional[Path] = None,
-):
-    """
-    Validates the export by checking that the outputs from both the reference and the exported model match.
-    The following method validates the ONNX models exported using the `export_decoder_model` method.
-
-    Args:
-        config ([`~OnnxConfig`]:
-            The configuration used to export the model.
-        reference_model ([`~PreTrainedModel`] or [`~TFPreTrainedModel`]):
-            The model used for the export.
-        onnx_named_outputs (`List[str]`):
-            The names of the outputs to check.
-        atol (`float`):
-            The absolute tolerance in terms of outputs difference between the reference and the exported model.
-        decoder_onnx_model (`Path`):
-            The path to the exported decoder ONNX model.
-        decoder_with_past_onnx_model (`Optional[Path]`, defaults to `None`):
-            The path to the exported decoder with past ONNX model. Required when `past_key_values` are exported.
-    Raises:
-        ValueError: If the outputs shapes or values do not match between the reference and the exported model.
-    """
-    models_for_validation = get_decoder_models_for_export(reference_model, config)
-
-    if len(onnx_named_outputs) != len(models_for_validation.keys()):
+    if output_names is not None and len(output_names) != len(models_for_validation):
         raise ValueError(
-            f"Invalid number of ONNX named outputs. Required {len(models_for_validation.keys())}, Provided {len(onnx_named_outputs)}"
+            f"Provided custom names {output_names} for the validation of {len(models_for_validation)} models. Please provide the same number of ONNX file names as models to export."
         )
 
-    # Validate decoder
-    model, onnx_config = models_for_validation["decoder"]
-    validate_model_outputs(onnx_config, model, decoder_onnx_model, onnx_named_outputs[0], atol)
-
-    if config.use_past:
-        # Validate decoder with past
-        model, onnx_config = models_for_validation["decoder_with_past"]
-        validate_model_outputs(onnx_config, model, decoder_with_past_onnx_model, onnx_named_outputs[1], atol)
+    for i, model_name in enumerate(models_for_validation.keys()):
+        submodel, sub_onnx_config = models_for_validation[model_name]
+        onnx_model_path = (
+            output_dir.joinpath(output_names[i])
+            if output_names is not None
+            else output_dir.joinpath(model_name + ".onnx")
+        )
+        validate_model_outputs(
+            sub_onnx_config,
+            submodel,
+            onnx_model_path,
+            onnx_named_outputs[i],
+            atol,
+        )
 
 
 def validate_model_outputs(
@@ -428,13 +392,13 @@ def export_tensorflow(
     return input_names, output_names
 
 
-def export_encoder_decoder_model(
+def export_models(
     model: Union["PreTrainedModel", "TFPreTrainedModel"],
-    config: OnnxConfig,
+    onnx_config: OnnxConfig,
     opset: int,
-    encoder_output: Path,
-    decoder_output: Path,
-    decoder_with_past_output: Optional[Path] = None,
+    output_dir: Path,
+    fn_get_models_from_config: Callable,
+    output_names: Optional[List[str]] = None,
     device: str = "cpu",
 ) -> Tuple[List[List[str]], List[List[str]]]:
     """
@@ -449,12 +413,14 @@ def export_encoder_decoder_model(
             The ONNX configuration associated with the exported model.
         opset (`int`):
             The version of the ONNX operator set to use.
-        encoder_output (`Path`):
-            Directory to store the exported encoder ONNX model.
-        decoder_output (`Path`):
-            Directory to store the exported decoder ONNX model.
-        decoder_with_past_output (`Optional[Path]`, defaults to `None`):
-            Directory to store the exported decoder with past ONNX model. Required when `past_key_values` are exported.
+        output_dir (`Path`):
+            Output directory to store the exported ONNX models.
+        fn_get_models_from_config (`Callable`):
+            Function with signature (`PreTrainedModel`, `exporters.onnx.config.OnnxConfig`) --> `Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]`
+            outputing a dictionary of submodels and downstream onnx config, for example to export the `model` in several pieces, as it is the case with encoder-decoder models.
+        output_names (`Optional[List[str]]`, defaults to `None`):
+            The names to use for the exported ONNX files. The order must be the same as the order of submodels in the ordered dict returned by `fn_get_models_from_config`.
+            If None, will use the keys from the output of `fn_get_models_from_config` as names.
         device (`str`, *optional*, defaults to `cpu`):
             The device on which the ONNX model will be exported. Either `cpu` or `cuda`. Only PyTorch is supported for
             export on CUDA devices.
@@ -462,68 +428,30 @@ def export_encoder_decoder_model(
         `Tuple[List[List[str]], List[List[str]]]`: A tuple with an ordered list of the model's inputs, and the named
         inputs from the ONNX configuration.
     """
-    models_for_export = get_encoder_decoder_models_for_export(model, config)
+    models_for_export = fn_get_models_from_config(model, onnx_config)
     outputs = []
 
-    # export encoder
-    model, onnx_config = models_for_export["encoder"]
-    outputs.append(export(model, onnx_config, opset, encoder_output, device=device))
+    if output_names is not None and len(output_names) != len(models_for_export):
+        raise ValueError(
+            f"Provided custom names {output_names} for the export of {len(models_for_export)} models. Please provide the same number of names as models to export."
+        )
 
-    # export decoder
-    model, onnx_config = models_for_export["decoder"]
-    outputs.append(export(model, onnx_config, opset, decoder_output, device=device))
-
-    if config.use_past:
-        # export decoder with past
-        model, onnx_config = models_for_export["decoder_with_past"]
-        outputs.append(export(model, onnx_config, opset, decoder_with_past_output, device=device))
-
-    outputs = list(map(list, zip(*outputs)))
-    return outputs
-
-
-def export_decoder_model(
-    model: Union["PreTrainedModel", "TFPreTrainedModel"],
-    config: OnnxConfig,
-    opset: int,
-    decoder_output: Path,
-    decoder_with_past_output: Optional[Path] = None,
-    device: str = "cpu",
-) -> Tuple[List[List[str]], List[List[str]]]:
-    """
-    Exports a Pytorch or TensorFlow encoder decoder model to an ONNX Intermediate Representation.
-    The following method exports the encoder and decoder components of the model as separate
-    ONNX files.
-
-    Args:
-        model ([`PreTrainedModel`] or [`TFPreTrainedModel`]):
-            The model to export.
-        config ([`~exporters.onnx.config.OnnxConfig`]):
-            The ONNX configuration associated with the exported model.
-        opset (`int`):
-            The version of the ONNX operator set to use.
-        decoder_output (`Path`):
-            Directory to store the exported decoder ONNX model.
-        decoder_with_past_output (`Optional[Path]`, defaults to `None`):
-            Directory to store the exported decoder with past ONNX model. Required when `past_key_values` are exported.
-        device (`str`, *optional*, defaults to `cpu`):
-            The device on which the ONNX model will be exported. Either `cpu` or `cuda`. Only PyTorch is supported for
-            export on CUDA devices.
-    Returns:
-        `Tuple[List[List[str]], List[List[str]]]`: A tuple with an ordered list of the model's inputs, and the named
-        inputs from the ONNX configuration.
-    """
-    models_for_export = get_decoder_models_for_export(model, config)
-    outputs = []
-
-    # export decoder
-    model, onnx_config = models_for_export["decoder"]
-    outputs.append(export(model, onnx_config, opset, decoder_output, device=device))
-
-    if config.use_past:
-        # export decoder with past
-        model, onnx_config = models_for_export["decoder_with_past"]
-        outputs.append(export(model, onnx_config, opset, decoder_with_past_output, device=device))
+    for i, model_name in enumerate(models_for_export.keys()):
+        submodel, sub_onnx_config = models_for_export[model_name]
+        output_path = (
+            output_dir.joinpath(output_names[i])
+            if output_names is not None
+            else output_dir.joinpath(model_name + ".onnx")
+        )
+        outputs.append(
+            export(
+                submodel,
+                sub_onnx_config,
+                opset,
+                output_path,
+                device=device,
+            )
+        )
 
     outputs = list(map(list, zip(*outputs)))
     return outputs

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -113,6 +113,7 @@ def get_encoder_decoder_models_for_export(
 
     return models_for_export
 
+
 def get_decoder_models_for_export(
     model: Union["PreTrainedModel", "TFPreTrainedModel"],
     config: "OnnxConfig",
@@ -132,7 +133,10 @@ def get_decoder_models_for_export(
     """
     models_for_export = dict()
 
-    models_for_export["decoder"] = (model, config.__class__(model.config, task=config.task, use_past=False))
+    models_for_export["decoder"] = (
+        model,
+        config.__class__(model.config, task=config.task, use_past=False, use_present_in_outputs=True),
+    )
 
     if config.use_past:
         onnx_config_with_past = config.__class__.with_past(model.config, task=config.task)

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -99,17 +99,17 @@ def get_encoder_decoder_models_for_export(
 
     encoder_model = model.get_encoder()
     encoder_onnx_config = config.get_encoder_onnx_config(encoder_model.config)
-    models_for_export["encoder"] = (encoder_model, encoder_onnx_config)
+    models_for_export["encoder_model"] = (encoder_model, encoder_onnx_config)
 
     decoder_model = model.get_decoder()
     decoder_onnx_config = config.get_decoder_onnx_config(decoder_model.config, config.task, use_past=False)
-    models_for_export["decoder"] = (model, decoder_onnx_config)
+    models_for_export["decoder_model"] = (model, decoder_onnx_config)
 
     if config.use_past:
         decoder_onnx_config_with_past = config.get_decoder_onnx_config(
             decoder_model.config, config.task, use_past=True
         )
-        models_for_export["decoder_with_past"] = (model, decoder_onnx_config_with_past)
+        models_for_export["decoder_with_past_model"] = (model, decoder_onnx_config_with_past)
 
     return models_for_export
 
@@ -133,13 +133,13 @@ def get_decoder_models_for_export(
     """
     models_for_export = dict()
 
-    models_for_export["decoder"] = (
+    models_for_export["decoder_model"] = (
         model,
         config.__class__(model.config, task=config.task, use_past=False, use_present_in_outputs=True),
     )
 
     if config.use_past:
         onnx_config_with_past = config.__class__.with_past(model.config, task=config.task)
-        models_for_export["decoder_with_past"] = (model, onnx_config_with_past)
+        models_for_export["decoder_with_past_model"] = (model, onnx_config_with_past)
 
     return models_for_export

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -112,3 +112,30 @@ def get_encoder_decoder_models_for_export(
         models_for_export["decoder_with_past"] = (model, decoder_onnx_config_with_past)
 
     return models_for_export
+
+def get_decoder_models_for_export(
+    model: Union["PreTrainedModel", "TFPreTrainedModel"],
+    config: "OnnxConfig",
+) -> Dict[str, Tuple[Union["PreTrainedModel", "TFPreTrainedModel"], "OnnxConfig"]]:
+    """
+    Returns the encoder and decoder parts of the model and their subsequent onnx configs.
+
+    Args:
+        model ([`PreTrainedModel`] or [`TFPreTrainedModel`]):
+            The model to export.
+        config ([`~exporters.onnx.config.OnnxConfig`]):
+            The ONNX configuration associated with the exported model.
+
+    Returns:
+        `Dict[str, Tuple[Union[`PreTrainedModel`, `TFPreTrainedModel`], `OnnxConfig`]: A Dict containing the model and
+        onnx configs for the encoder and decoder parts of the model.
+    """
+    models_for_export = dict()
+
+    models_for_export["decoder"] = (model, config.__class__(model.config, task=config.task, use_past=False))
+
+    if config.use_past:
+        onnx_config_with_past = config.__class__.with_past(model.config, task=config.task)
+        models_for_export["decoder_with_past"] = (model, onnx_config_with_past)
+
+    return models_for_export

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -534,7 +534,6 @@ class ORTModelDecoder(ORTModel):
                     fail_if_not_found=use_cache,
                 )
 
-
             decoder_with_past_regular_onnx_filenames = ORTModelDecoder._generate_regular_names_for_filename(
                 ONNX_DECODER_WITH_PAST_NAME
             )

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -567,7 +567,6 @@ class ORTModelDecoder(ORTModel):
                     f"The ONNX file {decoder_with_past_file_name} is not a regular name used in optimum.onnxruntime that are {decoder_with_past_regular_onnx_filenames}, "
                     f"the {cls.__name__} might not behave as expected."
                 )
-
             decoder_with_past_path = model_path / decoder_with_past_file_name
 
         preprocessors = None
@@ -718,9 +717,6 @@ class ORTModelDecoder(ORTModel):
         self.providers = self.decoder.session.get_providers()
 
         return self
-
-
-import sys
 
 
 class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -568,6 +568,8 @@ class ORTModelDecoder(ORTModel):
 
         preprocessors = None
         if model_path.is_dir():
+            print("LOADING:", model_path / decoder_file_name)
+            print("LOADING:", decoder_with_past_path)
             model = cls.load_model(
                 decoder_path=model_path / decoder_file_name,
                 decoder_with_past_path=decoder_with_past_path,
@@ -667,6 +669,8 @@ class ORTModelDecoder(ORTModel):
             model_type, "onnx", task=task, model_name=model_name
         )
         onnx_config = onnx_config_constructor(model.config, use_present_in_outputs=True)
+        print("HERE onnx_config.use_past", onnx_config.use_past)
+        print("HERE onnx_config.use_present_in_outputs", onnx_config.use_present_in_outputs)
 
         export(
             model,
@@ -723,7 +727,7 @@ class ORTModelDecoder(ORTModel):
 
         return self
 
-
+import sys
 class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
     """
     ONNX model with a causal language modeling head for ONNX Runtime inference.
@@ -748,14 +752,19 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
         **kwargs,
     ) -> CausalLMOutputWithCrossAttentions:
 
+        print("in forward")
         if past_key_values is None or self.decoder_with_past is None:
+            print("running self.decoder")
             outputs = self.decoder(input_ids=input_ids, attention_mask=attention_mask)
         else:
+            print("running self.decoder_with_past")
+            print(past_key_values)
             outputs = self.decoder_with_past(
                 input_ids=input_ids[:, -1:],
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
             )
+            sys.exit()
 
         return CausalLMOutputWithCrossAttentions(logits=outputs.logits, past_key_values=outputs.past_key_values)
 

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -541,7 +541,7 @@ class ORTModelDecoder(ORTModel):
             if decoder_with_past_file_name not in decoder_with_past_regular_onnx_filenames:
                 logger.warning(
                     f"The ONNX file {decoder_with_past_file_name} is not a regular name used in optimum.onnxruntime that are {decoder_with_past_regular_onnx_filenames}, "
-                    "the {cls.__name__} might not behave as expected."
+                    f"the {cls.__name__} might not behave as expected."
                 )
 
             decoder_with_past_path = model_path / decoder_with_past_file_name if use_cache else None

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -33,7 +33,7 @@ from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 import onnxruntime as ort
 from huggingface_hub import HfApi, HfFolder, get_hf_file_metadata, hf_hub_download, hf_hub_url
 
-from ..exporters.onnx.convert import export_encoder_decoder_model as export
+from ..exporters.onnx.convert import export_encoder_decoder_model
 from ..exporters.tasks import TasksManager
 from ..utils import NormalizedConfigManager, check_if_transformers_greater
 from ..utils.save_utils import maybe_load_preprocessors, maybe_save_preprocessors
@@ -1113,15 +1113,14 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             model_type, "onnx", task=task, model_name=model_name
         )
         onnx_config = onnx_config_constructor(model.config, use_past=use_cache)
-        onnx_opset = onnx_config.DEFAULT_ONNX_OPSET
 
-        export(
-            model,
-            onnx_config,
-            onnx_opset,
-            save_dir_path.joinpath(ONNX_ENCODER_NAME),
-            save_dir_path.joinpath(ONNX_DECODER_NAME),
-            save_dir_path.joinpath(ONNX_DECODER_WITH_PAST_NAME),
+        export_encoder_decoder_model(
+            model=model,
+            config=onnx_config,
+            opset=onnx_config.DEFAULT_ONNX_OPSET,
+            encoder_output=save_dir_path.joinpath(ONNX_ENCODER_NAME),
+            decoder_output=save_dir_path.joinpath(ONNX_DECODER_NAME),
+            decoder_with_past_output=save_dir_path.joinpath(ONNX_DECODER_WITH_PAST_NAME),
         )
 
         config.save_pretrained(save_dir_path)

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -31,9 +31,9 @@ from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 
 import onnxruntime as ort
-from huggingface_hub import HfApi, HfFolder, get_hf_file_metadata, hf_hub_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 
-from ..exporters.onnx.convert import export_encoder_decoder_model
+from ..exporters.onnx import export_models, get_encoder_decoder_models_for_export
 from ..exporters.tasks import TasksManager
 from ..utils import NormalizedConfigManager, check_if_transformers_greater
 from ..utils.file_utils import validate_file_exists
@@ -1096,13 +1096,16 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         )
         onnx_config = onnx_config_constructor(model.config, use_past=use_cache)
 
-        export_encoder_decoder_model(
+        output_names = [ONNX_ENCODER_NAME, ONNX_DECODER_NAME]
+        if use_cache is True:
+            output_names.append(ONNX_DECODER_WITH_PAST_NAME)
+        export_models(
             model=model,
-            config=onnx_config,
+            onnx_config=onnx_config,
             opset=onnx_config.DEFAULT_ONNX_OPSET,
-            encoder_output=save_dir_path.joinpath(ONNX_ENCODER_NAME),
-            decoder_output=save_dir_path.joinpath(ONNX_DECODER_NAME),
-            decoder_with_past_output=save_dir_path.joinpath(ONNX_DECODER_WITH_PAST_NAME),
+            output_dir=save_dir_path,
+            fn_get_models_from_config=get_encoder_decoder_models_for_export,
+            output_names=output_names,
         )
 
         config.save_pretrained(save_dir_path)

--- a/tests/exporters/test_onnx_export.py
+++ b/tests/exporters/test_onnx_export.py
@@ -292,7 +292,7 @@ class OnnxExportTestCase(TestCase):
                         model,
                         onnx_config,
                         onnx_config.DEFAULT_ONNX_OPSET,
-                        output_dir=tmpdirname,
+                        output_dir=Path(tmpdirname),
                         fn_get_models_from_config=get_decoder_models_for_export,
                         device=device,
                     )
@@ -302,7 +302,7 @@ class OnnxExportTestCase(TestCase):
                         model,
                         onnx_outputs,
                         atol,
-                        output_dir=tmpdirname,
+                        output_dir=Path(tmpdirname),
                         fn_get_models_from_config=get_decoder_models_for_export,
                     )
                 except (RuntimeError, ValueError) as e:


### PR DESCRIPTION
# What does this PR do?

Currently, the `optimum.exporters.onnx` export in separate encoder / decoder files works well. However, for decoder-only models as gpt2, the support was not yet implemented. This PR allows decoder-only models exported through `optimum.exporters.onnx` to be loaded in `ORTDecoder` subclasses (as `ORTModelForCausalLM`).

Note: I am not sure it's super clean to duplicate methods like in this PR for specific cases. @echarlaix how do you plan to support the ONNX export for diffusion models in the current framework, and integrate in `optimum.exporters.onnx`?

There are tests missing to check:
* that `optimum.exporters.onnx` is well interfaced with ORTModel
* that the CLI of `optimum.exporters.onnx` works well

Fixes https://github.com/huggingface/optimum/issues/552
