### PR TITLE
[`ONNX`] add `mobilenet` support

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -751,10 +751,10 @@ class WhisperOnnxConfig(AudioToTextOnnxConfig):
 class MobileNetV1OnnxConfig(VisionOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     MIN_TORCH_VERSION = version.parse("1.11")
-
+ATOL_FOR_VALIDATION = 1e-4
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        return OrderedDict([("pixel_values", {0: "batch"})])
+        return {"pixel_values", {0: "batch_size"}}
 
     @property
     def outputs(self) -> Mapping[str, Mapping[int, str]]:

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -753,6 +753,17 @@ class MobileNetV1OnnxConfig(VisionOnnxConfig):
     MIN_TORCH_VERSION = version.parse("1.11")
     ATOL_FOR_VALIDATION = 1e-4
 
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict([("pixel_values", {0: "batch"})])
+
+    @property
+    def outputs(self) -> Mapping[str, Mapping[int, str]]:
+        if self.task == "image-classification":
+            return OrderedDict([("logits", {0: "batch"})])
+        else:
+            return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
+
 
 class MobileNetV2OnnxConfig(MobileNetV1OnnxConfig):
     pass

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Model specific ONNX configurations."""
 import random
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Tuple
 
 from packaging import version
@@ -755,14 +754,7 @@ class MobileNetV1OnnxConfig(VisionOnnxConfig):
 
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        return OrderedDict([("pixel_values", {0: "batch"})])
-
-    @property
-    def outputs(self) -> Mapping[str, Mapping[int, str]]:
-        if self.task == "image-classification":
-            return OrderedDict([("logits", {0: "batch"})])
-        else:
-            return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
+        return {"pixel_values": {0: "batch"}}
 
 
 class MobileNetV2OnnxConfig(MobileNetV1OnnxConfig):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -753,17 +753,6 @@ class MobileNetV1OnnxConfig(VisionOnnxConfig):
     MIN_TORCH_VERSION = version.parse("1.11")
     ATOL_FOR_VALIDATION = 1e-4
 
-    @property
-    def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        return {"pixel_values", {0: "batch_size"}}
-
-    @property
-    def outputs(self) -> Mapping[str, Mapping[int, str]]:
-        if self.task == "image-classification":
-            return OrderedDict([("logits", {0: "batch"})])
-        else:
-            return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
-
 
 class MobileNetV2OnnxConfig(MobileNetV1OnnxConfig):
     pass

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Model specific ONNX configurations."""
 import random
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Tuple
 
 from packaging import version
@@ -745,3 +746,43 @@ class PerceiverOnnxConfig(TextAndVisionOnnxConfig):
 class WhisperOnnxConfig(AudioToTextOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig
     ATOL_FOR_VALIDATION = 1e-3
+
+
+class MobileNetV1OnnxConfig(VisionOnnxConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    MIN_TORCH_VERSION = version.parse("1.11")
+
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict([("pixel_values", {0: "batch"})])
+
+    @property
+    def outputs(self) -> Mapping[str, Mapping[int, str]]:
+        if self.task == "image-classification":
+            return OrderedDict([("logits", {0: "batch"})])
+        else:
+            return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
+
+    @property
+    def atol_for_validation(self) -> float:
+        return 1e-4
+
+
+class MobileNetV2OnnxConfig(VisionOnnxConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    MIN_TORCH_VERSION = version.parse("1.11")
+
+    @property
+    def inputs(self) -> Mapping[str, Mapping[int, str]]:
+        return OrderedDict([("pixel_values", {0: "batch"})])
+
+    @property
+    def outputs(self) -> Mapping[str, Mapping[int, str]]:
+        if self.task == "image-classification":
+            return OrderedDict([("logits", {0: "batch"})])
+        else:
+            return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
+
+    @property
+    def atol_for_validation(self) -> float:
+        return 1e-4

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -751,7 +751,8 @@ class WhisperOnnxConfig(AudioToTextOnnxConfig):
 class MobileNetV1OnnxConfig(VisionOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     MIN_TORCH_VERSION = version.parse("1.11")
-ATOL_FOR_VALIDATION = 1e-4
+    ATOL_FOR_VALIDATION = 1e-4
+
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
         return {"pixel_values", {0: "batch_size"}}
@@ -762,10 +763,6 @@ ATOL_FOR_VALIDATION = 1e-4
             return OrderedDict([("logits", {0: "batch"})])
         else:
             return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
-
-    @property
-    def atol_for_validation(self) -> float:
-        return 1e-4
 
 
 class MobileNetV2OnnxConfig(MobileNetV1OnnxConfig):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -768,21 +768,5 @@ ATOL_FOR_VALIDATION = 1e-4
         return 1e-4
 
 
-class MobileNetV2OnnxConfig(VisionOnnxConfig):
-    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
-    MIN_TORCH_VERSION = version.parse("1.11")
-
-    @property
-    def inputs(self) -> Mapping[str, Mapping[int, str]]:
-        return OrderedDict([("pixel_values", {0: "batch"})])
-
-    @property
-    def outputs(self) -> Mapping[str, Mapping[int, str]]:
-        if self.task == "image-classification":
-            return OrderedDict([("logits", {0: "batch"})])
-        else:
-            return OrderedDict([("last_hidden_state", {0: "batch"}), ("pooler_output", {0: "batch"})])
-
-    @property
-    def atol_for_validation(self) -> float:
-        return 1e-4
+class MobileNetV2OnnxConfig(MobileNetV1OnnxConfig):
+    pass

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -437,6 +437,16 @@ class TasksManager:
             "image-classification",
             onnx="MobileViTOnnxConfig",
         ),
+        "mobilenet-v1": supported_tasks_mapping(
+            "default",
+            "image-classification",
+            onnx="MobileNetV1OnnxConfig",
+        ),
+        "mobilenet-v2": supported_tasks_mapping(
+            "default",
+            "image-classification",
+            onnx="MobileNetV2OnnxConfig",
+        ),
         "mt5": supported_tasks_mapping(
             "default",
             "default-with-past",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -64,8 +64,8 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "marian": "sshleifer/tiny-marian-en-de",  # hf-internal-testing ones are broken
     "mbart": "hf-internal-testing/tiny-random-mbart",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
-    # "mobilenet_v1": "google/mobilenet_v1_0.75_192",
-    # "mobilenet_v2": "google/mobilenet_v2_0.35_96",
+    "mobilenet_v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
+    "mobilenet_v1": "google/mobilenet_v1_0.75_192",
     "mobilevit": "hf-internal-testing/tiny-random-mobilevit",
     "mt5": "lewtun/tiny-random-mt5",
     # "owlvit": "google/owlvit-base-patch32",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -64,8 +64,8 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "marian": "sshleifer/tiny-marian-en-de",  # hf-internal-testing ones are broken
     "mbart": "hf-internal-testing/tiny-random-mbart",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
-    "mobilenet_v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
-    "mobilenet_v1": "google/mobilenet_v1_0.75_192",
+    "mobilenet-v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
+    "mobilenet-v1": "google/mobilenet_v1_0.75_192",
     "mobilevit": "hf-internal-testing/tiny-random-mobilevit",
     "mt5": "lewtun/tiny-random-mt5",
     # "owlvit": "google/owlvit-base-patch32",

--- a/tests/exporters/test_onnx_export.py
+++ b/tests/exporters/test_onnx_export.py
@@ -139,6 +139,7 @@ def _get_models_to_test(export_models_dict: Dict):
     models_to_test = []
     if is_torch_available() or is_tf_available():
         for model_type, model_names_tasks in export_models_dict.items():
+            model_type = model_type.replace("_", "-")
             task_config_mapping = TasksManager.get_supported_tasks_for_model_type(model_type, "onnx")
 
             if isinstance(model_names_tasks, str):  # test export of all tasks on the same model


### PR DESCRIPTION
# What does this PR do?

This PR tries to add `mobilenet` models for ONNX support 

Partially fixes https://github.com/huggingface/transformers/issues/20856 
Related: https://github.com/huggingface/transformers/pull/20860 

Also it seems that `Mobilenet` used to be supported by `transformers`? At least when I run: 
```
from transformers import  AutoModelForImageClassification
from transformers.onnx import FeaturesManager

model = AutoModelForImageClassification.from_pretrained("google/mobilenet_v2_1.0_224")
model_kind, model_onnx_config = FeaturesManager.check_supported_model_or_raise(model)
```
Everything works fine, so maybe mobilenet has be forgotten by mistake?
cc @fxmarty @michaelbenayoun 