### PR TITLE
Fix uninformative message when passing `use_cache=True` to ORTModel and no ONNX with cache is available

### DIFF
--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -533,15 +533,21 @@ class ORTModelDecoder(ORTModel):
         decoder_with_past_path = None
         if use_cache is True:
             if not validate_file_exists(model_id, decoder_with_past_file_name, subfolder=subfolder, revision=revision):
-                decoder_with_past_path = ORTModelDecoder.infer_onnx_filename(
-                    model_id,
-                    DECODER_WITH_PAST_ONNX_FILE_PATTERN,
-                    "decoder_with_past_file_name",
-                    subfolder=subfolder,
-                    use_auth_token=use_auth_token,
-                    revision=revision,
-                    fail_if_not_found=use_cache,
-                )
+                try:
+                    decoder_with_past_path = ORTModelDecoder.infer_onnx_filename(
+                        model_id,
+                        DECODER_WITH_PAST_ONNX_FILE_PATTERN,
+                        "decoder_with_past_file_name",
+                        subfolder=subfolder,
+                        use_auth_token=use_auth_token,
+                        revision=revision,
+                    )
+                except FileNotFoundError as e:
+                    raise FileNotFoundError(
+                        "The parameter `use_cache=True` was passed to ORTModelDecoder.from_pretrained()"
+                        " but no ONNX file using past key values could be found in"
+                        f" {str(Path(model_id, subfolder))}, with the error:\n    {e}"
+                    )
             else:
                 decoder_with_past_path = model_path / subfolder / decoder_with_past_file_name
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -348,7 +348,7 @@ class ORTModel(OptimizedModel):
 
         if len(onnx_files) == 0:
             if fail_if_not_found:
-                raise FileNotFoundError(f"Could not find any ONNX model file in {path}")
+                raise FileNotFoundError(f"Could not find any ONNX model file for the regex {pattern} in {path}.")
             return None
         elif len(onnx_files) > 1:
             if argument_name is not None:

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -963,18 +963,26 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             )
         else:
             decoder_path = model_path / subfolder / decoder_file_name
-        if not validate_file_exists(model_id, decoder_with_past_file_name, subfolder=subfolder, revision=revision):
-            decoder_with_past_path = ORTModelForConditionalGeneration.infer_onnx_filename(
-                model_id,
-                DECODER_WITH_PAST_ONNX_FILE_PATTERN,
-                "decoder_with_past_file_name",
-                subfolder=subfolder,
-                use_auth_token=use_auth_token,
-                revision=revision,
-                fail_if_not_found=use_cache,
-            )
-        else:
-            decoder_with_past_path = model_path / subfolder / decoder_with_past_file_name
+
+        if use_cache is True:
+            if not validate_file_exists(model_id, decoder_with_past_file_name, subfolder=subfolder, revision=revision):
+                try:
+                    decoder_with_past_path = ORTModelForConditionalGeneration.infer_onnx_filename(
+                        model_id,
+                        DECODER_WITH_PAST_ONNX_FILE_PATTERN,
+                        "decoder_with_past_file_name",
+                        subfolder=subfolder,
+                        use_auth_token=use_auth_token,
+                        revision=revision,
+                    )
+                except FileNotFoundError as e:
+                    raise FileNotFoundError(
+                        "The parameter `use_cache=True` was passed to ORTModelForConditionalGeneration.from_pretrained()"
+                        " but no ONNX file using past key values could be found in"
+                        f" {str(Path(model_id, subfolder))}, with the error:\n    {e}"
+                    )
+            else:
+                decoder_with_past_path = model_path / subfolder / decoder_with_past_file_name
 
         encoder_regular_onnx_filenames = ORTModelForConditionalGeneration._generate_regular_names_for_filename(
             ONNX_ENCODER_NAME
@@ -998,7 +1006,8 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
                 "ORTModelForConditionalGeneration might not behave as expected."
             )
         if (
-            decoder_with_past_path is not None
+            use_cache is True
+            and decoder_with_past_path is not None
             and decoder_with_past_path.name not in decoder_with_past_regular_onnx_filenames
         ):
             logger.warning(

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -977,7 +977,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
                     )
                 except FileNotFoundError as e:
                     raise FileNotFoundError(
-                        "The parameter `use_cache=True` was passed to ORTModelForConditionalGeneration.from_pretrained()"
+                        "The parameter `use_cache=True` was passed to `ORTModelForConditionalGeneration.from_pretrained()`"
                         " but no ONNX file using past key values could be found in"
                         f" {str(Path(model_id, subfolder))}, with the error:\n    {e}"
                     )


### PR DESCRIPTION
As per title,

```
from optimum.onnxruntime import ORTModelForCausalLM

ort_model = ORTModelForCausalLM.from_pretrained("/path/to/gpt2_onnx", use_cache=True)
```

raises 

```
  File "/home/fxmarty/hf_internship/optimum/optimum/onnxruntime/modeling_decoder.py", line 536, in _from_pretrained
    decoder_with_past_path = ORTModelDecoder.infer_onnx_filename(
  File "/home/fxmarty/hf_internship/optimum/optimum/onnxruntime/modeling_ort.py", line 351, in infer_onnx_filename
    raise FileNotFoundError(f"Could not find any ONNX model file in {path}")
FileNotFoundError: Could not find any ONNX model file in /home/fxmarty/hf_internship/optimum/gpt2_onnx
```

which is not informative. With this PR, we get:

```
FileNotFoundError: The parameter `use_cache=True` was passed to ORTModelDecoder.from_pretrained() but no ONNX file using past key values could be found in /home/fxmarty/hf_internship/optimum/gpt2_onnx, with the error:
    Could not find any ONNX model file for the regex (.*)?decoder(.*)?with_past(.*)?\.onnx in /home/fxmarty/hf_internship/optimum/gpt2_onnx.
```