### PR TITLE
Fix whisper export

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -751,6 +751,21 @@ class WhisperOnnxConfig(AudioToTextOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig
     ATOL_FOR_VALIDATION = 1e-3
 
+    def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
+        dummy_inputs_generators = super()._create_dummy_input_generator_classes(**kwargs)
+
+        if self._behavior is ConfigBehavior.MONOLITH:
+            dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
+                self.task,
+                self._normalized_config,
+                batch_size=dummy_inputs_generators[0].batch_size,
+                encoder_sequence_length=dummy_inputs_generators[0].nb_max_frames // 2,
+                **kwargs,
+            )
+            dummy_inputs_generators[2] = dummy_seq2seq_past_key_values_generator
+
+        return dummy_inputs_generators
+
 
 class MobileNetV1OnnxConfig(VisionOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -753,7 +753,7 @@ class WhisperOnnxConfig(AudioToTextOnnxConfig):
 
     def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
         dummy_inputs_generators = super()._create_dummy_input_generator_classes(**kwargs)
-
+# The generated encoder_hidden_states for Whisper has dimensions (batch_size, encoder_sequence_length / 2, hidden_size). Therefore, the sequence length is updated to generate the proper cross attention KVS.
         if self._behavior is ConfigBehavior.MONOLITH:
             dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
                 self.task,

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -758,7 +758,6 @@ class WhisperOnnxConfig(AudioToTextOnnxConfig):
             dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
                 self.task,
                 self._normalized_config,
-                batch_size=dummy_inputs_generators[0].batch_size,
                 encoder_sequence_length=dummy_inputs_generators[0].nb_max_frames // 2,
                 **kwargs,
             )

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -753,7 +753,10 @@ class WhisperOnnxConfig(AudioToTextOnnxConfig):
 
     def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
         dummy_inputs_generators = super()._create_dummy_input_generator_classes(**kwargs)
-# The generated encoder_hidden_states for Whisper has dimensions (batch_size, encoder_sequence_length / 2, hidden_size). Therefore, the sequence length is updated to generate the proper cross attention KVS.
+        # The generated encoder_hidden_states for Whisper has dimensions
+        # (batch_size, encoder_sequence_length / 2, hidden_size). Therefore,
+        # the sequence length is updated to generate the proper cross attention
+        # KVS in monolith case.
         if self._behavior is ConfigBehavior.MONOLITH:
             dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
                 self.task,


### PR DESCRIPTION
# What does this PR do?

Fixes the whisper export

The current export for whisper fails because the cross attention key values are not exported as input in the ONNX model after the new condition introduced in the [transformers@97a51](https://github.com/huggingface/transformers/commit/97a51b0c7d483cdf13ea878a987f9aa1c9eecc91).

The error occurs due to incorrect dummy input generation for cross attention key values for export. The PR fixes the same.

Fixes #600 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

