### PR TITLE
OnnxConfig now handle the export to encoder / decoder / decoder_with_past themselves

### DIFF
--- a/docs/source/exporters/onnx/package_reference/configuration.mdx
+++ b/docs/source/exporters/onnx/package_reference/configuration.mdx
@@ -41,8 +41,6 @@ They specify which input generators should be used for the dummy inputs, but rem
     - with_past
 
 [[autodoc]] exporters.onnx.OnnxSeq2SeqConfigWithPast
-    - get_encoder_onnx_config
-    - get_decoder_onnx_config
 
 ## Middle-end classes
 

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -529,6 +529,8 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         """Override this to specify custom attribute change for a given behavior."""
         if self._behavior is ConfigBehavior.ENCODER:
             self.task = "default"
+            self.use_past_in_inputs = False
+            self.use_present_in_outputs = False
         if self._behavior is ConfigBehavior.DECODER:
             self.use_past_in_inputs = self.use_past
             self.use_present_in_outputs = True

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -485,6 +485,12 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
 
 class ConfigBehavior(str, enum.Enum):
+    """
+    Specifies the behavior of the [`~exporters.onnx.base.OnnxSeq2SeqConfigWithPast`]:
+        - MONOLITH: the config can be used to export the whole seq2seq model as a single file.
+        - ENCODER: the config can be used to export the encoder part of the seq2seq model.
+        - DECODER: the config can be used to export the decoder part of the seq2seq model.
+    """
     MONOLITH = "monolith"
     ENCODER = "encoder"
     DECODER = "decoder"
@@ -519,6 +525,7 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         self.override_attributes_for_behavior()
 
     def override_attributes_for_behavior(self):
+        """Override this to specify custom attribute change for a given behavior."""
         if self._behavior is ConfigBehavior.ENCODER:
             self.task = "default"
         if self._behavior is ConfigBehavior.DECODER:
@@ -528,6 +535,18 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
     def with_behavior(
         self, behavior: Union[str, ConfigBehavior], use_past: bool = False
     ) -> "OnnxSeq2SeqConfigWithPast":
