### PR TITLE
Better Transformer doc fix

### DIFF
--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -12,11 +12,12 @@ specific language governing permissions and limitations under the License.
 
 # Overview
 
-🤗 Optimum provides an integration with `BetterTransformer`, a stable API from PyTorch to benefit from interesting speedups on CPU & GPU through sparsity and fused kernels.
+🤗 Optimum provides an integration with `BetterTransformer`, a fast path of standard PyTorch Transformer APIs to benefit from interesting speedups on CPU & GPU through sparsity and fused kernels. For now, it supports Transformer encoders, basically fast path of [`nn.TransformerEncoderLayer'](https://pytorch.org/blog/a-better-transformer-for-fast-transformer-encoder-inference/),
+support for decoders and training path is coming soon.
 
 ## Quickstart
 
-Since its 1.13 version, PyTorch released the stable version of `BetterTransformer` in its library. You can benefit from interesting speedup on most consumer-type devices, including CPUs, older and newer versions of NIVIDIA GPUs.
+Since its 1.13 version, PyTorch released the stable version of fast path for its standard Transformer APIs that provides out of the box perfromance for the Pytorch Transformers. You can benefit from interesting speedup on most consumer-type devices, including CPUs, older and newer versions of NIVIDIA GPUs.
 You can now use this feature in 🤗 Optimum together with Transformers and use it for major models in the Hugging Face ecosystem.
 
 ### Supported models

--- a/docs/source/bettertransformer/tutorials/contribute.mdx
+++ b/docs/source/bettertransformer/tutorials/contribute.mdx
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 -->
 # Adding BetterTransformer support for new architectures
 
-You want to add a new model for `BetterTransformer` API? Check this guideline!
+You want to add a new model for `BetterTransformer`, the fast path of PyTorch Transformer API? Check this guideline!
 
 ## Models that should be supported
 


### PR DESCRIPTION
# What does this PR do?

Fixing the message on Better Transformer to clarify its the PyTorch standard Transformer API and not a new/separate API.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

