### PR TITLE
Reimplement get_io_numpy_type_map in IO binding helper

### DIFF
--- a/optimum/onnxruntime/io_binding/io_binding_helper.py
+++ b/optimum/onnxruntime/io_binding/io_binding_helper.py
@@ -20,6 +20,7 @@ import torch
 
 import onnxruntime as ort
 from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
+from onnxruntime.transformers.io_binding_helper import TypeHelper as ORTTypeHelper
 
 from ..utils import is_cupy_available, is_onnxruntime_training_available
 
@@ -34,7 +35,7 @@ if is_cupy_available():
 
 
 # Adapted from https://github.com/microsoft/onnxruntime/blob/93e0a151177ad8222c2c95f814342bfa27f0a64d/onnxruntime/python/tools/transformers/io_binding_helper.py#L12
-class TypeHelper:
+class TypeHelper(ORTTypeHelper):
     """
     Gets data type information of the ONNX Runtime inference session and provides the mapping from
     `OrtValue` data types to the data types of other frameworks (NumPy, PyTorch, etc).


### PR DESCRIPTION
This allows to avoid an error with numpy==1.24.0 when the parent `get_io_numpy_type_map` is called, and in turn the parents `ort_type_to_numpy_type` are called.

@JingyaHuang  Just to understand, why do we have `"tensor(bool)": np.uint8,` in `ort_type_to_numpy_type` and not `"tensor(bool)": bool`? Because of the dlpack/bool thing support?

Related:
https://github.com/huggingface/optimum/pull/604
https://github.com/microsoft/onnxruntime/pull/14014