### PR TITLE
Fix FlaubertOnnxConfig

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -119,7 +119,7 @@ class CamembertOnnxConfig(DistilBertOnnxConfig):
     pass
 
 
-class FlaubertOnnxConfig(DistilBertOnnxConfig):
+class FlaubertOnnxConfig(BertOnnxConfig):
     pass
 
 


### PR DESCRIPTION
# What does this PR do?

Flaubert requires `token_type_ids` just like BERT, so `FlaubertOnnxConfig` inherints from `BertOnnxConfig` instead of `DistilBertOnnxConfig` to fix that.


Fixes #667 


