### PR TITLE
Use nvcr.io/nvidia/tensorrt image for GPU tests

### DIFF
--- a/.github/workflows/test_onnxruntime_gpu.yml
+++ b/.github/workflows/test_onnxruntime_gpu.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 7 * * * # every day at 7am
+  pull_request:
+    types: [labeled]
   # uncomment to enable on PR merge on main branch:
   #push:
   #  branches:
@@ -60,7 +62,7 @@ jobs:
           docker build -f tests/onnxruntime/Dockerfile_onnxruntime_gpu -t onnxruntime-gpu .
       - name: Test with unittest within docker container
         run: |
-          docker run --gpus all --workdir=/workspace/optimum/tests onnxruntime-gpu:latest
+          docker run --rm --gpus all --workdir=/workspace/optimum/tests onnxruntime-gpu:latest
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/test_onnxruntime_gpu.yml
+++ b/.github/workflows/test_onnxruntime_gpu.yml
@@ -2,11 +2,12 @@ name: ONNX Runtime / Test GPU
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   schedule:
     - cron: 0 7 * * * # every day at 7am
+  # uncomment to enable on PR merge on main branch:
+  #push:
+  #  branches:
+  #    - main
 
 jobs:
   start-runner:

--- a/tests/onnxruntime/Dockerfile_onnxruntime_gpu
+++ b/tests/onnxruntime/Dockerfile_onnxruntime_gpu
@@ -1,17 +1,10 @@
-# Use nvidia/cuda image
-FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
+# use version with cudnn 8.5 to match torch==1.13.1 that uses 8.5.0.96
+# has Python 3.8.10
+FROM nvcr.io/nvidia/tensorrt:22.08-py3
 CMD nvidia-smi
 
 # Ignore interactive questions during `docker build`
 ENV DEBIAN_FRONTEND noninteractive
-
-# Bash shell
-RUN chsh -s /bin/bash
-SHELL ["/bin/bash", "-c"]
-
-# Temporary fix until NVDIA finish the update of its docker images
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 
 # Install and update tools to minimize security vulnerabilities
 RUN apt-get update
@@ -20,14 +13,6 @@ RUN apt-get install -y software-properties-common wget apt-utils patchelf git li
     apt-get clean
 RUN unattended-upgrade
 RUN apt-get autoremove -y
-
-# Install Pythyon (3.8 as default)
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN apt-get install -y python3-pip
-RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-RUN pip install -U pip
-RUN pip install pygit2 pgzip
-RUN pip3 install --upgrade requests
 
 # Install Optimum
 COPY . /workspace/optimum

--- a/tests/onnxruntime/Dockerfile_onnxruntime_gpu
+++ b/tests/onnxruntime/Dockerfile_onnxruntime_gpu
@@ -14,6 +14,8 @@ RUN apt-get install -y software-properties-common wget apt-utils patchelf git li
 RUN unattended-upgrade
 RUN apt-get autoremove -y
 
+RUN python -m pip install -U pip
+
 # Install Optimum
 COPY . /workspace/optimum
 RUN pip install /workspace/optimum[onnxruntime-gpu,tests]


### PR DESCRIPTION
GPU test may need TensorRT, so let's use an image that has TensorRT pre-installed.

Still need to test that everything runs fine before merging.