### PR TITLE
Fix provider options when several providers are passed

### DIFF
--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -436,11 +436,17 @@ class ORTModelDecoder(ORTModel):
             # follow advice in https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#python
             providers.append("CUDAExecutionProvider")
 
+        # `providers` and `provider_options` need to be of the same length
+        if provider_options is not None:
+            providers_options = [provider_options] + [{} for _ in range(len(providers) - 1)]
+        else:
+            providers_options = None
+
         decoder_session = onnxruntime.InferenceSession(
             str(decoder_path),
             providers=providers,
             sess_options=session_options,
-            provider_options=None if provider_options is None else [provider_options],
+            provider_options=providers_options,
         )
         decoder_with_past_session = None
         # If a decoder_with_past_path is provided, an inference session for the decoder with past key/values as inputs
@@ -450,7 +456,7 @@ class ORTModelDecoder(ORTModel):
                 str(decoder_with_past_path),
                 providers=providers,
                 sess_options=session_options,
-                provider_options=None if provider_options is None else [provider_options],
+                provider_options=None if provider_options is None else providers_options,
             )
         return decoder_session, decoder_with_past_session
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -288,12 +288,17 @@ class ORTModel(OptimizedModel):
         if not isinstance(path, str):
             path = str(path)
 
-        # `providers` list must of be of the same length as `provider_options` list
+        # `providers` and `provider_options` need to be of the same length
+        if provider_options is not None:
+            providers_options = [provider_options] + [{} for _ in range(len(providers) - 1)]
+        else:
+            providers_options = None
+
         return ort.InferenceSession(
             path,
             providers=providers,
             sess_options=session_options,
-            provider_options=None if provider_options is None else [provider_options],
+            provider_options=providers_options,
         )
 
     def _save_pretrained(self, save_directory: Union[str, Path], file_name: str = ONNX_WEIGHTS_NAME, **kwargs):

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -851,17 +851,23 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             # follow advice in https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#python
             providers.append("CUDAExecutionProvider")
 
+        # `providers` and `provider_options` need to be of the same length
+        if provider_options is not None:
+            providers_options = [provider_options] + [{} for _ in range(len(providers) - 1)]
+        else:
+            providers_options = None
+
         encoder_session = ort.InferenceSession(
             str(encoder_path),
             providers=providers,
             sess_options=session_options,
-            provider_options=None if provider_options is None else [provider_options],
+            provider_options=providers_options,
         )
         decoder_session = ort.InferenceSession(
             str(decoder_path),
             providers=providers,
             sess_options=session_options,
-            provider_options=None if provider_options is None else [provider_options],
+            provider_options=providers_options,
         )
 
         decoder_with_past_session = None
@@ -872,7 +878,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
                 str(decoder_with_past_path),
                 providers=providers,
                 sess_options=session_options,
-                provider_options=None if provider_options is None else [provider_options],
+                provider_options=providers_options,
             )
 
         return encoder_session, decoder_session, decoder_with_past_session


### PR DESCRIPTION
When several providers are passed to the `InferenceSession`, which is the case when `TensorrtExecutionProvider` is chosen, the `provider_options` argument needs to be of the same length than `providers`, otherwise raising:

```
EP Error using ['TensorrtExecutionProvider', 'CUDAExecutionProvider']
Falling back to ['CUDAExecutionProvider', 'CPUExecutionProvider'] and retrying.
```

Reference: https://onnxruntime.ai/docs/api/python/api_summary.html#inferencesession

This was untested up to now. Still need to add a test for this PR.

In a next PR: remove all the code duplication for `load_model()` in `modeling_ort.py`, `modeling_decoder.py`, `modeling_seq2seq.py`. But I won't do it in this PR.

This should fix https://github.com/huggingface/optimum/issues/606

