### PR TITLE
Add TensorRT engine to ONNX Runtime GPU documentation

### DIFF
--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -294,9 +294,9 @@ ort_model = ORTModelForCausalLM.from_pretrained(
 TensorRT builds its engine depending on specified input shapes. Unfortunately, in the [current ONNX Runtime implementation](https://github.com/microsoft/onnxruntime/blob/613920d6c5f53a8e5e647c5f1dcdecb0a8beef31/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc#L1677-L1688) (references: [1](https://github.com/microsoft/onnxruntime/issues/13559), [2](https://github.com/microsoft/onnxruntime/issues/13851)), the engine is rebuilt every time an input has a shape smaller than the previously smallest encountered shape, and conversely if the input has a shape larger than the previously largest encountered shape. For example, if a model takes `(batch_size, input_ids)` as inputs, and the model takes successively the inputs:
 
 1. `input.shape: (4, 5)  --> the engine is built (first input)`
-2. `input.shape: (4, 10) --> engine rebuilt (8 larger than 3)`
-3. `input.shape: (4, 7)  --> no rebuild (3 <= 5 <= 8)`
-4. `input.shape: (4, 12) --> engine rebuilt (9 <= 10)`
+2. `input.shape: (4, 10) --> engine rebuilt (10 larger than 5)`
+3. `input.shape: (4, 7)  --> no rebuild (5 <= 7 <= 10)`
+4. `input.shape: (4, 12) --> engine rebuilt (10 <= 12)`
 5. `input.shape: (4, 3)  --> engine rebuilt (3 <= 5)`
 
 One big issue is that engine building can be time consuming, especially for large models. Therefore, as a workaround, one recommendation is to **first build the TensorRT engine with an input of small shape, and an input of large shape to have an engine valid for all shapes inbetween**. This allows to avoid rebuilding the engine for new small and large shapes, which is unwanted once the model is deployed for inference.

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -270,7 +270,7 @@ something is wrong with the TensorRT or ONNX Runtime installation.
 
 ### TensorRT engine build and warmup
 
-TensorRT requires to build its [inference engine](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#build-phase) ahead of inference, which takes some time due to the model optimization, nodes fusion. To avoid rebuiling the engine every time the model is loaded, ONNX Runtime provides a pair of options to allow to save the engine: `trt_engine_cache_enable` and `trt_engine_cache_path`.
+TensorRT requires to build its [inference engine](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#build-phase) ahead of inference, which takes some time due to the model optimization and nodes fusion. To avoid rebuilding the engine every time the model is loaded, ONNX Runtime provides a pair of options to save the engine: `trt_engine_cache_enable` and `trt_engine_cache_path`.
 
 We recommend to set these two provier options when using TensorRT execution provider. The usage is as follow, where here [`optimum/gpt2`](https://huggingface.co/optimum/gpt2) is an ONNX model converted from PyTorch using [Optimum ONNX export](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model):
 

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -217,6 +217,8 @@ Note that previous experiments are run with __vanilla ONNX__ models exported dir
 
 ## TensorrtExecutionProvider
 
+TensorRT uses its own set of optimizations, and **generally does not support the optimizations from [`~onnxruntime.ORTOptimizer`]**. We therefore recommend to use the original ONNX models when using TensorrtExecutionProvider ([reference](https://github.com/microsoft/onnxruntime/issues/10905#issuecomment-1072649358)).
+
 ### TensorRT installation
 
 The easiest way to use TensorRT as the execution provider for models optimized through 🤗 Optimum is with the available ONNX Runtime `TensorrtExecutionProvider`.

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -15,7 +15,7 @@ Due to a limitation of ONNX Runtime, it is not possible to run quantized models 
 
 ## CUDAExecutionProvider
 
-### Installation
+### CUDA installation
 
 Provided the CUDA and cuDNN [requirements](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements) are satisfied, install the additional dependencies by running
 
@@ -25,7 +25,7 @@ pip install optimum[onnxruntime-gpu]
 
 To avoid conflicts between `onnxruntime` and `onnxruntime-gpu`, make sure the package `onnxruntime` is not installed by running `pip uninstall onnxruntime` prior to installing Optimum.
 
-### Checking the installation is successful
+### Checking the CUDA installation is successful
 
 Before going further, run the following sample code to check whether the install was successful:
 
@@ -217,7 +217,7 @@ Note that previous experiments are run with __vanilla ONNX__ models exported dir
 
 ## TensorrtExecutionProvider
 
-### Installation
+### TensorRT installation
 
 The easiest way to use TensorRT as the execution provider for models optimized through 🤗 Optimum is with the available ONNX Runtime `TensorrtExecutionProvider`.
 
@@ -235,7 +235,7 @@ export CUDA_PATH=/usr/local/cuda
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-x.x/lib64:/path/to/TensorRT-8.x.x/lib
 ```
 
-### Checking the installation is successful
+### Checking the TensorRT installation is successful
 
 Before going further, run the following sample code to check whether the install was successful:
 
@@ -265,6 +265,102 @@ Failed to create TensorrtExecutionProvider. Please reference https://onnxruntime
 ```
 
 something is wrong with the TensorRT or ONNX Runtime installation.
+
+### TensorRT engine build and warmup
+
+TensorRT requires to build its [inference engine](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#build-phase) ahead of inference, which takes some time due to the model optimization, nodes fusion. To avoid rebuiling the engine every time the model is loaded, ONNX Runtime provides a pair of options to allow to save the engine: `trt_engine_cache_enable` and `trt_engine_cache_path`.
+
+We recommend to set these two provier options when using TensorRT execution provider. The usage is as follow, where here [`optimum/gpt2`](https://huggingface.co/optimum/gpt2) is an ONNX model converted from PyTorch using [Optimum ONNX export](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model):
+
+```python
+from optimum.onnxruntime import ORTModelForCausalLM
+
+provider_options = {
+    "trt_engine_cache_enable": True,
+    "trt_engine_cache_path": "/path/to/trt_cache_gpt2_example"
+}
+
+# the TensorRT engine is not built here, it will be when doing inference
+ort_model = ORTModelForCausalLM.from_pretrained(
+    "optimum/gpt2",
+    use_cache=False,
+    provider="TensorrtExecutionProvider",
+    provider_options=provider_options
+)
+```
+
+TensorRT builds its engine depending on specified input shapes. Unfortunately, in [current ONNX Runtime implementation](https://github.com/microsoft/onnxruntime/blob/613920d6c5f53a8e5e647c5f1dcdecb0a8beef31/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc#L1677-L1688) (references: [1](https://github.com/microsoft/onnxruntime/issues/13559), [2](https://github.com/microsoft/onnxruntime/issues/13851)), the engine is rebuilt every time an input has a shape smaller than the previously smallest encountered shape, and conversely if the input has a shape larger than the previously largest encountered shape. For example, if a model takes `(batch_size, input_ids)` as inputs, and the model takes successively the inputs:
+
+1. `input.shape: (4, 5)  --> the engine is built (first input)`
+2. `input.shape: (4, 10) --> engine rebuilt (8 larger than 3)`
+3. `input.shape: (4, 7)  --> no rebuild (3 <= 5 <= 8)`
+4. `input.shape: (4, 12) --> engine rebuilt (9 <= 10)`
+5. `input.shape: (4, 3)  --> engine rebuilt (3 <= 5)`
+
+One big issue is that engine building can be time consuming, especially for large models. Therefore, as a workaround, one recommendation is to **first build the TensorRT engine with an input of small shape, and an input of large shape to have an engine valid for all shapes inbetween**. This allows to avoid rebuilding the engine for new small and large shapes, which is unwanted once the model is deployed for inference.
+
+Passing the engine cache path in the provider options, the engine can therefore be built once for all and used fully for inference thereafter.
+
+For example, for text generation, the engine building can be done with:
+
+```python
+from transformers import AutoTokenizer
+from optimum.onnxruntime import ORTModelForCausalLM
+
+provider_options = {
+    "trt_engine_cache_enable": True,
+    "trt_engine_cache_path": "/path/to/trt_cache_gpt2_example"
+}
+
+ort_model = ORTModelForCausalLM.from_pretrained(
+    "optimum/gpt2",
+    use_cache=False,
+    provider="TensorrtExecutionProvider",
+    provider_options=provider_options,
+)
+tokenizer = AutoTokenizer.from_pretrained("optimum/gpt2")
+
+# build engine for a short sequence
+text = ["short"]
+encoded_input = tokenizer(text, return_tensors="pt").to("cuda")
+output = ort_model(**encoded_input)
+
+# build engine for a long sequence
+text = [" a very long input just for demo purpose, this is very long" * 10]
+encoded_input = tokenizer(text, return_tensors="pt").to("cuda")
+output = ort_model(**encoded_input)
+```
+
+Once the engine is built, generation is fast and does not need engine rebuild:
+
+```python
+from transformers import AutoTokenizer
+from optimum.onnxruntime import ORTModelForCausalLM
+
+provider_options = {
+    "trt_engine_cache_enable": True,
+    "trt_engine_cache_path": "/path/to/trt_cache_gpt2_example"
+}
+
+ort_model = ORTModelForCausalLM.from_pretrained(
+    "optimum/gpt2",
+    use_cache=False,
+    provider="TensorrtExecutionProvider",
+    provider_options=provider_options,
+)
+tokenizer = AutoTokenizer.from_pretrained("optimum/gpt2")
+
+text = ["Replace me by any text you'd like."]
+encoded_input = tokenizer(text, return_tensors="pt").to("cuda")
+
+for i in range(3):
+    output = ort_model.generate(**encoded_input)
+    print(tokenizer.decode(output[0]))
+```
+
+#### Warmup
+
+Once the engine is built, it is recommended to do before inference **one or a few warmup steps**, as the first inference runs have [some overhead](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#trtexec-flags).
 
 ### Use TensorRT execution provider with floating-point models
 

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -291,7 +291,7 @@ ort_model = ORTModelForCausalLM.from_pretrained(
 )
 ```
 
-TensorRT builds its engine depending on specified input shapes. Unfortunately, in [current ONNX Runtime implementation](https://github.com/microsoft/onnxruntime/blob/613920d6c5f53a8e5e647c5f1dcdecb0a8beef31/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc#L1677-L1688) (references: [1](https://github.com/microsoft/onnxruntime/issues/13559), [2](https://github.com/microsoft/onnxruntime/issues/13851)), the engine is rebuilt every time an input has a shape smaller than the previously smallest encountered shape, and conversely if the input has a shape larger than the previously largest encountered shape. For example, if a model takes `(batch_size, input_ids)` as inputs, and the model takes successively the inputs:
+TensorRT builds its engine depending on specified input shapes. Unfortunately, in the [current ONNX Runtime implementation](https://github.com/microsoft/onnxruntime/blob/613920d6c5f53a8e5e647c5f1dcdecb0a8beef31/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc#L1677-L1688) (references: [1](https://github.com/microsoft/onnxruntime/issues/13559), [2](https://github.com/microsoft/onnxruntime/issues/13851)), the engine is rebuilt every time an input has a shape smaller than the previously smallest encountered shape, and conversely if the input has a shape larger than the previously largest encountered shape. For example, if a model takes `(batch_size, input_ids)` as inputs, and the model takes successively the inputs:
 
 1. `input.shape: (4, 5)  --> the engine is built (first input)`
 2. `input.shape: (4, 10) --> engine rebuilt (8 larger than 3)`

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -331,6 +331,10 @@ encoded_input = tokenizer(text, return_tensors="pt").to("cuda")
 output = ort_model(**encoded_input)
 ```
 
+The engine is stored as:
+
+![TensorRT engine cache folder](https://huggingface.co/datasets/optimum/documentation-images/resolve/main/onnxruntime/tensorrt_cache.png)
+
 Once the engine is built, generation is fast and does not need engine rebuild:
 
 ```python

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -337,7 +337,7 @@ The engine is stored as:
 
 ![TensorRT engine cache folder](https://huggingface.co/datasets/optimum/documentation-images/resolve/main/onnxruntime/tensorrt_cache.png)
 
-Once the engine is built, generation is fast and does not need engine rebuild:
+Once the engine is built, generation is fast and does not need to rebuild the engine:
 
 ```python
 from transformers import AutoTokenizer

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -299,7 +299,7 @@ TensorRT builds its engine depending on specified input shapes. Unfortunately, i
 4. `input.shape: (4, 12) --> engine rebuilt (10 <= 12)`
 5. `input.shape: (4, 3)  --> engine rebuilt (3 <= 5)`
 
-One big issue is that engine building can be time consuming, especially for large models. Therefore, as a workaround, one recommendation is to **first build the TensorRT engine with an input of small shape, and an input of large shape to have an engine valid for all shapes inbetween**. This allows to avoid rebuilding the engine for new small and large shapes, which is unwanted once the model is deployed for inference.
+One big issue is that building the engine can be time consuming, especially for large models. Therefore, as a workaround, one recommendation is to **first build the TensorRT engine with an input of small shape, and then with an input of large shape to have an engine valid for all shapes inbetween**. This allows to avoid rebuilding the engine for new small and large shapes, which is unwanted once the model is deployed for inference.
 
 Passing the engine cache path in the provider options, the engine can therefore be built once for all and used fully for inference thereafter.
 

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -272,7 +272,7 @@ something is wrong with the TensorRT or ONNX Runtime installation.
 
 TensorRT requires to build its [inference engine](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#build-phase) ahead of inference, which takes some time due to the model optimization and nodes fusion. To avoid rebuilding the engine every time the model is loaded, ONNX Runtime provides a pair of options to save the engine: `trt_engine_cache_enable` and `trt_engine_cache_path`.
 
-We recommend to set these two provier options when using TensorRT execution provider. The usage is as follow, where here [`optimum/gpt2`](https://huggingface.co/optimum/gpt2) is an ONNX model converted from PyTorch using [Optimum ONNX export](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model):
+We recommend setting these two provider options when using the TensorRT execution provider. The usage is as follows, where [`optimum/gpt2`](https://huggingface.co/optimum/gpt2) is an ONNX model converted from PyTorch using the [Optimum ONNX exporter](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model):
 
 ```python
 from optimum.onnxruntime import ORTModelForCausalLM

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -303,7 +303,7 @@ One big issue is that building the engine can be time consuming, especially for 
 
 Passing the engine cache path in the provider options, the engine can therefore be built once for all and used fully for inference thereafter.
 
-For example, for text generation, the engine building can be done with:
+For example, for text generation, the engine can be built with:
 
 ```python
 from transformers import AutoTokenizer


### PR DESCRIPTION
# What does this PR do?

This documentation addition clarifies the usage of the TensorRT engine. Note: https://github.com/huggingface/optimum/pull/653 is needed for the code samples to work.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
