### PR TITLE
Add vision encoder decoder model in exporters

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -164,6 +164,7 @@ class OnnxConfig(ExportConfig, ABC):
         "sequence-classification": OrderedDict({"logits": {0: "batch_size"}}),
         "speech2seq-lm": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "token-classification": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
+        "vision2seq-lm": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
     }
 
     def __init__(

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -246,7 +246,6 @@ class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
         from ..tasks import TasksManager
 
         if self._behavior is not ConfigBehavior.DECODER:
-            # retrieve the encoder config
             encoder_onnx_config_constructor = TasksManager.get_exporter_config_constructor(
                 exporter="onnx", task="default", model_type=config.encoder.model_type
             )
@@ -254,7 +253,6 @@ class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
             self._normalized_config.ENCODER_NORMALIZED_CONFIG_CLASS = self._encoder_onnx_config._normalized_config
 
         if self._behavior is not ConfigBehavior.ENCODER:
-            # retrieve the decoder config
             decoder_onnx_config_constructor = TasksManager.get_exporter_config_constructor(
                 exporter="onnx", task="default", model_type=config.decoder.model_type
             )

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -218,10 +218,7 @@ class AudioToTextOnnxConfig(OnnxSeq2SeqConfigWithPast):
 
 
 class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
-    DUMMY_INPUT_GENERATOR_CLASSES = (
-        DummyTextInputGenerator,
-        DummySeq2SeqDecoderTextInputGenerator,
-    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator,)
 
     def __init__(
         self,
@@ -293,8 +290,4 @@ class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
         return self._decoder_onnx_config.flatten_output_collection_property(name, field)
 
     def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-        if self._behavior is ConfigBehavior.DECODER:
-            reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
-            reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
-
-        return reference_model_inputs
+        return self._decoder_onnx_config.generate_dummy_inputs_for_validation(reference_model_inputs)

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -245,7 +245,6 @@ class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
 
         from ..tasks import TasksManager
 
-        from pdb import set_trace; set_trace()
         # retrieve the encoder config
         encoder_onnx_config_constructor = TasksManager.get_exporter_config_constructor(
             exporter="onnx", task="default", model_type=config.encoder.model_type
@@ -261,7 +260,7 @@ class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
         self._normalized_config.ENCODER_NORMALIZED_CONFIG_CLASS = self._encoder_onnx_config._normalized_config
         self._normalized_config.DECODER_NORMALIZED_CONFIG_CLASS = self._decoder_onnx_config._normalized_config
 
-        if isinstance(self.decoder_onnx_config, OnnxSeq2SeqConfigWithPast):
+        if isinstance(self._decoder_onnx_config, OnnxSeq2SeqConfigWithPast):
             self._past_key_values_generator = (DummySeq2SeqPastKeyValuesGenerator,)
         else:
             self._past_key_values_generator = (DummyPastKeyValuesGenerator,)

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -290,4 +290,8 @@ class EncoderDecoderOnnxConfig(OnnxSeq2SeqConfigWithPast):
         return self._decoder_onnx_config.flatten_output_collection_property(name, field)
 
     def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-        return self._decoder_onnx_config.generate_dummy_inputs_for_validation(reference_model_inputs)
+        if self._behavior is ConfigBehavior.DECODER:
+            reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
+            reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
+
+        return reference_model_inputs

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -971,7 +971,7 @@ class VisionEncoderDecoderOnnxConfig(EncoderDecoderOnnxConfig):
     ):
         super().__init__(config, task, patching_specs, use_past, use_past_in_inputs, use_present_in_outputs, behavior)
 
-        # TODO: Check modelling code to fix the issue with use_cache for trocr
+        # TODO: Check modeling code to fix the issue with use_cache for trocr
         if config.decoder.model_type == "trocr":
             if self.use_past_in_inputs:
                 raise ValueError("Exporting past key values is not supported with TrOCR model!")

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -948,13 +948,8 @@ class TrOCROnnxConfig(TextSeq2SeqOnnxConfig):
     )
 
 
-class VisionEncoderDecoderNormalizedConfig(NormalizedEncoderDecoderConfig):
-    ENCODER_CONFIG = "encoder"
-    DECODER_CONFIG = "decoder"
-
-
 class VisionEncoderDecoderOnnxConfig(EncoderDecoderOnnxConfig):
-    NORMALIZED_CONFIG_CLASS = VisionEncoderDecoderNormalizedConfig
+    NORMALIZED_CONFIG_CLASS = NormalizedEncoderDecoderConfig
     ATOL_FOR_VALIDATION = 1e-4
 
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -950,7 +950,7 @@ class TrOCROnnxConfig(TextSeq2SeqOnnxConfig):
 
 class VisionEncoderDecoderOnnxConfig(EncoderDecoderOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedEncoderDecoderConfig
-    ATOL_FOR_VALIDATION = 1e-4
+    ATOL_FOR_VALIDATION = 1e-3
 
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -942,7 +942,7 @@ class Speech2TextOnnxConfig(AudioToTextOnnxConfig):
 class TrOCROnnxConfig(TextSeq2SeqOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
         decoder_num_layers="decoder_layers",
-        num_layers="decoder_layers",  # Used for the causal-lm task past key values input generation.
+        num_layers="decoder_layers",
         decoder_num_attention_heads="decoder_attention_heads",
         eos_token_id="eos_token_id",
         hidden_size="d_model",

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -944,7 +944,6 @@ class TrOCROnnxConfig(TextSeq2SeqOnnxConfig):
         decoder_num_layers="decoder_layers",
         num_layers="decoder_layers",
         decoder_num_attention_heads="decoder_attention_heads",
-        eos_token_id="eos_token_id",
         hidden_size="cross_attention_hidden_size",
     )
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -945,7 +945,7 @@ class TrOCROnnxConfig(TextSeq2SeqOnnxConfig):
         num_layers="decoder_layers",
         decoder_num_attention_heads="decoder_attention_heads",
         eos_token_id="eos_token_id",
-        hidden_size="d_model",
+        hidden_size="cross_attention_hidden_size",
     )
 
 

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -105,6 +105,7 @@ class TasksManager:
             "audio-frame-classification": "AutoModelForAudioFrameClassification",
             "audio-ctc": "AutoModelForCTC",
             "audio-xvector": "AutoModelForAudioXVector",
+            "vision2seq-lm": "AutoModelForVision2Seq",
             "stable-diffusion": "StableDiffusionPipeline",
         }
     if is_tf_available():
