### PR TITLE
Add argument in the CLI to specify device to do the ONNX export on

### DIFF
--- a/.github/workflows/test_exporters.yml
+++ b/.github/workflows/test_exporters.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        pytest exporters -s --durations=0
+        pytest exporters  -k "test_exporters_cli_pytorch_203_levit_no_task" -s --durations=0

--- a/.github/workflows/test_exporters.yml
+++ b/.github/workflows/test_exporters.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Test with unittest
       working-directory: tests
       run: |
-        pytest exporters  -k "test_exporters_cli_pytorch_203_levit_no_task" -s --durations=0
+        pytest exporters -s --durations=0

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -46,6 +46,12 @@ def parse_args_onnx(parser):
         ),
     )
     optional_group.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help='The device to use to do the export. Defaults to "cpu".',
+    )
+    optional_group.add_argument(
         "--opset",
         type=int,
         default=None,

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -139,10 +139,16 @@ def main():
             output_dir=args.output.parent,
             output_names=output_names,
             input_shapes=input_shapes,
+            device=args.device,
         )
     else:
         onnx_inputs, onnx_outputs = export(
-            model=model, config=onnx_config, output=args.output, opset=args.opset, input_shapes=input_shapes
+            model=model,
+            config=onnx_config,
+            output=args.output,
+            opset=args.opset,
+            input_shapes=input_shapes,
+            device=args.device,
         )
 
     try:

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -161,6 +161,7 @@ def main():
                 atol=args.atol,
                 output_dir=args.output.parent,
                 output_names=output_names,
+                device=args.device,
             )
         else:
             validate_model_outputs(
@@ -169,6 +170,7 @@ def main():
                 onnx_model=args.output,
                 onnx_named_outputs=onnx_outputs,
                 atol=args.atol,
+                device=args.device,
             )
 
         logger.info(f"The ONNX export succeeded and the exported model was saved at: {args.output.parent.as_posix()}")
