### PR TITLE
Fix ORTTrainer wrapper duplication / PyTorch evaluate / update with transformers 4.25.1

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -441,7 +441,7 @@ class ORTTrainer(Trainer):
             deepspeed_engine, optimizer, lr_scheduler = deepspeed_init(
                 self, num_training_steps=max_steps, resume_from_checkpoint=resume_from_checkpoint
             )
-            self.model = deepspeed_engine.module
+            self.model = unwrap_model(deepspeed_engine)
             self.model_wrapped = deepspeed_engine
             self.deepspeed = deepspeed_engine
             self.optimizer = optimizer
@@ -472,7 +472,7 @@ class ORTTrainer(Trainer):
         self._load_optimizer_and_scheduler(resume_from_checkpoint)
 
         # Important: at this point if enabled distributed training features:
-        # self.model         is the ORTModule(Transformers Model)
+        # self.model         is the Transformers Model
         # self.model_wrapped is DDP(ORTModule(Transformers Model)), Deepspeed(ORTModule(Transformers Model)), etc.
 
         # Train!

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -119,13 +119,6 @@ if is_fairscale_available():
 if TYPE_CHECKING:
     import optuna
 
-if is_onnxruntime_training_available():
-    from torch_ort import ORTModule
-else:
-    raise ImportError(
-        "You need to install `onnxruntime-training` to use `ORTTrainer`. Check out "
-        "https://huggingface.co/docs/optimum/onnxruntime/usage_guides/trainer#install-onnx-runtime."
-    )
 
 logger = logging.get_logger(__name__)
 
@@ -297,6 +290,11 @@ class ORTTrainer(Trainer):
             kwargs:
                 Additional keyword arguments used to hide deprecated arguments
         """
+        if not is_onnxruntime_training_available():
+            raise ImportError(
+                "You need to install `onnxruntime-training` to use `ORTTrainer` for training. Check out "
+                "https://huggingface.co/docs/optimum/onnxruntime/usage_guides/trainer#install-onnx-runtime."
+            )
 
         if resume_from_checkpoint is False:
             resume_from_checkpoint = None
@@ -364,6 +362,7 @@ class ORTTrainer(Trainer):
     def _inner_training_loop(
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
     ):
+        from torch_ort import ORTModule
 
         self._train_batch_size = batch_size
 
@@ -1500,6 +1499,8 @@ class ORTTrainer(Trainer):
 
         # train/eval could be run multiple-times - if already wrapped, don't re-wrap it again
         if unwrap_model(model) is not model:
+            from torch_ort import ORTModule
+
             if not isinstance(model, ORTModule):
                 return model
 

--- a/optimum/onnxruntime/training_args.py
+++ b/optimum/onnxruntime/training_args.py
@@ -138,23 +138,32 @@ class ORTTrainingArguments(TrainingArguments):
             self.greater_is_better = self.metric_for_best_model not in ["loss", "eval_loss"]
         if self.run_name is None:
             self.run_name = self.output_dir
+        if self.framework == "pt" and is_torch_available():
+            if self.fp16_backend and self.fp16_backend != "auto":
+                warnings.warn(
+                    "`fp16_backend` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
+                    " `half_precision_backend` instead",
+                    FutureWarning,
+                )
+                self.half_precision_backend = self.fp16_backend
 
-        if self.fp16_backend and self.fp16_backend != "auto":
-            warnings.warn(
-                "`fp16_backend` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
-                " `half_precision_backend` instead",
-                FutureWarning,
-            )
-            self.half_precision_backend = self.fp16_backend
+            if self.bf16 or self.bf16_full_eval:
 
-        if (self.bf16 or self.bf16_full_eval) and not is_torch_bf16_available() and not self.no_cuda:
-            raise ValueError(
-                "Your setup doesn't support bf16. You need torch>=1.10, using Ampere GPU with cuda>=11.0 or using CPU"
-                " (no_cuda)"
-            )
+                if self.no_cuda and not is_torch_bf16_cpu_available():
+                    # cpu
+                    raise ValueError("Your setup doesn't support bf16/cpu. You need torch>=1.10")
+                elif not self.no_cuda and torch.cuda.is_available() and not is_torch_bf16_gpu_available():
+                    # gpu
+                    raise ValueError(
+                        "Your setup doesn't support bf16/gpu. You need torch>=1.10, using Ampere GPU with cuda>=11.0"
+                    )
 
         if self.fp16 and self.bf16:
             raise ValueError("At most one of fp16 and bf16 can be True, but not both")
+
+        if self.fp16_full_eval and self.bf16_full_eval:
+            raise ValueError("At most one of fp16 and bf16 can be True for full eval, but not both")
+
         if self.bf16:
             if self.half_precision_backend == "apex":
                 raise ValueError(
@@ -199,6 +208,15 @@ class ORTTrainingArguments(TrainingArguments):
                 " (`--bf16_full_eval`) can only be used on CUDA or CPU devices."
             )
 
+        if self.framework == "pt" and is_torch_available() and self.torchdynamo is not None:
+            if is_torch_tf32_available():
+                if self.tf32 is None and not self.fp16 or self.bf16:
+                    logger.info("Setting TF32 in CUDA backends to speedup torchdynamo.")
+                    torch.backends.cuda.matmul.allow_tf32 = True
+            else:
+                logger.warning(
+                    "The speedups for torchdynamo mostly come wih GPU Ampere or higher and which is not detected here."
+                )
         if is_torch_available() and self.tf32 is not None:
             if self.tf32:
                 if is_torch_tf32_available():


### PR DESCRIPTION
# What does this PR do?

- [x] Fix `evaluate` / `predict` with PyTorch in `ORTTrainer`.
- [x] Avoid wrapping `ORTModule` multiple times.
- [x] Improve the import message.
- [x] Update with the changes in transformers 4.25.1.