@@ -139,6 +140,7 @@ class TasksManager:
         "audio-classification": "transformers",
         "audio-frame-classification": "transformers",
         "audio-xvector": "transformers",
+        "vision2seq-lm": "transformers",
         "stable-diffusion": "diffusers",
     }
 
@@ -328,6 +330,10 @@ class TasksManager:
             "token-classification",
             "question-answering",
             onnx="DistilBertOnnxConfig",
+        ),
+        "donut-swin": supported_tasks_mapping(
+            "default",
+            onnx="DonutSwinOnnxConfig",
         ),
         "electra": supported_tasks_mapping(
             "default",
@@ -606,6 +612,13 @@ class TasksManager:
             "seq2seq-lm-with-past",
             onnx="T5OnnxConfig",
         ),
+        "trocr": supported_tasks_mapping(
+            "default",
+            "default-with-past",
+            "vision2seq-lm",
+            "vision2seq-lm-with-past",
+            onnx="TrOCROnnxConfig",
+        ),
         "unet": supported_tasks_mapping(
             "semantic-segmentation",
             onnx="UNetOnnxConfig",
@@ -631,6 +644,11 @@ class TasksManager:
         "vae-decoder": supported_tasks_mapping(
             "semantic-segmentation",
             onnx="VaeDecoderOnnxConfig",
+        ),
+        "vision-encoder-decoder": supported_tasks_mapping(
+            "vision2seq-lm",
+            "vision2seq-lm-with-past",
+            onnx="VisionEncoderDecoderOnnxConfig",
         ),
         "vit": supported_tasks_mapping("default", "image-classification", "masked-im", onnx="ViTOnnxConfig"),
         "wavlm": supported_tasks_mapping(

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -331,10 +331,10 @@ class TasksManager:
             "question-answering",
             onnx="DistilBertOnnxConfig",
         ),
-        "donut-swin": supported_tasks_mapping(
-            "default",
-            onnx="DonutSwinOnnxConfig",
-        ),
+        # "donut-swin": supported_tasks_mapping(
+        #     "default",
+        #     onnx="DonutSwinOnnxConfig",
+        # ),
         "electra": supported_tasks_mapping(
             "default",
             "masked-lm",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -710,7 +710,7 @@ class TasksManager:
             onnx="YolosOnnxConfig",
         ),
     }
