### PR TITLE
Fix exporters onnx shapes

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -279,7 +279,7 @@ class OnnxConfig(ExportConfig, ABC):
             for name, dynamic_axes in to_insert:
                 name = self.torch_to_onnx_input_map.get(name, name)
                 ordered_inputs[name] = dynamic_axes
-        
+
         print("ordered_inputs:", ordered_inputs)
         return ordered_inputs
 

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -278,7 +278,6 @@ class OnnxConfig(ExportConfig, ABC):
             for name, dynamic_axes in to_insert:
                 name = self.torch_to_onnx_input_map.get(name, name)
                 ordered_inputs[name] = dynamic_axes
-
         return ordered_inputs
 
     @add_dynamic_docstring(text=GENERATE_DUMMY_DOCSTRING, dynamic_elements=DEFAULT_DUMMY_SHAPES)
@@ -411,7 +410,6 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
         dummy_inputs = {}
         input_names = [key for key in self.inputs.keys() if not key.startswith("past_key_values")]
-
         if self.use_past:
             input_names.append("past_key_values")
         for input_name in input_names:

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -267,6 +267,7 @@ class OnnxConfig(ExportConfig, ABC):
             sig = inspect.signature(model.forward)
         else:
             sig = inspect.signature(model.call)
+        print("signature:", sig)
         for param in sig.parameters:
             param_regex = re.compile(rf"{param}(\.\d*)?")
             to_insert = []
@@ -278,6 +279,8 @@ class OnnxConfig(ExportConfig, ABC):
             for name, dynamic_axes in to_insert:
                 name = self.torch_to_onnx_input_map.get(name, name)
                 ordered_inputs[name] = dynamic_axes
+        
+        print("ordered_inputs:", ordered_inputs)
         return ordered_inputs
 
     @add_dynamic_docstring(text=GENERATE_DUMMY_DOCSTRING, dynamic_elements=DEFAULT_DUMMY_SHAPES)

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -418,6 +418,10 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                 if dummy_input_gen.supports_input(input_name):
                     if input_name == "decoder_input_ids" and self.use_past is True:
                         sequence_length = dummy_input_gen.sequence_length
+                        if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
+                            logger.info(
+                                f"Asked a sequence length of {kwargs['sequence_length']}, but a sequence length of 1 will be used with use_past ==True for `decoder_input_ids`."
+                            )
                         dummy_input_gen.sequence_length = 1
                         dummy_inputs[input_name] = dummy_input_gen.generate(input_name, framework=framework)
                         dummy_input_gen.sequence_length = sequence_length

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -96,16 +96,6 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
         dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](
             self.task, self._normalized_config, **kwargs
         )
-
-        """
-        if self.use_past_in_inputs is True:
-            if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
-                logger.warning(
-                    f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."
-                )
-            kwargs["sequence_length"] = 1
-        """
-
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task,
             self._normalized_config,

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -97,12 +97,14 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
             self.task, self._normalized_config, **kwargs
         )
 
+        """
         if self.use_past_in_inputs is True:
             if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
                 logger.warning(
                     f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."
                 )
             kwargs["sequence_length"] = 1
+        """
 
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task,

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -312,22 +312,6 @@ def export_pytorch(
         else:
             # Export can work with named args but the dict containing named args has to be the last element of the args
             # tuple.
-
-            print(type(config))
-            print(f"EXPORTING A MODEL as {output}")
-            print(dummy_inputs.keys())
-            for name, inp in dummy_inputs.items():
-                if isinstance(inp, tuple):
-                    print(name, "len:", len(inp))
-                    for inp2 in inp:
-                        print(f"        {inp2.shape if inp2 is not None else None}")
-                elif isinstance(inp, list):
-                    print(name + " (is list)", len(inp))
-                else:
-                    print(name, inp.shape)
-
-            print(type(model))
-            print("start torch.onnx.export")
             onnx_export(
                 model,
                 (dummy_inputs,),
@@ -338,7 +322,6 @@ def export_pytorch(
                 do_constant_folding=True,
                 opset_version=opset,
             )
-            print("end torch.onnx.export")
 
         config.restore_ops()
 

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -313,6 +313,21 @@ def export_pytorch(
             # Export can work with named args but the dict containing named args has to be the last element of the args
             # tuple.
 
+            print(type(config))
+            print(f"EXPORTING A MODEL as {output}")
+            print(dummy_inputs.keys())
+            for name, inp in dummy_inputs.items():
+                if isinstance(inp, tuple):
+                    print(name, "len:", len(inp))
+                    for inp2 in inp:
+                        print(f"        {inp2.shape if inp2 is not None else None}")
+                elif isinstance(inp, list):
+                    print(name + " (is list)", len(inp))
+                else:
+                    print(name, inp.shape)
+
+            print(type(model))
+            print("start torch.onnx.export")
             onnx_export(
                 model,
                 (dummy_inputs,),
@@ -323,6 +338,7 @@ def export_pytorch(
                 do_constant_folding=True,
                 opset_version=opset,
             )
+            print("end torch.onnx.export")
 
         config.restore_ops()
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -400,12 +400,14 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             self.task, self._normalized_config, **kwargs
         )
 
+        """
         if self.use_past_in_inputs is True:
             if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
                 logger.warning(
                     f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."
                 )
             kwargs["sequence_length"] = 1
+        """
 
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task, self._normalized_config, batch_size=dummy_text_input_generator.batch_size, **kwargs

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -399,16 +399,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](
             self.task, self._normalized_config, **kwargs
         )
-
-        """
-        if self.use_past_in_inputs is True:
-            if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
-                logger.warning(
-                    f"Asked a sequence length of {kwargs['sequence_length']}, but expecting a sequence length of 1 with use_past == True. Overriding the sequence length to 1."
-                )
-            kwargs["sequence_length"] = 1
-        """
-
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
             self.task, self._normalized_config, batch_size=dummy_text_input_generator.batch_size, **kwargs
         )

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -350,11 +350,7 @@ class DummySeq2SeqDecoderTextInputGenerator(DummyDecoderTextInputGenerator):
                 None,
             )
         else:
