### PR TITLE
minor updates on ONNX config guide

### DIFF
--- a/docs/source/exporters/onnx/usage_guides/contribute.mdx
+++ b/docs/source/exporters/onnx/usage_guides/contribute.mdx
@@ -185,7 +185,7 @@ This function expects the ONNX configuration, along with the base model, and the
 >>> onnx_config_constructor = TasksManager.get_exporter_config_constructor("onnx", base_model)
 >>> onnx_config = onnx_config_constructor(base_model.config)
 
->>> onnx_inputs, onnx_outputs = export(base_model, onnx_config, onnx_path ,onnx_config.DEFAULT_ONNX_OPSET)
+>>> onnx_inputs, onnx_outputs = export(base_model, onnx_config, onnx_path, onnx_config.DEFAULT_ONNX_OPSET)
 ```
 
 The `onnx_inputs` and `onnx_outputs` returned by the `export()` function are lists of the keys defined in the [`~optimum.exporters.onnx.OnnxConfig.inputs`]

--- a/docs/source/exporters/onnx/usage_guides/contribute.mdx
+++ b/docs/source/exporters/onnx/usage_guides/contribute.mdx
@@ -96,7 +96,7 @@ Once you have implemented an ONNX configuration, you can instantiate it by provi
 
 ```python
 >>> from transformers import AutoConfig
-
+>>> from optimum.exporters.onnx.model_configs import BertOnnxConfig
 >>> config = AutoConfig.from_pretrained("bert-base-uncased")
 >>> onnx_config = BertOnnxConfig(config)
 ```
@@ -182,10 +182,10 @@ This function expects the ONNX configuration, along with the base model, and the
 >>> base_model = AutoModel.from_pretrained("bert-base-uncased")
 
 >>> onnx_path = Path("model.onnx")
->>> onnx_config_constructor = TasksManager.get_exporter_config_constructor(base_model, "onnx")
+>>> onnx_config_constructor = TasksManager.get_exporter_config_constructor("onnx", base_model)
 >>> onnx_config = onnx_config_constructor(base_model.config)
 
->>> onnx_inputs, onnx_outputs = export(base_model, onnx_config, onnx_config.DEFAULT_ONNX_OPSET, onnx_path)
+>>> onnx_inputs, onnx_outputs = export(base_model, onnx_config, onnx_path ,onnx_config.DEFAULT_ONNX_OPSET)
 ```
 
 The `onnx_inputs` and `onnx_outputs` returned by the `export()` function are lists of the keys defined in the [`~optimum.exporters.onnx.OnnxConfig.inputs`]


### PR DESCRIPTION
# What does this PR do?
Adds a missing import for BertOnnxConfig
Updates the parameter order of get_exporter_config_constructor and export functions, which were inverted recently.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?