@@ -184,7 +186,7 @@ def main():
         )
     except Exception as e:
         logger.error(
-            f"An error occured with error {e}.\n The model was exported model was saved at: {args.output.parent.as_posix()}"
+            f"An error occured with the error message: {e}.\n The exported model was saved at: {args.output.parent.as_posix()}"
         )
 
 

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -152,7 +152,7 @@ def validate_model_outputs(
     onnx_named_outputs: List[str],
     atol: Optional[float] = None,
     input_shapes: Optional[Dict] = None,
-    device: Optional[str] = "cpu",
+    device: str = "cpu",
 ):
     """
     Validates the export by checking that the outputs from both the reference and the exported model match.

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -28,6 +28,7 @@ import onnx
 from ...onnx.utils import _get_onnx_external_data_tensors, check_model_uses_external_data
 from ...utils import TORCH_MINIMUM_VERSION, is_diffusers_available, is_torch_onnx_support_available, logging
 from .base import OnnxConfig
+from .utils import recursive_to_device
 
 
 if is_torch_available():
@@ -206,11 +207,7 @@ def validate_model_outputs(
         reference_model.to(device)
 
         for key, value in reference_model_inputs.items():
-            if isinstance(value, (list, tuple)):
-                for i, val in enumerate(value):
-                    reference_model_inputs[key][i] = val.to(device)
-            else:
-                reference_model_inputs[key] = value.to(device)
+            reference_model_inputs[key] = recursive_to_device(value=value, device=device)
 
     ref_outputs = reference_model(**reference_model_inputs)
     ref_outputs_dict = {}

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -91,7 +91,7 @@ def validate_models_outputs(
     atol: Optional[float] = None,
     output_names: Optional[List[str]] = None,
     input_shapes: Optional[Dict] = None,
-    device: Optional[str] = "cpu",
+    device: str = "cpu",
 ):
     """
     Validates the export of several models, by checking that the outputs from both the reference and the exported model match.

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -206,7 +206,11 @@ def validate_model_outputs(
         reference_model.to(device)
 
         for key, value in reference_model_inputs.items():
-            reference_model_inputs[key] = value.to(device)
+            if isinstance(value, (list, tuple)):
+                for i, val in enumerate(value):
+                    reference_model_inputs[key][i] = val.to(device)
+            else:
+                reference_model_inputs[key] = value.to(device)
 
     ref_outputs = reference_model(**reference_model_inputs)
     ref_outputs_dict = {}

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -15,7 +15,7 @@
 """Utility functions."""
 
 import copy
-from typing import TYPE_CHECKING, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 import packaging
 from transformers.utils import is_tf_available, is_torch_available
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from .base import OnnxConfig
 
     if is_torch_available():
+        import torch
         from transformers.modeling_utils import PreTrainedModel
 
     if is_tf_available():
@@ -174,3 +175,18 @@ def get_stable_diffusion_models_for_export(
     models_for_export["vae"] = (vae, vae_onnx_config)
 
     return models_for_export
+
+
+def recursive_to_device(value: Union[Tuple, List, "torch.Tensor"], device: str):
+    if isinstance(value, tuple):
+        value = list(value)
+        for i, val in enumerate(value):
+            value[i] = recursive_to_device(val, device)
+        value = tuple(value)
+    elif isinstance(value, list):
+        for i, val in enumerate(value):
+            value[i] = recursive_to_device(val, device)
+    else:
+        value = value.to(device)
+
+    return value

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -24,11 +24,13 @@ from ...utils import ORT_QUANTIZE_MINIMUM_VERSION, TORCH_MINIMUM_VERSION, is_dif
 from ..tasks import TasksManager
 
 
+if is_torch_available():
+    import torch
+
 if TYPE_CHECKING:
     from .base import OnnxConfig
 
     if is_torch_available():
-        import torch
         from transformers.modeling_utils import PreTrainedModel
 
     if is_tf_available():

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -186,7 +186,7 @@ def recursive_to_device(value: Union[Tuple, List, "torch.Tensor"], device: str):
     elif isinstance(value, list):
         for i, val in enumerate(value):
             value[i] = recursive_to_device(val, device)
-    else:
+    elif isinstance(value, torch.Tensor):
         value = value.to(device)
 
     return value

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -18,14 +18,12 @@ import copy
 from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 import packaging
+import torch
 from transformers.utils import is_tf_available, is_torch_available
 
 from ...utils import ORT_QUANTIZE_MINIMUM_VERSION, TORCH_MINIMUM_VERSION, is_diffusers_available
 from ..tasks import TasksManager
 
-
-if is_torch_available():
-    import torch
 
 if TYPE_CHECKING:
     from .base import OnnxConfig

--- a/tests/exporters/test_exporters_onnx_cli.py
+++ b/tests/exporters/test_exporters_onnx_cli.py
@@ -80,21 +80,18 @@ class OnnxExportTestCase(unittest.TestCase):
 
         with TemporaryDirectory() as tmpdir:
             for_ort = " --for-ort " if for_ort is True else " "
-            try:
-                if task is not None:
-                    subprocess.run(
-                        f"python3 -m optimum.exporters.onnx --model {model_name}{for_ort}--task {task} {tmpdir}",
-                        shell=True,
-                        check=True,
-                    )
-                else:
-                    subprocess.run(
-                        f"python3 -m optimum.exporters.onnx --model {model_name}{for_ort}{tmpdir}",
-                        shell=True,
-                        check=True,
-                    )
-            except Exception as e:
-                self.fail(f"{test_name} raised: {e}")
+            if task is not None:
+                subprocess.run(
+                    f"python3 -m optimum.exporters.onnx --model {model_name}{for_ort}--task {task} {tmpdir}",
+                    shell=True,
+                    check=True,
+                )
+            else:
+                subprocess.run(
+                    f"python3 -m optimum.exporters.onnx --model {model_name}{for_ort}{tmpdir}",
+                    shell=True,
+                    check=True,
+                )
 
     def test_all_models_tested(self):
         # make sure we test all models


### PR DESCRIPTION
As per title, can be useful for large models.

The validation should be done on the same device as well.