+        """
+        Creates a copy of the current OnnxConfig but with a different `ConfigBehavior` and `use_past` value.
+
+        Args:
+            behavior ([`ConfigBehavior`]):
+                The behavior to use for the new instance.
+            use_past (`bool`, defaults to `False`):
+                Whether or not the new instance should use past.
+
+        Returns:
+            `OnnxSeq2SeqConfigWithPast`
+        """
         if isinstance(behavior, str) and not isinstance(behavior, ConfigBehavior):
             behavior = ConfigBehavior(behavior)
         return self.__class__(

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -491,6 +491,7 @@ class ConfigBehavior(str, enum.Enum):
         - ENCODER: the config can be used to export the encoder part of the seq2seq model.
         - DECODER: the config can be used to export the decoder part of the seq2seq model.
     """
+
     MONOLITH = "monolith"
     ENCODER = "encoder"
     DECODER = "decoder"

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -177,7 +177,7 @@ class AudioToTextOnnxConfig(OnnxSeq2SeqConfigWithPast):
         common_inputs = {}
 
         if self._behavior is not ConfigBehavior.DECODER:
-            common_inputs["input_features"] = ({0: "batch_size", 1: "feature_size", 2: "encoder_sequence_length"},)
+            common_inputs["input_features"] = {0: "batch_size", 1: "feature_size", 2: "encoder_sequence_length"}
 
         if self._behavior is not ConfigBehavior.ENCODER:
             if self.use_past_in_inputs:

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -430,7 +430,7 @@ class BigBirdPegasusOnnxConfig(BartOnnxConfig):
         if self._behavior is ConfigBehavior.ENCODER:
             # TODO: check why the attention mask is not present in the exported model
             reference_model_inputs.pop("attention_mask")
-        return reference_model_inputs
+        return super().generate_dummy_inputs_for_validation(reference_model_inputs)
 
 
 class MarianOnnxConfig(BartOnnxConfig):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -26,6 +26,7 @@ from ...utils import (
     DummyTextInputGenerator,
     DummyTimestepInputGenerator,
     DummyVisionInputGenerator,
+    NormalizedConfig,
     NormalizedSeq2SeqConfig,
     NormalizedTextAndVisionConfig,
     NormalizedTextConfig,

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -53,55 +53,55 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-# class Seq2SeqEncoderOnnxConfig(TextEncoderOnnxConfig):
-#     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
-#
-#     @property
-#     def inputs(self) -> Mapping[str, Mapping[int, str]]:
-#         return {
-#             "input_ids": {0: "batch_size", 1: "sequence_length"},
-#             "attention_mask": {0: "batch_size", 1: "sequence_length"},
-#         }
-#
-#
-# class Seq2SeqDecoderOnnxConfig(TextSeq2SeqOnnxConfig):
-#     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig
-#
-#     DUMMY_INPUT_GENERATOR_CLASSES = (
-#         DummyTextInputGenerator,
-#         DummySeq2SeqDecoderTextInputGenerator,
-#         DummySeq2SeqPastKeyValuesGenerator,
-#     )
-#
-#     USE_PRESENT_IN_OUTPUTS = True
-#
-#     @property
-#     def inputs(self) -> Mapping[str, Mapping[int, str]]:
-#         common_inputs = {
-#             "decoder_input_ids": {0: "batch_size", 1: "past_decoder_sequence_length + sequence_length"},
-#             "encoder_outputs": {0: "batch_size", 1: "encoder_sequence_length"},
-#             "attention_mask": {0: "batch_size", 1: "encoder_sequence_length"},
-#         }
-#
-#         if self.use_past_in_inputs:
-#             self.add_past_key_values(common_inputs, direction="inputs")
-#
-#         return common_inputs
-#
-#     @property
-#     def torch_to_onnx_input_map(self) -> Mapping[str, str]:
-#         return {
-#             "decoder_input_ids": "input_ids",
-#             "encoder_outputs": "encoder_hidden_states",
-#             "attention_mask": "encoder_attention_mask",
-#         }
-#
-#     def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-#         reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
-#         reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
-#         reference_model_inputs["encoder_attention_mask"] = reference_model_inputs.pop("attention_mask")
-#
-#         return reference_model_inputs
+class Seq2SeqEncoderOnnxConfig(TextEncoderOnnxConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        return {
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "attention_mask": {0: "batch_size", 1: "sequence_length"},
+        }
+
+
+class Seq2SeqDecoderOnnxConfig(TextSeq2SeqOnnxConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyTextInputGenerator,
+        DummySeq2SeqDecoderTextInputGenerator,
+        DummySeq2SeqPastKeyValuesGenerator,
+    )
+
+    USE_PRESENT_IN_OUTPUTS = True
+
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        common_inputs = {
+            "decoder_input_ids": {0: "batch_size", 1: "past_decoder_sequence_length + sequence_length"},
+            "encoder_outputs": {0: "batch_size", 1: "encoder_sequence_length"},
+            "attention_mask": {0: "batch_size", 1: "encoder_sequence_length"},
+        }
+
+        if self.use_past_in_inputs:
+            self.add_past_key_values(common_inputs, direction="inputs")
+
+        return common_inputs
+
+    @property
+    def torch_to_onnx_input_map(self) -> Mapping[str, str]:
+        return {
+            "decoder_input_ids": "input_ids",
+            "encoder_outputs": "encoder_hidden_states",
+            "attention_mask": "encoder_attention_mask",
+        }
+
+    def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
+        reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
+        reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
+        reference_model_inputs["encoder_attention_mask"] = reference_model_inputs.pop("attention_mask")
+
+        return reference_model_inputs
 
 
 class BertOnnxConfig(TextEncoderOnnxConfig):
@@ -279,23 +279,6 @@ class T5DummySeq2SeqPastKeyValuesGenerator(DummySeq2SeqPastKeyValuesGenerator):
         ]
 
 
-class T5DecoderOnnxConfig(Seq2SeqDecoderOnnxConfig):
-    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
-        hidden_size="d_model",
-        num_attention_heads="num_heads",
-        encoder_num_layers="num_layers",
-        decoder_num_layers="num_decoder_layers",
-        key_value_dim="d_kv",
-        allow_new=True,
-    )
-
-    DUMMY_INPUT_GENERATOR_CLASSES = (
-        DummyTextInputGenerator,
-        DummySeq2SeqDecoderTextInputGenerator,
-        T5DummySeq2SeqPastKeyValuesGenerator,
-    )
-
-
 class T5OnnxConfig(TextSeq2SeqOnnxConfig):
     DEFAULT_ONNX_OPSET = 13
     DUMMY_INPUT_GENERATOR_CLASSES = TextSeq2SeqOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[:-1] + (
@@ -309,14 +292,6 @@ class T5OnnxConfig(TextSeq2SeqOnnxConfig):
         key_value_dim="d_kv",
         allow_new=True,
     )
-
-    def get_encoder_onnx_config(self, config: "PretrainedConfig") -> Seq2SeqEncoderOnnxConfig:
-        return self.for_encoder(task="default", use_past=False)
-
-    def get_decoder_onnx_config(
-        self, config: "PretrainedConfig", task: str = "default", use_past: bool = False
-    ) -> T5DecoderOnnxConfig:
-        return self.for_decoder(use_present_in_outputs=True, use_past_in_inputs=use_past)
 
 
 class MT5OnnxConfig(T5OnnxConfig):
@@ -366,17 +341,6 @@ class BartDummyTextInputGenerator(DummyTextInputGenerator):
         return int_tensor
 
 
-class BartDecoderOnnxConfig(Seq2SeqDecoderOnnxConfig):
-    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
-        encoder_num_layers="encoder_layers",
-        decoder_num_layers="decoder_layers",
-        num_layers="decoder_layers",  # Used for the causal-lm task past key values input generation.
-        encoder_num_attention_heads="encoder_attention_heads",
-        decoder_num_attention_heads="decoder_attention_heads",
-        eos_token_id="eos_token_id",
-    )
-
-
 class BartOnnxConfig(TextSeq2SeqOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
         encoder_num_layers="encoder_layers",
@@ -388,7 +352,10 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
     )
     DUMMY_INPUT_GENERATOR_CLASSES = (
         BartDummyTextInputGenerator,
-        DummyDecoderTextInputGenerator,
+        {
+            "default": DummySeq2SeqDecoderTextInputGenerator,
+            "causal-lm": DummyDecoderTextInputGenerator,
+        },
         {
             "default": DummySeq2SeqPastKeyValuesGenerator,
             "causal-lm": DummyPastKeyValuesGenerator,
@@ -399,10 +366,9 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](
             self.task, self._normalized_config, **kwargs
         )
-        dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1](
+        dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1][task](
             self.task, self._normalized_config, batch_size=dummy_text_input_generator.batch_size, **kwargs
         )
-        task = "default" if self.task != "causal-lm" else "causal-lm"
         kwargs = {}
         if self.task != "causal-lm":
             kwargs["encoder_sequence_length"] = dummy_text_input_generator.sequence_length
@@ -493,16 +459,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
 
         dummy_inputs = super().generate_dummy_inputs(framework=framework)
 
-        # if self.use_past and self.task in ["default", "seq2seq-lm"]:
-        #     attention_mask_length = dummy_inputs["decoder_attention_mask"].shape[1]
-        #     decoder_past_length = dummy_inputs["past_key_values"][0][0].shape[2]
-        #     dummy_inputs["decoder_attention_mask"] = self.dummy_inputs_generators[0].pad_input_on_dim(
-        #         dummy_inputs["decoder_attention_mask"],
-        #         desired_length=decoder_past_length,
-        #         dim=1,
-        #         dtype=dummy_inputs["decoder_attention_mask"].dtype,
-        #     )
-
         # Setting it back to the default version.
         self.PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = False
         return dummy_inputs
@@ -514,14 +470,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             flattened_output = super(OnnxSeq2SeqConfigWithPast, self).flatten_past_key_values(
                 flattened_output, name, idx, t
             )
-
-    def get_encoder_onnx_config(self, config: "PretrainedConfig") -> Seq2SeqEncoderOnnxConfig:
-        return Seq2SeqEncoderOnnxConfig(config, task="default")
-
-    def get_decoder_onnx_config(
-        self, config: "PretrainedConfig", task: str = "default", use_past: bool = False
-    ) -> BartDecoderOnnxConfig:
-        return BartDecoderOnnxConfig(config, task, use_past=use_past)
 
 
 class MBartOnnxConfig(BartOnnxConfig):
@@ -540,16 +488,13 @@ class BlenderbotSmallOnnxConfig(BartOnnxConfig):
     pass
 
 
-class BigBirdPegasusEncoderOnnxConfig(Seq2SeqEncoderOnnxConfig):
-    def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-        # TODO: check why the attention mask is not present in the exported model
-        reference_model_inputs.pop("attention_mask")
-        return reference_model_inputs
-
-
 class BigBirdPegasusOnnxConfig(BartOnnxConfig):
-    def get_encoder_onnx_config(self, config: "PretrainedConfig") -> BigBirdPegasusEncoderOnnxConfig:
-        return BigBirdPegasusEncoderOnnxConfig(config, task="default")
+    def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
+        from .base import ConfigBehavior
+        if self._behavior is ConfigBehavior.ENCODER:
+            # TODO: check why the attention mask is not present in the exported model
+            reference_model_inputs.pop("attention_mask")
+        return reference_model_inputs
 
 
 class MarianOnnxConfig(BartOnnxConfig):
@@ -749,44 +694,6 @@ class PerceiverOnnxConfig(TextAndVisionOnnxConfig):
         return dummy_inputs
 
 
-class SpeechSeq2SeqEncoderOnnxConfig(AudioOnnxConfig):
-    NORMALIZED_CONFIG_CLASS = NormalizedConfig
-
-    @property
-    def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        return {
-            "input_features": {0: "batch_size", 1: "feature_size", 2: "encoder_sequence_length"},
-        }
-
-
-class SpeechSeq2SeqDecoderOnnxConfig(Seq2SeqDecoderOnnxConfig):
-    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig
-
-    DUMMY_INPUT_GENERATOR_CLASSES = (
-        DummyTextInputGenerator,
-        DummySeq2SeqDecoderTextInputGenerator,
-        DummySeq2SeqPastKeyValuesGenerator,
-    )
-
-    @property
-    def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        common_inputs = {
-            "decoder_input_ids": {0: "batch_size", 1: "past_decoder_sequence_length + sequence_length"},
-            "encoder_outputs": {0: "batch_size", 1: "encoder_sequence_length"},
-        }
-
-        if self.use_past_in_inputs:
-            self.add_past_key_values(common_inputs, direction="inputs")
-
-        return common_inputs
-
-    def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-        reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
-        reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
-
-        return reference_model_inputs
-
-
 class WhisperOnnxConfig(TextAndAudioOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig
     ATOL_FOR_VALIDATION = 1e-3
@@ -806,10 +713,20 @@ class WhisperOnnxConfig(TextAndAudioOnnxConfig):
 
         return common_inputs
 
-    def get_encoder_onnx_config(self, config: "PretrainedConfig") -> SpeechSeq2SeqEncoderOnnxConfig:
-        return SpeechSeq2SeqEncoderOnnxConfig(config, task="default")
+    @property
+    def inputs_for_encoder(self) -> Mapping[str, Mapping[int, str]]:
+        return {
+            "input_features": {0: "batch_size", 1: "feature_size", 2: "encoder_sequence_length"},
+        }
 
-    def get_decoder_onnx_config(
-        self, config: "PretrainedConfig", task: str = "default", use_past: bool = False
-    ) -> SpeechSeq2SeqDecoderOnnxConfig:
-        return SpeechSeq2SeqDecoderOnnxConfig(config, task, use_past=use_past)
+    @property
+    def inputs_for_decoder(self) -> Mapping[str, Mapping[int, str]]:
+        common_inputs = {
+            "decoder_input_ids": {0: "batch_size", 1: "past_decoder_sequence_length + sequence_length"},
+            "encoder_outputs": {0: "batch_size", 1: "encoder_sequence_length"},
+        }
+
+        if self.use_past_in_inputs:
+            self.add_past_key_values(common_inputs, direction="inputs")
+
+        return common_inputs

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -313,6 +313,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         dummy_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[0](
             self.task, self._normalized_config, **kwargs
         )
+        task = "default" if self.task != "causal-lm" else "causal-lm"
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1][task](
             self.task, self._normalized_config, batch_size=dummy_text_input_generator.batch_size, **kwargs
         )

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -116,7 +116,12 @@ def get_decoder_models_for_export(
     config: "OnnxConfig",
 ) -> Dict[str, Tuple[Union["PreTrainedModel", "TFPreTrainedModel"], "OnnxConfig"]]:
     """
-    Returns the encoder and decoder parts of the model and their subsequent onnx configs.
+    Returns two versions of the decoder that can be used together to perform fast generation:
+
+        1. The first one takes regular inputs, and outputs the result along with past key/values.
+        2. The second one takes regular inputs and past key/values, and outputs the result along with the updated past
+        key/values.
+
 
     Args:
         model ([`PreTrainedModel`] or [`TFPreTrainedModel`]):
@@ -125,15 +130,17 @@ def get_decoder_models_for_export(
             The ONNX configuration associated with the exported model.
 
     Returns:
-        `Dict[str, Tuple[Union[`PreTrainedModel`, `TFPreTrainedModel`], `OnnxConfig`]: A Dict containing the model and
+        `Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]]: A Dict containing the model and
         onnx configs for the encoder and decoder parts of the model.
     """
     models_for_export = {}
 
-    models_for_export["decoder_model"] = (model, config.with_behavior("decoder", use_past=False))
+    models_for_export["decoder_model"] = onnx_config_with_past = config.__class__(
+        model.config, task=config.task, use_past_in_inputs=False, use_present_in_outputs=True
+    )
 
     if config.use_past:
-        onnx_config_with_past = config.with_behavior("decoder", use_past=True)
+        onnx_config_with_past = config.__class__(model.config, task=config.task, use_past=True)
         models_for_export["decoder_with_past_model"] = (model, onnx_config_with_past)
 
     return models_for_export

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -130,13 +130,10 @@ def get_decoder_models_for_export(
     """
     models_for_export = {}
 