-            sequence_length = self.sequence_length
-            self.sequence_length = 1 if input_name == "decoder_input_ids" else self.sequence_length
-            generated_tensor = super().generate(input_name, framework=framework)
-            self.sequence_length = sequence_length
-            return generated_tensor
+            return super().generate(input_name, framework=framework)
 
 
 class DummyPastKeyValuesGenerator(DummyInputGenerator):

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -338,10 +338,11 @@ class DummySeq2SeqDecoderTextInputGenerator(DummyDecoderTextInputGenerator):
         self.hidden_size = normalized_config.hidden_size
 
     def generate(self, input_name: str, framework: str = "pt"):
+        sequence_length = 1 if input_name == "decoder_input_ids" else self.sequence_length
         if input_name == "encoder_outputs":
             return (
                 self.random_float_tensor(
-                    shape=[self.batch_size, self.sequence_length, self.hidden_size],
+                    shape=[self.batch_size, sequence_length, self.hidden_size],
                     min_value=0,
                     max_value=1,
                     framework=framework,

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -349,8 +349,7 @@ class DummySeq2SeqDecoderTextInputGenerator(DummyDecoderTextInputGenerator):
                 None,
                 None,
             )
-        else:
-            return super().generate(input_name, framework=framework)
+        return super().generate(input_name, framework=framework)
 
 
 class DummyPastKeyValuesGenerator(DummyInputGenerator):

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -338,11 +338,10 @@ class DummySeq2SeqDecoderTextInputGenerator(DummyDecoderTextInputGenerator):
         self.hidden_size = normalized_config.hidden_size
 
     def generate(self, input_name: str, framework: str = "pt"):
-        sequence_length = 1 if input_name == "decoder_input_ids" else self.sequence_length
         if input_name == "encoder_outputs":
             return (
                 self.random_float_tensor(
-                    shape=[self.batch_size, sequence_length, self.hidden_size],
+                    shape=[self.batch_size, self.sequence_length, self.hidden_size],
                     min_value=0,
                     max_value=1,
                     framework=framework,
@@ -350,8 +349,12 @@ class DummySeq2SeqDecoderTextInputGenerator(DummyDecoderTextInputGenerator):
                 None,
                 None,
             )
-
-        return super().generate(input_name, framework=framework)
+        else:
+            sequence_length = self.sequence_length
+            self.sequence_length = 1 if input_name == "decoder_input_ids" else self.sequence_length
+            generated_tensor = super().generate(input_name, framework=framework)
+            self.sequence_length = sequence_length
+            return generated_tensor
 
 
 class DummyPastKeyValuesGenerator(DummyInputGenerator):


### PR DESCRIPTION
Fixes https://github.com/huggingface/optimum/issues/569

Note that the shapes we were providing were "wrong" in the first place, and that this commit breaks with our weird input shapes: https://github.com/huggingface/transformers/commit/97a51b0c7d483cdf13ea878a987f9aa1c9eecc91#diff-ebaff1224cad711fd3cefb771ce17d1392ae2dfc7f74dc7da9dd014d7642a344

@mht-sharma @michaelbenayoun What do you think of this fix?

So with this PR we have shapes during the export of the `decoder_with_past_model.onnx` model (sequence length = 16, batch size = 2, num beams = 3):

```
decoder_input_ids torch.Size([2, 1])
encoder_outputs len: 3
        torch.Size([2, 16, 512])
        None
        None
attention_mask torch.Size([2, 16])
past_key_values (is list) 6
```

which somewhat match transformers (exception of the input preprocessing in `generate()`) (sequence length = 8, batch size = 3, num beams = 3):

```
decoder inputs:
    input_ids torch.Size([12, 1])
    attention_mask None
    inputs_embeds None
    encoder_hidden_states (= key_value_states) torch.Size([12, 8, 512])
    encoder_attention_mask torch.Size([12, 8])
```

I'm not sure having `decoder_input_ids` of length 1 is necessary, it doesn't fail otherwise but I'm not sure about what happens under the hood?
