### PR TITLE
Constraint temprarily NumPy version to save CIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRED_PKGS = [
     "transformers[sentencepiece]>=4.20.1",
     "torch>=1.9",
     "packaging",
-    "numpy",
+    "numpy<1.24.0",
     "huggingface_hub>=0.8.0",
 ]
 


### PR DESCRIPTION
# What does this PR do?

As suggested in the title, the new NumPy has deprecated some features, we need to set it back to lower than 1.24.0 to pass CIs before patch releases of our partner libs.