-    models_for_export["decoder_model"] = (
-        model,
-        config.__class__(model.config, task=config.task, use_past=False, use_present_in_outputs=True),
-    )
+    models_for_export["decoder_model"] = (model, config.with_behavior("decoder", use_past=False))
 
     if config.use_past:
-        onnx_config_with_past = config.__class__.with_past(model.config, task=config.task)
+        onnx_config_with_past = config.with_behavior("decoder", use_past=True)
         models_for_export["decoder_with_past_model"] = (model, onnx_config_with_past)
 
     return models_for_export

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -95,20 +95,17 @@ def get_encoder_decoder_models_for_export(
         `Dict[str, Tuple[Union[`PreTrainedModel`, `TFPreTrainedModel`], `OnnxConfig`]: A Dict containing the model and
         onnx configs for the encoder and decoder parts of the model.
     """
-    models_for_export = dict()
+    models_for_export = {}
 
     encoder_model = model.get_encoder()
-    encoder_onnx_config = config.get_encoder_onnx_config(encoder_model.config)
+    encoder_onnx_config = config.with_behavior("encoder")
     models_for_export["encoder_model"] = (encoder_model, encoder_onnx_config)
 
-    decoder_model = model.get_decoder()
-    decoder_onnx_config = config.get_decoder_onnx_config(decoder_model.config, config.task, use_past=False)
+    decoder_onnx_config = config.with_behavior("decoder", use_past=False)
     models_for_export["decoder_model"] = (model, decoder_onnx_config)
 
     if config.use_past:
-        decoder_onnx_config_with_past = config.get_decoder_onnx_config(
-            decoder_model.config, config.task, use_past=True
-        )
+        decoder_onnx_config_with_past = config.with_behavior("decoder", use_past=True)
         models_for_export["decoder_with_past_model"] = (model, decoder_onnx_config_with_past)
 
     return models_for_export
@@ -131,7 +128,7 @@ def get_decoder_models_for_export(
         `Dict[str, Tuple[Union[`PreTrainedModel`, `TFPreTrainedModel`], `OnnxConfig`]: A Dict containing the model and
         onnx configs for the encoder and decoder parts of the model.
     """
-    models_for_export = dict()
+    models_for_export = {}
 
     models_for_export["decoder_model"] = (
         model,

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -135,9 +135,10 @@ def get_decoder_models_for_export(
     """
     models_for_export = {}
 
-    models_for_export["decoder_model"] = onnx_config_with_past = config.__class__(
+    onnx_config = config.__class__(
         model.config, task=config.task, use_past_in_inputs=False, use_present_in_outputs=True
     )
+    models_for_export["decoder_model"] = (model, onnx_config)
 
     if config.use_past:
         onnx_config_with_past = config.__class__(model.config, task=config.task, use_past=True)


### PR DESCRIPTION
# What does this PR do?

This handles the export to ONNX in multiple files (for seq2seq models) directly in the relevant OnnxConfig itself, instead of using others.

cc @mht-sharma @fxmarty 