-    _UNSUPPORTED_CLI_MODEL_TYPE = {"unet", "vae-encoder", "vae-decoder", "clip-text-model"}
+    _UNSUPPORTED_CLI_MODEL_TYPE = {"unet", "vae-encoder", "vae-decoder", "clip-text-model", "trocr"}
     _SUPPORTED_CLI_MODEL_TYPE = set(_SUPPORTED_MODEL_TYPE.keys()) - _UNSUPPORTED_CLI_MODEL_TYPE
 
     @staticmethod

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -43,6 +43,7 @@ from .modeling_utils import recurse_setattr
 from .normalized_config import (
     NormalizedConfig,
     NormalizedConfigManager,
+    NormalizedEncoderDecoderConfig,
     NormalizedSeq2SeqConfig,
     NormalizedTextAndVisionConfig,
     NormalizedTextConfig,

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -101,6 +101,30 @@ class NormalizedTextAndVisionConfig(NormalizedTextConfig, NormalizedVisionConfig
         return super().__getattr__(attr_name)
 
 
+class NormalizedEncoderDecoderConfig(NormalizedSeq2SeqConfig, NormalizedVisionConfig):
+    ENCODER_CONFIG = None
+    DECODER_CONFIG = None
+
+    ENCODER_NORMALIZED_CONFIG_CLASS = None
+    DECODER_NORMALIZED_CONFIG_CLASS = None
+
+    def __getattr__(self, attr_name):
+        if (
+            self.ENCODER_CONFIG is not None
+            and self.ENCODER_NORMALIZED_CONFIG_CLASS is not None
+            and attr_name.upper() in dir(self.ENCODER_NORMALIZED_CONFIG_CLASS)
+        ):
+            return self.ENCODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
+        elif (
+            self.DECODER_CONFIG is not None
+            and self.DECODER_NORMALIZED_CONFIG_CLASS is not None
+            and attr_name.upper() in dir(self.DECODER_NORMALIZED_CONFIG_CLASS)
+        ):
+            return self.DECODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
+
+        return super().__getattr__(attr_name)
+
+
 # TODO: this config is bug prone, as `encoder_attention_heads` and `decoder_attention_heads` may be different
 BartLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="encoder_attention_heads",
@@ -199,3 +223,27 @@ class NormalizedConfigManager:
     def get_normalized_config_class(cls, model_type: str) -> Type:
         cls.check_supported_model(model_type)
         return cls._conf[model_type]
+
+
+class NormalizedEncoderDecoderConfig(NormalizedSeq2SeqConfig, NormalizedVisionConfig):
+    ENCODER_CONFIG = None
+    DECODER_CONFIG = None
+
+    ENCODER_NORMALIZED_CONFIG_CLASS = None
+    DECODER_NORMALIZED_CONFIG_CLASS = None
+
+    def __getattr__(self, attr_name):
+        if (
+            self.ENCODER_CONFIG is not None
+            and self.ENCODER_NORMALIZED_CONFIG_CLASS is not None
+            and attr_name.upper() in dir(self.ENCODER_NORMALIZED_CONFIG_CLASS)
+        ):
+            return self.ENCODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
+        elif (
+            self.DECODER_CONFIG is not None
+            and self.DECODER_NORMALIZED_CONFIG_CLASS is not None
+            and attr_name.upper() in dir(self.DECODER_NORMALIZED_CONFIG_CLASS)
+        ):
+            return self.DECODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
+
+        return super().__getattr__(attr_name)

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -115,7 +115,7 @@ class NormalizedEncoderDecoderConfig(NormalizedSeq2SeqConfig, NormalizedVisionCo
             and attr_name.upper() in dir(self.ENCODER_NORMALIZED_CONFIG_CLASS)
         ):
             return self.ENCODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
-        elif (
+        if (
             self.DECODER_CONFIG is not None
             and self.DECODER_NORMALIZED_CONFIG_CLASS is not None
             and attr_name.upper() in dir(self.DECODER_NORMALIZED_CONFIG_CLASS)
@@ -223,28 +223,3 @@ class NormalizedConfigManager:
     def get_normalized_config_class(cls, model_type: str) -> Type:
         cls.check_supported_model(model_type)
         return cls._conf[model_type]
-
-
-class NormalizedEncoderDecoderConfig(NormalizedSeq2SeqConfig, NormalizedVisionConfig):
-    ENCODER_CONFIG = None
-    DECODER_CONFIG = None
-
-    ENCODER_NORMALIZED_CONFIG_CLASS = None
-    DECODER_NORMALIZED_CONFIG_CLASS = None
-
-    def __getattr__(self, attr_name):
-        if (
-            self.ENCODER_CONFIG is not None
-            and self.ENCODER_NORMALIZED_CONFIG_CLASS is not None
-            and attr_name.upper() in dir(self.ENCODER_NORMALIZED_CONFIG_CLASS)
-        ):
-            return self.ENCODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
-
-        if (
-            self.DECODER_CONFIG is not None
-            and self.DECODER_NORMALIZED_CONFIG_CLASS is not None
-            and attr_name.upper() in dir(self.DECODER_NORMALIZED_CONFIG_CLASS)
-        ):
-            return self.DECODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
-
-        return super().__getattr__(attr_name)

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -239,7 +239,8 @@ class NormalizedEncoderDecoderConfig(NormalizedSeq2SeqConfig, NormalizedVisionCo
             and attr_name.upper() in dir(self.ENCODER_NORMALIZED_CONFIG_CLASS)
         ):
             return self.ENCODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
-        elif (
+
+        if (
             self.DECODER_CONFIG is not None
             and self.DECODER_NORMALIZED_CONFIG_CLASS is not None
             and attr_name.upper() in dir(self.DECODER_NORMALIZED_CONFIG_CLASS)

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -101,24 +101,17 @@ class NormalizedTextAndVisionConfig(NormalizedTextConfig, NormalizedVisionConfig
         return super().__getattr__(attr_name)
 
 
-class NormalizedEncoderDecoderConfig(NormalizedSeq2SeqConfig, NormalizedVisionConfig):
-    ENCODER_CONFIG = None
-    DECODER_CONFIG = None
-
+class NormalizedEncoderDecoderConfig(NormalizedConfig):
     ENCODER_NORMALIZED_CONFIG_CLASS = None
     DECODER_NORMALIZED_CONFIG_CLASS = None
 
     def __getattr__(self, attr_name):
-        if (
-            self.ENCODER_CONFIG is not None
-            and self.ENCODER_NORMALIZED_CONFIG_CLASS is not None
-            and attr_name.upper() in dir(self.ENCODER_NORMALIZED_CONFIG_CLASS)
+        if self.ENCODER_NORMALIZED_CONFIG_CLASS is not None and attr_name.upper() in dir(
+            self.ENCODER_NORMALIZED_CONFIG_CLASS
         ):
             return self.ENCODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
-        if (
-            self.DECODER_CONFIG is not None
-            and self.DECODER_NORMALIZED_CONFIG_CLASS is not None
-            and attr_name.upper() in dir(self.DECODER_NORMALIZED_CONFIG_CLASS)
+        if self.DECODER_NORMALIZED_CONFIG_CLASS is not None and attr_name.upper() in dir(
+            self.DECODER_NORMALIZED_CONFIG_CLASS
         ):
             return self.DECODER_NORMALIZED_CONFIG_CLASS.__getattr__(attr_name)
 

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -110,6 +110,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "speech-to-text": "hf-internal-testing/tiny-random-Speech2TextModel",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
     "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
+    "vision-encoder-decoder": "hf-internal-testing/tiny-random-VisionEncoderDecoderModel-vit-gpt2",
 }
 
 

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -110,7 +110,15 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "speech-to-text": "hf-internal-testing/tiny-random-Speech2TextModel",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
     "xlm-roberta": "hf-internal-testing/tiny-xlm-roberta",
-    "vision-encoder-decoder": "hf-internal-testing/tiny-random-VisionEncoderDecoderModel-vit-gpt2",
+    "vision-encoder-decoder": {
+        "hf-internal-testing/tiny-random-VisionEncoderDecoderModel-vit-gpt2": [
+            "vision2seq-lm",
+            "vision2seq-lm-with-past",
+        ],
+        "microsoft/trocr-small-handwritten": ["vision2seq-lm"],
+    },
+    # Disabled for now because of high atol threshold requirement to pass
+    # "donut-swin": "hf-internal-testing/tiny-random-DonutSwinModel"
 }
 
 

--- a/tests/exporters/test_exporters_onnx_cli.py
+++ b/tests/exporters/test_exporters_onnx_cli.py
@@ -42,7 +42,11 @@ def _get_models_to_test(export_models_dict: Dict):
                 tasks = list(task_config_mapping.keys())
                 model_tasks = {model_names_tasks: tasks}
             else:
-                n_tested_tasks = sum(len(tasks) for tasks in model_names_tasks.values())
+                unique_tasks = set()
+                for tasks in model_names_tasks.values():
+                    for task in tasks:
+                        unique_tasks.add(task)
+                n_tested_tasks = len(unique_tasks)
                 if n_tested_tasks != len(task_config_mapping):
                     raise ValueError(f"Not all tasks are tested for {model_type}.")
                 model_tasks = model_names_tasks  # possibly, test different tasks on different models
@@ -53,14 +57,14 @@ def _get_models_to_test(export_models_dict: Dict):
 
                     if any(
                         task.startswith(ort_special_task)
-                        for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm"]
+                        for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm"]
                     ):
                         models_to_test.append((f"{model_type}_{task}_forort", model_name, task, True))
 
             # TODO: segformer task can not be automatically inferred
             # TODO: xlm-roberta model auto-infers causal-lm, but we don't support it
             # TODO: perceiver auto-infers default, but we don't support it (why?)
-            if model_type not in ["segformer", "xlm-roberta", "perceiver"]:
+            if model_type not in ["segformer", "xlm-roberta", "perceiver", "vision-encoder-decoder"]:
                 models_to_test.append((f"{model_type}_no_task", model_name, None, False))
 
         return sorted(models_to_test)

--- a/tests/exporters/test_onnx_export.py
+++ b/tests/exporters/test_onnx_export.py
@@ -149,7 +149,11 @@ def _get_models_to_test(export_models_dict: Dict):
                 tasks = list(task_config_mapping.keys())
                 model_tasks = {model_names_tasks: tasks}
             else:
-                n_tested_tasks = sum(len(tasks) for tasks in model_names_tasks.values())
+                unique_tasks = set()
+                for tasks in model_names_tasks.values():
+                    for task in tasks:
+                        unique_tasks.add(task)
+                n_tested_tasks = len(unique_tasks)
                 if n_tested_tasks != len(task_config_mapping):
                     raise ValueError(f"Not all tasks are tested for {model_type}.")
                 model_tasks = model_names_tasks  # possibly, test different tasks on different models
@@ -166,7 +170,7 @@ def _get_models_to_test(export_models_dict: Dict):
 
                     if any(
                         task.startswith(ort_special_task)
-                        for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm"]
+                        for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm"]
                     ):
                         models_to_test.append(
                             (


### PR DESCRIPTION
# What does this PR do?

Supports vision-encoder-decoder export to onnx in optimum

Changes
* Adds generic class for exporting Encoder-Decoder type models [doc](https://huggingface.co/docs/transformers/model_doc/encoder-decoder)
* Adds export for `vision-encoder-decoder` models using the above class

Limitation
* Past key value export not supported with TROcr
* Donut model is not supported

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

