### PR TITLE
prevent optimum from re-wrapping ORTModule

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -421,7 +421,7 @@ class ORTTrainer(Trainer):
 
         # Wrap the model with `ORTModule`
         logger.info("Wrap ORTModule for ONNX Runtime training.")
-        model = ORTModule(self.model)
+        model = ORTModule(self.model) if not isinstance(self.model, ORTModule) else self.model
         self.model_wrapped = model
 
         if args.deepspeed:


### PR DESCRIPTION
# What does this PR do?

In the case of running optimum + accelerate's auto_batch_size, ORTModule is recursively wrapped which causes export errors the second time batch_size is halved as ORT will try to export an already exported model. This fix adds a quick instance check to prevent ORTModule being double wrapped when optimum + accelerate's auto_batch_size is used.