### PR TITLE
[`BetterTransformer`] Let's make the transformation invertible

### DIFF
--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from copy import deepcopy
+
 import torch
 import torch.nn as nn
-
-from copy import deepcopy
 
 from ...utils import logging
 
@@ -62,7 +62,7 @@ class BetterTransformerBaseLayer(nn.Module):
             if hasattr(config, attr):
                 self.num_layers = getattr(config, attr)
                 break
-        
+
         if old_layer is not None:
             # Last step, store the old module skeleton by copying the old module and putting
             # it on the `meta` device.
@@ -124,10 +124,12 @@ class BetterTransformerBaseLayer(nn.Module):
                 "Training is not supported for `BetterTransformer` integration.",
                 " Please use `model.eval()` before running the model.",
             )
-    
+
     def _replace_to_original_module(self):
         r"""
         A wrapper function to replace the current layer with the previous non-BetterTransformer
         layer.
         """
-        raise NotImplementedError("Please implement this method in the `BetterTransformerLayer` class to benefit from the `BetterTransformer` inverse transformation.")
+        raise NotImplementedError(
+            "Please implement this method in the `BetterTransformerLayer` class to benefit from the `BetterTransformer` inverse transformation."
+        )

--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -48,7 +48,7 @@ class BetterTransformerBaseLayer(nn.Module):
         Args:
             config (`transformers.PretrainedConfig`):
                 The config of the model.
-            orig_layer (`torch.nn.Module`, `optional`):
+            orig_layer (`Optional[torch.nn.Module]`, defaults to `None`):
                 The original layer that needs to be modified. Defaults to `None`.
         """
         super().__init__()
@@ -60,7 +60,7 @@ class BetterTransformerBaseLayer(nn.Module):
         self.embed_dim = None
         self.num_layers = None
         self.original_layers_mapping = {}
-        # some models does not have some attributes thus needs to be ignored
+        # Some models does not have some attributes thus needs to be ignored
         # e.g. whisper does not have self_attn.k_proj.bias but has self_attn.v_proj.bias & self_attn.q_proj.bias
         self.keys_to_ignore = []
 
@@ -154,12 +154,10 @@ class BetterTransformerBaseLayer(nn.Module):
         layer.
         """
         for modified_layer_key_names, original_layer_key_names in self.original_layers_mapping.items():
-            # to deal with qkv layers for example
             if isinstance(original_layer_key_names, list):
-                # retrieve the current weight
                 current_weight = getattr(self, modified_layer_key_names)
 
-                # split the current weight n chunks - this is useful to split
+                # Split the current weight n chunks - this is useful to split
                 # the qkv layers into q, k, v layers for example.
                 split_index = current_weight.shape[0] // len(original_layer_key_names)
                 for i, module in enumerate(original_layer_key_names):

--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
+from typing import List, Optional
 
 import torch
 import torch.nn as nn
@@ -31,7 +32,21 @@ logger = logging.get_logger(__name__)
 
 
 class BetterTransformerBaseLayer(nn.Module):
-    def __init__(self, config, old_layer=None):
+    def __init__(
+        self,
+        config: "transformers.PretrainedConfig",
+        orig_layer: Optional[nn.Module] = None,
+    ):
+        r"""
+        Base layer for `BetterTransformer` integration. This class is used to wrap all the necessary
+        components for the `BetterTransformer` integration.
+
+        Args:
+            config (`transformers.PretrainedConfig`):
+                The config of the model.
+            orig_layer (`torch.nn.Module`, `optional`):
+                The original layer that needs to be modified. Defaults to `None`.
+        """
         super().__init__()
         self.norm_first = False
         self.use_gelu = False
@@ -63,12 +78,12 @@ class BetterTransformerBaseLayer(nn.Module):
                 self.num_layers = getattr(config, attr)
                 break
 
-        if old_layer is not None:
+        if orig_layer is not None:
             # Last step, store the old module skeleton by copying the old module and putting
             # it on the `meta` device.
-            self.old_layer = deepcopy(old_layer).to("meta")
+            self.orig_layer = deepcopy(orig_layer).to("meta")
         else:
-            self.old_layer = old_layer
+            self.orig_layer = orig_layer
 
     def validate_bettertransformer(self):
         r"""

--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
 
 import torch
 import torch.nn as nn
@@ -34,7 +38,7 @@ logger = logging.get_logger(__name__)
 class BetterTransformerBaseLayer(nn.Module):
     def __init__(
         self,
-        config: "transformers.PretrainedConfig",
+        config: "PretrainedConfig",
         orig_layer: Optional[nn.Module] = None,
     ):
         r"""

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -231,7 +231,7 @@ class BertLayerBetterTransformer(BetterTransformerBaseLayer):
         if hidden_states.is_nested and self.is_last_layer:
             hidden_states = hidden_states.to_padded_tensor(0.0)
         return (hidden_states,)
-    
+
     def _replace_to_original_module(self):
         if self.old_layer is None:
             raise ValueError("You should add the attribute `old_layer` when initializing a `BetterTransformer` layer.")
@@ -240,17 +240,17 @@ class BertLayerBetterTransformer(BetterTransformerBaseLayer):
         qkv_split_index = self.in_proj_weight.shape[0] // 3
 
         query = self.in_proj_weight[:qkv_split_index, :]
-        key = self.in_proj_weight[qkv_split_index:2*qkv_split_index, :]
-        value = self.in_proj_weight[2*qkv_split_index:, :]
+        key = self.in_proj_weight[qkv_split_index : 2 * qkv_split_index, :]
+        value = self.in_proj_weight[2 * qkv_split_index :, :]
 
         self.old_layer.attention.self.query.weight = nn.Parameter(query)
         self.old_layer.attention.self.key.weight = nn.Parameter(key)
         self.old_layer.attention.self.value.weight = nn.Parameter(value)
 
         query_bias = self.in_proj_bias[:qkv_split_index]
-        key_bias = self.in_proj_bias[qkv_split_index:2*qkv_split_index]
-        value_bias = self.in_proj_bias[2*qkv_split_index:]
-    
+        key_bias = self.in_proj_bias[qkv_split_index : 2 * qkv_split_index]
+        value_bias = self.in_proj_bias[2 * qkv_split_index :]
+
         self.old_layer.attention.self.query.bias = nn.Parameter(query_bias)
         self.old_layer.attention.self.key.bias = nn.Parameter(key_bias)
         self.old_layer.attention.self.value.bias = nn.Parameter(value_bias)

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -32,7 +32,7 @@ class AlbertLayerBetterTransformer(BetterTransformerBaseLayer):
             albert_layer (`torch.nn.Module`):
                 The original ALBERT Layer where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, albert_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -81,6 +81,23 @@ class AlbertLayerBetterTransformer(BetterTransformerBaseLayer):
 
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
+
+        self.original_layers_mapping = {
+            "in_proj_weight": ["attention.query.weight", "attention.key.weight", "attention.value.weight"],
+            "in_proj_bias": ["attention.query.bias", "attention.key.bias", "attention.value.bias"],
+            "out_proj_weight": "attention.dense.weight",
+            "out_proj_bias": "attention.dense.bias",
+            "linear1_weight": "ffn.weight",
+            "linear1_bias": "ffn.bias",
+            "linear2_weight": "ffn_output.weight",
+            "linear2_bias": "ffn_output.bias",
+            "norm1_eps": "attention.LayerNorm.eps",
+            "norm1_weight": "attention.LayerNorm.weight",
+            "norm1_bias": "attention.LayerNorm.bias",
+            "norm2_eps": "full_layer_layer_norm.eps",
+            "norm2_weight": "full_layer_layer_norm.weight",
+            "norm2_bias": "full_layer_layer_norm.bias",
+        }
 
         self.validate_bettertransformer()
 
@@ -263,7 +280,7 @@ class BartEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
             bart_layer (`torch.nn.Module`):
                 The original `BartEncoderLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, bart_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -313,6 +330,23 @@ class BartEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
 
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
+
+        self.original_layers_mapping = {
+            "in_proj_weight": ["self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight"],
+            "in_proj_bias": ["self_attn.q_proj.bias", "self_attn.k_proj.bias", "self_attn.v_proj.bias"],
+            "out_proj_weight": "self_attn.out_proj.weight",
+            "out_proj_bias": "self_attn.out_proj.bias",
+            "linear1_weight": "fc1.weight",
+            "linear1_bias": "fc1.bias",
+            "linear2_weight": "fc2.weight",
+            "linear2_bias": "fc2.bias",
+            "norm1_eps": "self_attn_layer_norm.eps",
+            "norm1_weight": "self_attn_layer_norm.weight",
+            "norm1_bias": "self_attn_layer_norm.bias",
+            "norm2_eps": "final_layer_norm.eps",
+            "norm2_weight": "final_layer_norm.weight",
+            "norm2_bias": "final_layer_norm.bias",
+        }
 
         self.validate_bettertransformer()
 
@@ -378,7 +412,7 @@ class MBartEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
             mbart_layer (`torch.nn.Module`):
                 The original `MBartEncoderLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, mbart_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -429,6 +463,28 @@ class MBartEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
         self.norm_first = True
+
+        self.original_layers_mapping = {
+            "in_proj_weight": [
+                "self_attn.q_proj.weight",
+                "self_attn.k_proj.weight",
+                "self_attn.v_proj.weight",
+            ],
+            "in_proj_bias": ["self_attn.q_proj.bias", "self_attn.k_proj.bias", "self_attn.v_proj.bias"],
+            "out_proj_weight": "self_attn.out_proj.weight",
+            "out_proj_bias": "self_attn.out_proj.bias",
+            "linear1_weight": "fc1.weight",
+            "linear1_bias": "fc1.bias",
+            "linear2_weight": "fc2.weight",
+            "linear2_bias": "fc2.bias",
+            "norm1_weight": "self_attn_layer_norm.weight",
+            "norm1_bias": "self_attn_layer_norm.bias",
+            "norm1_eps": "self_attn_layer_norm.eps",
+            "norm2_weight": "final_layer_norm.weight",
+            "norm2_bias": "final_layer_norm.bias",
+            "norm2_eps": "final_layer_norm.eps",
+        }
+
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, position_bias=None, *_, **__):
@@ -494,7 +550,7 @@ class DistilBertLayerBetterTransformer(BetterTransformerBaseLayer):
             bert_layer (`torch.nn.Module`):
                 The original Distill-BERT Layer where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, bert_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -543,6 +599,22 @@ class DistilBertLayerBetterTransformer(BetterTransformerBaseLayer):
 
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
+
+        self.original_layers_mapping = {
+            "in_proj_weight": ["attention.q_lin.weight", "attention.k_lin.weight", "attention.v_lin.weight"],
+            "in_proj_bias": ["attention.q_lin.bias", "attention.k_lin.bias", "attention.v_lin.bias"],
+            "out_proj_weight": "attention.out_lin.weight",
+            "out_proj_bias": "attention.out_lin.bias",
+            "linear1_weight": "ffn.lin1.weight",
+            "linear1_bias": "ffn.lin1.bias",
+            "linear2_weight": "ffn.lin2.weight",
+            "linear2_bias": "ffn.lin2.bias",
+            "norm1_weight": "sa_layer_norm.weight",
+            "norm1_bias": "sa_layer_norm.bias",
+            "norm2_weight": "output_layer_norm.weight",
+            "norm2_bias": "output_layer_norm.bias",
+        }
+
         self.validate_bettertransformer()
 
     def forward(self, x, attn_mask, head_mask=None, output_attentions=None, *_):
@@ -601,7 +673,7 @@ class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
             whisper_layer (`torch.nn.Module`):
                 The original `WhisperEncoderLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, whisper_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -652,6 +724,22 @@ class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
         self.is_last_layer = False
         self.norm_first = True
 
+        self.original_layers_mapping = {
+            "in_proj_weight": ["self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight"],
+            "in_proj_bias": ["self_attn.q_proj.bias", "self_attn.k_proj.bias", "self_attn.v_proj.bias"],
+            "out_proj_weight": "self_attn.out_proj.weight",
+            "out_proj_bias": "self_attn.out_proj.bias",
+            "linear1_weight": "fc1.weight",
+            "linear1_bias": "fc1.bias",
+            "linear2_weight": "fc2.weight",
+            "linear2_bias": "fc2.bias",
+            "norm1_weight": "self_attn_layer_norm.weight",
+            "norm1_bias": "self_attn_layer_norm.bias",
+            "norm2_weight": "final_layer_norm.weight",
+            "norm2_bias": "final_layer_norm.bias",
+        }
+        self.keys_to_ignore.append("self_attn.k_proj.bias")
+
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, *_, **__):
@@ -697,7 +785,7 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
             vit_layer (`torch.nn.Module`):
                 The original `ViTLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, vit_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -748,6 +836,29 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer):
         self.is_last_layer = False
         self.norm_first = True
 
+        self.original_layers_mapping = {
+            "in_proj_weight": [
+                "attention.attention.query.weight",
+                "attention.attention.key.weight",
+                "attention.attention.value.weight",
+            ],
+            "in_proj_bias": [
+                "attention.attention.query.bias",
+                "attention.attention.key.bias",
+                "attention.attention.value.bias",
+            ],
+            "out_proj_weight": "attention.output.dense.weight",
+            "out_proj_bias": "attention.output.dense.bias",
+            "linear1_weight": "intermediate.dense.weight",
+            "linear1_bias": "intermediate.dense.bias",
+            "linear2_weight": "output.dense.weight",
+            "linear2_bias": "output.dense.bias",
+            "norm1_weight": "layernorm_before.weight",
+            "norm1_bias": "layernorm_before.bias",
+            "norm2_weight": "layernorm_after.weight",
+            "norm2_bias": "layernorm_after.bias",
+        }
+
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, *_, **__):
@@ -793,7 +904,7 @@ class ViltLayerBetterTransformer(BetterTransformerBaseLayer):
             vilt_layer (`torch.nn.Module`):
                 The original `VilTLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, vilt_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -844,6 +955,29 @@ class ViltLayerBetterTransformer(BetterTransformerBaseLayer):
         self.is_last_layer = False
         self.norm_first = True
 
+        self.original_layers_mapping = {
+            "in_proj_weight": [
+                "attention.attention.query.weight",
+                "attention.attention.key.weight",
+                "attention.attention.value.weight",
+            ],
+            "in_proj_bias": [
+                "attention.attention.query.bias",
+                "attention.attention.key.bias",
+                "attention.attention.value.bias",
+            ],
+            "out_proj_weight": "attention.output.dense.weight",
+            "out_proj_bias": "attention.output.dense.bias",
+            "linear1_weight": "intermediate.dense.weight",
+            "linear1_bias": "intermediate.dense.bias",
+            "linear2_weight": "output.dense.weight",
+            "linear2_bias": "output.dense.bias",
+            "norm1_weight": "layernorm_before.weight",
+            "norm1_bias": "layernorm_before.bias",
+            "norm2_weight": "layernorm_after.weight",
+            "norm2_bias": "layernorm_after.bias",
+        }
+
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, *_, **__):
@@ -889,7 +1023,7 @@ class Wav2Vec2EncoderLayerBetterTransformer(BetterTransformerBaseLayer):
             wav2vec2_layer (`torch.nn.Module`):
                 The original `Wav2Vec2EncoderLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, wav2vec2_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -938,6 +1072,23 @@ class Wav2Vec2EncoderLayerBetterTransformer(BetterTransformerBaseLayer):
 
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
+
+        self.original_layers_mapping = {
+            "in_proj_weight": ["attention.q_proj.weight", "attention.k_proj.weight", "attention.v_proj.weight"],
+            "in_proj_bias": ["attention.q_proj.bias", "attention.k_proj.bias", "attention.v_proj.bias"],
+            "out_proj_weight": "attention.out_proj.weight",
+            "out_proj_bias": "attention.out_proj.bias",
+            "linear1_weight": "feed_forward.intermediate_dense.weight",
+            "linear1_bias": "feed_forward.intermediate_dense.bias",
+            "linear2_weight": "feed_forward.output_dense.weight",
+            "linear2_bias": "feed_forward.output_dense.bias",
+            "norm1_weight": "layer_norm.weight",
+            "norm1_bias": "layer_norm.bias",
+            "norm1_eps": "layer_norm.eps",
+            "norm2_weight": "final_layer_norm.weight",
+            "norm2_bias": "final_layer_norm.bias",
+            "norm2_eps": "final_layer_norm.eps",
+        }
 
         self.validate_bettertransformer()
 
@@ -995,7 +1146,7 @@ class FSMTEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
             fsmt_layer (`torch.nn.Module`):
                 The original FSMT Layer where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, fsmt_layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -1044,6 +1195,21 @@ class FSMTEncoderLayerBetterTransformer(BetterTransformerBaseLayer):
 
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
+
+        self.original_layers_mapping = {
+            "in_proj_weight": ["self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight"],
+            "in_proj_bias": ["self_attn.q_proj.bias", "self_attn.k_proj.bias", "self_attn.v_proj.bias"],
+            "out_proj_weight": "self_attn.out_proj.weight",
+            "out_proj_bias": "self_attn.out_proj.bias",
+            "linear1_weight": "fc1.weight",
+            "linear1_bias": "fc1.bias",
+            "linear2_weight": "fc2.weight",
+            "linear2_bias": "fc2.bias",
+            "norm1_weight": "self_attn_layer_norm.weight",
+            "norm1_bias": "self_attn_layer_norm.bias",
+            "norm2_weight": "final_layer_norm.weight",
+            "norm2_bias": "final_layer_norm.bias",
+        }
 
         self.validate_bettertransformer()
 
@@ -1117,7 +1283,7 @@ class CLIPLayerBetterTransformer(BetterTransformerBaseLayer):
             layer (`torch.nn.Module`):
                 The original `CLIPEncoderLayer` where the weights needs to be retrieved.
         """
-        super().__init__(config)
+        super().__init__(config, layer)
         # In_proj layer
         self.in_proj_weight = nn.Parameter(
             torch.cat(
@@ -1167,6 +1333,23 @@ class CLIPLayerBetterTransformer(BetterTransformerBaseLayer):
         # Last step: set the last layer to `False` -> this will be set to `True` when converting the model
         self.is_last_layer = False
         self.norm_first = True
+
+        self.original_layers_mapping = {
+            "in_proj_weight": ["self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight"],
+            "in_proj_bias": ["self_attn.q_proj.bias", "self_attn.k_proj.bias", "self_attn.v_proj.bias"],
+            "out_proj_weight": "self_attn.out_proj.weight",
+            "out_proj_bias": "self_attn.out_proj.bias",
+            "linear1_weight": "mlp.fc1.weight",
+            "linear1_bias": "mlp.fc1.bias",
+            "linear2_weight": "mlp.fc2.weight",
+            "linear2_bias": "mlp.fc2.bias",
+            "norm1_eps": "layer_norm1.eps",
+            "norm1_weight": "layer_norm1.weight",
+            "norm1_bias": "layer_norm1.bias",
+            "norm2_eps": "layer_norm2.eps",
+            "norm2_weight": "layer_norm2.weight",
+            "norm2_bias": "layer_norm2.bias",
+        }
 
         self.validate_bettertransformer()
 

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -88,9 +88,9 @@ def revert_to_original_model(
 
     Args:
         `bt_model` (`torch.nn.Module`):
-            The input converted model
+            The input `BetterTransformer` converted model
     Returns:
-        The invert-converted model
+        The original `transformers` model
     """
 
     for name, module in bt_model.named_children():

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -96,7 +96,7 @@ def invert_to_old_model(bt_model):
             # we may explicitly exclude part of the model to use BetterTransformer
             invert_to_old_model(module)
 
-        is_invert_compatible = hasattr(module, 'old_layer') and module.old_layer is not None
+        is_invert_compatible = hasattr(module, "old_layer") and module.old_layer is not None
 
         if is_invert_compatible:
             bt_model._modules[name] = module._replace_to_original_module()
@@ -261,17 +261,17 @@ class BetterTransformer(object):
         setattr(model_fast, "save_pretrained", warn_uncompatible_save(model_fast.save_pretrained))
 
         return model_fast
-    
+
     @check_if_pytorch_greater(
         "1.13.0",
         "Please upgrade PyTorch following https://pytorch.org/get-started/locally/ in order to use BetterTransformer.",
     )
-    def inverse_transform(
-        model: torch.nn.Module, **kwargs
-    ) -> torch.nn.Module:
+    def inverse_transform(model: torch.nn.Module, **kwargs) -> torch.nn.Module:
         # Step 1: check if the model has the attribute `use_bettertransformer`
         if not getattr(model, "use_bettertransformer", False):
-            raise ValueError("You should inverse_transform a model that has been already transformed to a `BetterTransformer` format.")
+            raise ValueError(
+                "You should inverse_transform a model that has been already transformed to a `BetterTransformer` format."
+            )
 
         model = invert_to_old_model(model)
         return model

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -293,10 +293,8 @@ class BetterTransformer(object):
                 "The method BetterTransformer.reverse() should be used on a model already transformed to the BetterTransformer format, which appears to not be the case."
             )
 
-        # Step 1: revert the model
         model = revert_to_original_model(model)
 
-        # Step 2: retrieve the old `save_pretrained` and `push_to_hub` methods
         model.save_pretrained = model._old_save_pretrained
         model.push_to_hub = model._old_push_to_hub
 

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -79,7 +79,9 @@ def replace_to_bettertransformer(model, config):
     return model
 
 
-def invert_to_old_model(bt_model):
+def revert_to_original_model(
+    bt_model: torch.nn.Module,
+):
     r"""
     Replaces the BT-converted model to its old variant, to be able to safely store the weights
     of a trained model.
@@ -94,12 +96,12 @@ def invert_to_old_model(bt_model):
     for name, module in bt_model.named_children():
         if len(list(module.children())) > 0:
             # we may explicitly exclude part of the model to use BetterTransformer
-            invert_to_old_model(module)
+            revert_to_original_model(module)
 
-        is_invert_compatible = hasattr(module, "old_layer") and module.old_layer is not None
+        is_invert_compatible = hasattr(module, "orig_layer") and module.orig_layer is not None
 
         if is_invert_compatible:
-            bt_model._modules[name] = module._replace_to_original_module()
+            bt_model._modules[name] = module._revert_back_to_original_module()
             module = None
     return bt_model
 
@@ -273,5 +275,5 @@ class BetterTransformer(object):
                 "You should inverse_transform a model that has been already transformed to a `BetterTransformer` format."
             )
 
-        model = invert_to_old_model(model)
+        model = revert_to_original_model(model)
         return model

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -272,7 +272,7 @@ class BetterTransformer(object):
         # Step 1: check if the model has the attribute `use_bettertransformer`
         if not getattr(model, "use_bettertransformer", False):
             raise ValueError(
-                "You should inverse_transform a model that has been already transformed to a `BetterTransformer` format."
+                "The method BetterTransformer.reverse() should be used on a model already transformed to the BetterTransformer format, which appears to not be the case."
             )
 
         model = revert_to_original_model(model)

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -87,7 +87,7 @@ def revert_to_original_model(
     of a trained model.
 
     Args:
-        `model` (`torch.nn.Module`):
+        `bt_model` (`torch.nn.Module`):
             The input converted model
     Returns:
         The invert-converted model
@@ -268,7 +268,7 @@ class BetterTransformer(object):
         "1.13.0",
         "Please upgrade PyTorch following https://pytorch.org/get-started/locally/ in order to use BetterTransformer.",
     )
-    def inverse_transform(model: torch.nn.Module, **kwargs) -> torch.nn.Module:
+    def reverse(model: torch.nn.Module, **kwargs) -> torch.nn.Module:
         # Step 1: check if the model has the attribute `use_bettertransformer`
         if not getattr(model, "use_bettertransformer", False):
             raise ValueError(

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -98,9 +98,9 @@ def revert_to_original_model(
             # we may explicitly exclude part of the model to use BetterTransformer
             revert_to_original_model(module)
 
-        is_invert_compatible = hasattr(module, "orig_layer") and module.orig_layer is not None
+        can_be_reversed = getattr(module, "orig_layer", None) is not None
 
-        if is_invert_compatible:
+        if can_be_reversed:
             bt_model._modules[name] = module._revert_back_to_original_module()
             module = None
     return bt_model

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -39,6 +39,7 @@ from .input_generators import (
     DummyTrainingLabelsInputGenerator,
     DummyVisionInputGenerator,
 )
+from .modeling_utils import recurse_setattr
 from .normalized_config import (
     NormalizedConfig,
     NormalizedConfigManager,

--- a/optimum/utils/modeling_utils.py
+++ b/optimum/utils/modeling_utils.py
@@ -1,7 +1,5 @@
 def recurse_setattr(module, name, value):
-    r"""
-    A wrapper function to recursively set attributes to a module.
-    """
+    """A wrapper function to recursively set attributes to a module."""
     if "." not in name:
         setattr(module, name, value)
     else:

--- a/optimum/utils/modeling_utils.py
+++ b/optimum/utils/modeling_utils.py
@@ -1,5 +1,5 @@
 def recurse_setattr(module, name, value):
-    """A wrapper function to recursively set attributes to a module."""
+    """A function to recursively set attributes to a module."""
     if "." not in name:
         setattr(module, name, value)
     else:

--- a/optimum/utils/modeling_utils.py
+++ b/optimum/utils/modeling_utils.py
@@ -1,0 +1,9 @@
+def recurse_setattr(module, name, value):
+    r"""
+    A wrapper function to recursively set attributes to a module.
+    """
+    if "." not in name:
+        setattr(module, name, value)
+    else:
+        name, rest = name.split(".", 1)
+        recurse_setattr(getattr(module, name), rest, value)

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -155,7 +155,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
         for model_id in self.all_models_to_test:
 
             bt_model = AutoModel.from_pretrained(model_id)
-            # get bt model and invert it
             bt_model = BetterTransformer.transform(bt_model, keep_original_model=keep_original_model)
             bt_model = BetterTransformer.reverse(bt_model)
 
@@ -200,8 +199,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
 
                 bt_model_from_load = AutoModel.from_pretrained(tmpdirname)
 
-                # check if the state dict is the same
-                # first check if the keys are the same
                 self.assertEqual(
                     set(bt_model.state_dict().keys()),
                     set(bt_model_from_load.state_dict().keys()),

--- a/tests/bettertransformer/test_bettertransformer_audio.py
+++ b/tests/bettertransformer/test_bettertransformer_audio.py
@@ -255,3 +255,24 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
 
             # Assert that the outputs are the same
             self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))
+
+    @parameterized.expand([(False,)])
+    def test_raise_save_pretrained_error(self, keep_original_model=False):
+        r"""
+        Test if the converted model raises an error when calling `save_pretrained`
+        but not when the model is reverted
+        """
+        for model in self.all_models_to_test:
+            # get hf and bt model
+            hf_model = AutoModel.from_pretrained(model)
+            # get bt model and invert it
+            bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+
+            with self.assertRaises(ValueError):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    bt_model.save_pretrained(tmpdirname)
+
+            # revert model and save it
+            bt_model = BetterTransformer.reverse(bt_model)
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                bt_model.save_pretrained(tmpdirname)

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -28,7 +28,7 @@ from optimum.utils.testing_utils import (
     require_torch_gpu,
 )
 from parameterized import parameterized
-from testing_bettertransformer_utils import BetterTransformersTestMixin, BetterTransformersInvertibleTestMixin
+from testing_bettertransformer_utils import BetterTransformersInvertibleTestMixin, BetterTransformersTestMixin
 
 
 ALL_ENCODER_MODELS_TO_TEST = [
@@ -56,9 +56,7 @@ ALL_ENCODER_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-nllb",
 ]
 
-ALL_INVERTIBLE_MODELS_TO_TEST = [
-    "hf-internal-testing/tiny-random-BertModel"
-]
+ALL_INVERTIBLE_MODELS_TO_TEST = ["hf-internal-testing/tiny-random-BertModel"]
 
 
 class BetterTransformersEncoderTest(BetterTransformersTestMixin, unittest.TestCase):
@@ -296,7 +294,7 @@ class BetterTransformersEncoderDecoderTest(BetterTransformersTestMixin, unittest
 
 class BetterTransformerInvertibleTest(BetterTransformersInvertibleTestMixin, unittest.TestCase):
     r"""
-    `BetterTransformers` integration into Hugging Face `transformers` ecosystem includes also the 
+    `BetterTransformers` integration into Hugging Face `transformers` ecosystem includes also the
     inverse transform of the models. This test suite checks that the inverse conversion is correct.
     This class inherits from `BetterTransformersInvertibleTestMixin` which contains the state dict tests.
 
@@ -338,7 +336,7 @@ class BetterTransformerInvertibleTest(BetterTransformersInvertibleTestMixin, uni
 
             # Assert that the outputs are the same
             self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))
-    
+
     def test_modules(self):
         r"""
         Test that the inverse converted model and hf model have the same modules
@@ -366,10 +364,6 @@ class BetterTransformerInvertibleTest(BetterTransformersInvertibleTestMixin, uni
                 bt_module_attributes = [attr for attr in dir(bt_module) if not attr.startswith("_")]
 
                 self.assertEqual(hf_module_attributes, bt_module_attributes)
-
-
-
-
 
 
 def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -325,7 +325,7 @@ class BetterTransformerInvertibleTest(BetterTransformersInvertibleTestMixin, uni
             hf_model = AutoModel.from_pretrained(model)
             # get bt model and invert it
             bt_model = BetterTransformer.transform(hf_model)
-            bt_model = BetterTransformer.inverse_transform(bt_model)
+            bt_model = BetterTransformer.reverse(bt_model)
 
             # get inputs
             inputs = self.prepare_inputs_for_class(model)
@@ -346,7 +346,7 @@ class BetterTransformerInvertibleTest(BetterTransformersInvertibleTestMixin, uni
             hf_model = AutoModel.from_pretrained(model)
             # get bt model and invert it
             bt_model = BetterTransformer.transform(hf_model)
-            bt_model = BetterTransformer.inverse_transform(bt_model)
+            bt_model = BetterTransformer.reverse(bt_model)
 
             # get modules:
             hf_modules = list(hf_model.modules())

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -28,7 +28,7 @@ from optimum.utils.testing_utils import (
     require_torch_gpu,
 )
 from parameterized import parameterized
-from testing_bettertransformer_utils import BetterTransformersTestMixin
+from testing_bettertransformer_utils import BetterTransformersTestMixin, BetterTransformersInvertibleTestMixin
 
 
 ALL_ENCODER_MODELS_TO_TEST = [
@@ -54,6 +54,10 @@ ALL_ENCODER_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-FSMTModel",
     "hf-internal-testing/tiny-random-mbart",
     "hf-internal-testing/tiny-random-nllb",
+]
+
+ALL_INVERTIBLE_MODELS_TO_TEST = [
+    "hf-internal-testing/tiny-random-BertModel"
 ]
 
 
@@ -288,6 +292,84 @@ class BetterTransformersEncoderDecoderTest(BetterTransformersTestMixin, unittest
     )
     def test_logits(self, test_name: str, model_id, padding, max_length=20):
         super().test_logits([model_id], padding=padding, max_length=max_length)
+
+
+class BetterTransformerInvertibleTest(BetterTransformersInvertibleTestMixin, unittest.TestCase):
+    r"""
+    `BetterTransformers` integration into Hugging Face `transformers` ecosystem includes also the 
+    inverse transform of the models. This test suite checks that the inverse conversion is correct.
+    This class inherits from `BetterTransformersInvertibleTestMixin` which contains the state dict tests.
+
+    Check the docstring of each test to understand the purpose of each test. Basically we test:
+    - if the conversion dictionnary is consistent, ie if the converted model have the exact same
+    state_dict as the original model.
+    - if the converted inverted model produces the same logits as the original model.
+    - if the converted inverted model has the same module, signature and parameters as the original model.
+    """
+    all_models_to_test = ALL_INVERTIBLE_MODELS_TO_TEST
+
+    def tearDown(self):
+        gc.collect()
+
+    def prepare_inputs_for_class(self, model_id=None):
+        input_dict = {
+            "input_ids": torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]]),
+            "attention_mask": torch.LongTensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]]),
+        }
+        return input_dict
+
+    def test_logits(self):
+        r"""
+        Test that the inverse converted model and hf model have the same logits
+        """
+        for model in self.all_models_to_test:
+            # get hf and bt model
+            hf_model = AutoModel.from_pretrained(model)
+            # get bt model and invert it
+            bt_model = BetterTransformer.transform(hf_model)
+            bt_model = BetterTransformer.inverse_transform(bt_model)
+
+            # get inputs
+            inputs = self.prepare_inputs_for_class(model)
+
+            # get outputs
+            output_bt = bt_model(**inputs)
+            output_hf = hf_model(**inputs)
+
+            # Assert that the outputs are the same
+            self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))
+    
+    def test_modules(self):
+        r"""
+        Test that the inverse converted model and hf model have the same modules
+        """
+        for model in self.all_models_to_test:
+            # get hf and bt model
+            hf_model = AutoModel.from_pretrained(model)
+            # get bt model and invert it
+            bt_model = BetterTransformer.transform(hf_model)
+            bt_model = BetterTransformer.inverse_transform(bt_model)
+
+            # get modules:
+            hf_modules = list(hf_model.modules())
+            bt_modules = list(bt_model.modules())
+
+            # Assert that the modules are the same
+            self.assertEqual(len(hf_modules), len(bt_modules))
+            for hf_module, bt_module in zip(hf_modules, bt_modules):
+                self.assertEqual(type(hf_module), type(bt_module))
+                # check the modules have the same methods
+                self.assertEqual(dir(hf_module), dir(bt_module))
+
+                # check the modules have the same attributes
+                hf_module_attributes = [attr for attr in dir(hf_module) if not attr.startswith("_")]
+                bt_module_attributes = [attr for attr in dir(bt_module) if not attr.startswith("_")]
+
+                self.assertEqual(hf_module_attributes, bt_module_attributes)
+
+
+
+
 
 
 def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):

--- a/tests/bettertransformer/test_bettertransformer_encoder.py
+++ b/tests/bettertransformer/test_bettertransformer_encoder.py
@@ -254,6 +254,50 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin, unittest.TestCa
         max_memory = {0: "2GB"}
         self.check_accelerate_compatibility_cpu_gpu(keep_original_model=False, max_memory=max_memory)
 
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_modules(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_save_load_invertible(self, test_name: str, model_id, keep_original_model=False):
+        super().test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_model_logits(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_model_logits(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_raise_save_pretrained_error(self, test_name: str, model_id, keep_original_model=False):
+        super().test_raise_save_pretrained_error(model_id=model_id, keep_original_model=keep_original_model)
+
 
 class BetterTransformersEncoderDecoderTest(BetterTransformersTestMixin, unittest.TestCase):
     r"""
@@ -288,6 +332,50 @@ class BetterTransformersEncoderDecoderTest(BetterTransformersTestMixin, unittest
     )
     def test_logits(self, test_name: str, model_id, padding, max_length=20):
         super().test_logits([model_id], padding=padding, max_length=max_length)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_modules(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_save_load_invertible(self, test_name: str, model_id, keep_original_model=False):
+        super().test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_model_logits(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_model_logits(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_raise_save_pretrained_error(self, test_name: str, model_id, keep_original_model=False):
+        super().test_raise_save_pretrained_error(model_id=model_id, keep_original_model=keep_original_model)
 
 
 def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -59,6 +59,50 @@ class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCas
         inputs = feature_extractor(images=image, return_tensors="pt")
         return inputs
 
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_modules(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_save_load_invertible(self, test_name: str, model_id, keep_original_model=False):
+        super().test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_model_logits(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_model_logits(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_raise_save_pretrained_error(self, test_name: str, model_id, keep_original_model=False):
+        super().test_raise_save_pretrained_error(model_id=model_id, keep_original_model=keep_original_model)
+
 
 class BetterTransformersViLTTest(BetterTransformersTestMixin, unittest.TestCase):
     r"""
@@ -75,6 +119,50 @@ class BetterTransformersViLTTest(BetterTransformersTestMixin, unittest.TestCase)
         processor = AutoProcessor.from_pretrained(model_id)
         inputs = processor(images=image, text=text, return_tensors="pt")
         return inputs
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_modules(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_save_load_invertible(self, test_name: str, model_id, keep_original_model=False):
+        super().test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_model_logits(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_model_logits(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_raise_save_pretrained_error(self, test_name: str, model_id, keep_original_model=False):
+        super().test_raise_save_pretrained_error(model_id=model_id, keep_original_model=keep_original_model)
 
 
 class BetterTransformersCLIPTest(BetterTransformersTestMixin, unittest.TestCase):
@@ -135,6 +223,73 @@ class BetterTransformersCLIPTest(BetterTransformersTestMixin, unittest.TestCase)
     )
     def test_raise_train(self, test_name: str, model_id, padding, max_length=20):
         super().test_raise_train([model_id], padding=padding, max_length=max_length)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_invert_modules(self, test_name: str, model_id, keep_original_model=False):
+        super().test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_save_load_invertible(self, test_name: str, model_id, keep_original_model=False):
+        super().test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+                "padding": ["max_length", True],
+            }
+        )
+    )
+    def test_invert_model_logits(self, test_name: str, model_id, keep_original_model=False, padding=True):
+        r"""
+        Test that the inverse converted model and hf model have the same logits
+        """
+        # get hf and bt model
+        hf_model = AutoModel.from_pretrained(model_id)
+        # get bt model and invert it
+        bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+        bt_model = BetterTransformer.reverse(bt_model)
+
+        # get inputs
+        inputs = self.prepare_inputs_for_class(model_id, padding=padding)
+
+        # get outputs
+        torch.manual_seed(42)
+        output_bt = bt_model(**inputs)
+
+        torch.manual_seed(42)
+        output_hf = hf_model(**inputs)
+
+        # Assert that the outputs are the same
+        self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_id": all_models_to_test,
+                "keep_original_model": [True, False],
+            }
+        )
+    )
+    def test_raise_save_pretrained_error(
+        self, test_name: str, model_id, keep_original_model=False, **preprocessor_kwargs
+    ):
+        super().test_raise_save_pretrained_error(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand([(True,), (False,)])
     def test_invert_model_logits(self, keep_original_model=True, **preprocessor_kwargs):

--- a/tests/bettertransformer/test_bettertransformer_vision.py
+++ b/tests/bettertransformer/test_bettertransformer_vision.py
@@ -143,24 +143,19 @@ class BetterTransformersCLIPTest(BetterTransformersTestMixin, unittest.TestCase)
         """
         # The first row of the attention mask needs to be all ones -> check: https://github.com/pytorch/pytorch/blob/19171a21ee8a9cc1a811ac46d3abd975f0b6fc3b/test/test_nn.py#L5283
         for model in self.all_models_to_test:
-            # get hf and bt model
             hf_model = AutoModel.from_pretrained(model)
-            # get bt model and invert it
             bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
             bt_model = BetterTransformer.reverse(bt_model)
 
-            # get inputs
             if model == "laion/CLIP-ViT-B-32-laion2B-s34B-b79K":
                 inputs = self.prepare_inputs_for_class(model_id=model, padding=True)
             else:
                 inputs = self.prepare_inputs_for_class(model_id=model, padding="max_length")
 
-            # get outputs
             torch.manual_seed(42)
             output_bt = bt_model(**inputs)
 
             torch.manual_seed(42)
             output_hf = hf_model(**inputs)
 
-            # Assert that the outputs are the same
             self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))

--- a/tests/bettertransformer/testing_bettertransformer_utils.py
+++ b/tests/bettertransformer/testing_bettertransformer_utils.py
@@ -194,7 +194,6 @@ class BetterTransformersInvertibleTestMixin:
                 for name, param in bt_model.named_parameters():
                     self.assertFalse(param.device.type == "meta", f"Parameter {name} is on the meta device.")
 
-
                 bt_model.save_pretrained(tmpdirname)
 
                 bt_model_from_load = AutoModel.from_pretrained(tmpdirname)
@@ -211,7 +210,6 @@ class BetterTransformersInvertibleTestMixin:
                     set(bt_model_from_load.state_dict().keys()),
                 )
 
-
                 for key in bt_model.state_dict().keys():
                     self.assertTrue(
                         torch.allclose(
@@ -226,9 +224,6 @@ class BetterTransformersInvertibleTestMixin:
                             bt_model_from_load.state_dict()[key],
                         )
                     )
-
-
-                
 
 
 def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):

--- a/tests/bettertransformer/testing_bettertransformer_utils.py
+++ b/tests/bettertransformer/testing_bettertransformer_utils.py
@@ -189,7 +189,7 @@ class BetterTransformersInvertibleTestMixin:
                 hf_model = AutoModel.from_pretrained(model).eval()
                 bt_model = BetterTransformer.transform(hf_model, keep_original_model=False)
 
-                bt_model = BetterTransformer.inverse_transform(bt_model)
+                bt_model = BetterTransformer.reverse(bt_model)
                 # check if no parameter is on the `meta` device
                 for name, param in bt_model.named_parameters():
                     self.assertFalse(param.device.type == "meta", f"Parameter {name} is on the meta device.")

--- a/tests/bettertransformer/testing_bettertransformer_utils.py
+++ b/tests/bettertransformer/testing_bettertransformer_utils.py
@@ -177,122 +177,114 @@ class BetterTransformersTestMixin:
             self.assertTrue(isinstance(converted_model, hf_random_model.__class__))
             self.assertTrue(hasattr(converted_model, "generate"))
 
-    @parameterized.expand([(True,), (False,)])
-    def test_invert_modules(self, keep_original_model=False):
+    def test_invert_modules(self, model_id, keep_original_model=False):
         r"""
         Test that the inverse converted model and hf model have the same modules
         """
-        for model in self.all_models_to_test:
-            # get hf and bt model
-            hf_model = AutoModel.from_pretrained(model)
-            # get bt model and invert it
+        # get hf and bt model
+        hf_model = AutoModel.from_pretrained(model_id)
+        # get bt model and invert it
+        bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+        bt_model = BetterTransformer.reverse(bt_model)
+
+        # get modules:
+        hf_modules = list(hf_model.modules())
+        bt_modules = list(bt_model.modules())
+
+        # Assert that the modules are the same
+        self.assertEqual(len(hf_modules), len(bt_modules))
+        for hf_module, bt_module in zip(hf_modules, bt_modules):
+            # check the modules have the same signature and code
+            # for the `forward` and `__init__` methods
+            # as those are the only functions we change
+            self.assertEqual(inspect.signature(hf_module.forward), inspect.signature(bt_module.forward))
+            self.assertEqual(inspect.signature(hf_module.__init__), inspect.signature(bt_module.__init__))
+
+            self.assertEqual(inspect.getsource(hf_module.forward), inspect.getsource(bt_module.forward))
+            self.assertEqual(inspect.getsource(hf_module.__init__), inspect.getsource(bt_module.__init__))
+
+    def test_save_load_invertible(self, model_id, keep_original_model=True):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            hf_model = AutoModel.from_pretrained(model_id).eval()
             bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+
             bt_model = BetterTransformer.reverse(bt_model)
+            # check if no parameter is on the `meta` device
 
-            # get modules:
-            hf_modules = list(hf_model.modules())
-            bt_modules = list(bt_model.modules())
+            for name, param in bt_model.named_parameters():
+                self.assertFalse(param.device.type == "meta", f"Parameter {name} is on the meta device.")
 
-            # Assert that the modules are the same
-            self.assertEqual(len(hf_modules), len(bt_modules))
-            for hf_module, bt_module in zip(hf_modules, bt_modules):
-                # check the modules have the same signature and code
-                # for the `forward` and `__init__` methods
-                # as those are the only functions we change
-                self.assertEqual(inspect.signature(hf_module.forward), inspect.signature(bt_module.forward))
-                self.assertEqual(inspect.signature(hf_module.__init__), inspect.signature(bt_module.__init__))
+            bt_model.save_pretrained(tmpdirname)
 
-                self.assertEqual(inspect.getsource(hf_module.forward), inspect.getsource(bt_module.forward))
-                self.assertEqual(inspect.getsource(hf_module.__init__), inspect.getsource(bt_module.__init__))
+            bt_model_from_load = AutoModel.from_pretrained(tmpdirname)
 
-    @parameterized.expand([(True,), (False,)])
-    def test_save_load_invertible(self, keep_original_model=True):
-        for model in self.all_models_to_test:
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                hf_model = AutoModel.from_pretrained(model).eval()
-                bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+            # check if the state dict is the same
+            # first check if the keys are the same
+            self.assertEqual(
+                set(bt_model.state_dict().keys()),
+                set(bt_model_from_load.state_dict().keys()),
+            )
+            # check also with HF model
+            self.assertEqual(
+                set(hf_model.state_dict().keys()),
+                set(bt_model_from_load.state_dict().keys()),
+            )
 
-                bt_model = BetterTransformer.reverse(bt_model)
-                # check if no parameter is on the `meta` device
-
-                for name, param in bt_model.named_parameters():
-                    self.assertFalse(param.device.type == "meta", f"Parameter {name} is on the meta device.")
-
-                bt_model.save_pretrained(tmpdirname)
-
-                bt_model_from_load = AutoModel.from_pretrained(tmpdirname)
-
-                # check if the state dict is the same
-                # first check if the keys are the same
-                self.assertEqual(
-                    set(bt_model.state_dict().keys()),
-                    set(bt_model_from_load.state_dict().keys()),
-                )
-                # check also with HF model
-                self.assertEqual(
-                    set(hf_model.state_dict().keys()),
-                    set(bt_model_from_load.state_dict().keys()),
+            for key in bt_model.state_dict().keys():
+                self.assertTrue(
+                    torch.allclose(
+                        bt_model.state_dict()[key],
+                        bt_model_from_load.state_dict()[key],
+                    )
                 )
 
-                for key in bt_model.state_dict().keys():
-                    self.assertTrue(
-                        torch.allclose(
-                            bt_model.state_dict()[key],
-                            bt_model_from_load.state_dict()[key],
-                        )
+                self.assertTrue(
+                    torch.allclose(
+                        hf_model.state_dict()[key],
+                        bt_model_from_load.state_dict()[key],
                     )
+                )
 
-                    self.assertTrue(
-                        torch.allclose(
-                            hf_model.state_dict()[key],
-                            bt_model_from_load.state_dict()[key],
-                        )
-                    )
-
-    @parameterized.expand([(True,), (False,)])
-    def test_invert_model_logits(self, keep_original_model=True):
+    def test_invert_model_logits(self, model_id, keep_original_model=True, **preprocessor_kwargs):
         r"""
         Test that the inverse converted model and hf model have the same logits
         """
-        for model in self.all_models_to_test:
-            # get hf and bt model
-            hf_model = AutoModel.from_pretrained(model)
-            # get bt model and invert it
-            bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
-            bt_model = BetterTransformer.reverse(bt_model)
+        # get hf and bt model
+        hf_model = AutoModel.from_pretrained(model_id)
+        # get bt model and invert it
+        bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+        bt_model = BetterTransformer.reverse(bt_model)
 
-            # get inputs
-            inputs = self.prepare_inputs_for_class(model)
+        # get inputs
+        inputs = self.prepare_inputs_for_class(model_id, **preprocessor_kwargs)
 
-            # get outputs
-            torch.manual_seed(42)
-            output_bt = bt_model(**inputs)
+        # get outputs
+        torch.manual_seed(42)
+        output_bt = bt_model(**inputs)
 
-            torch.manual_seed(42)
-            output_hf = hf_model(**inputs)
+        torch.manual_seed(42)
+        output_hf = hf_model(**inputs)
 
-            # Assert that the outputs are the same
-            self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))
+        # Assert that the outputs are the same
+        self.assertTrue(torch.allclose(output_bt[0], output_hf[0], atol=1e-3))
 
-    @parameterized.expand([(True,), (False,)])
-    def test_raise_save_pretrained_error(self, keep_original_model=True):
+    def test_raise_save_pretrained_error(self, model_id, keep_original_model=True):
         r"""
         Test if the converted model raises an error when calling `save_pretrained`
         but not when the model is reverted
         """
-        for model in self.all_models_to_test:
-            # get hf and bt model
-            hf_model = AutoModel.from_pretrained(model)
-            # get bt model and invert it
-            bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
+        # get hf and bt model
+        hf_model = AutoModel.from_pretrained(model_id)
+        # get bt model and invert it
+        bt_model = BetterTransformer.transform(hf_model, keep_original_model=keep_original_model)
 
-            with self.assertRaises(ValueError), tempfile.TemporaryDirectory() as tmpdirname:
-                bt_model.save_pretrained(tmpdirname)
+        with self.assertRaises(ValueError), tempfile.TemporaryDirectory() as tmpdirname:
+            bt_model.save_pretrained(tmpdirname)
 
-            # revert model and save it
-            bt_model = BetterTransformer.reverse(bt_model)
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                bt_model.save_pretrained(tmpdirname)
+        # revert model and save it
+        bt_model = BetterTransformer.reverse(bt_model)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            bt_model.save_pretrained(tmpdirname)
 
 
 def get_batch(batch_size, avg_seqlen, max_sequence_length, seqlen_stdev, vocab_size, pad_idx=0):


### PR DESCRIPTION
This PR adds the `inverse_transform` support for BT-transformed models. 
In the future, PyTorch will support `BetterTransformer` for training. Therefore a user would want to first convert a model, train it with `BetterTransformer` as backend and save the trained model afterwards. Before this PR the keys of the model's state dict are changed, therefore saving the model out of the box would break the model architecture and support with `transformers`. This PR adds a new transformation `invert_transform` that will let users convert back the BT model in its original format so that they can push/save their model.

## TODOs:

- [x] stronger API regarding saving-related methods (block `save_pretrained`, `push_to_hub` etc for converted models)
- [x] leverage copy mechanism (`# Copied from ...`)
- [x] more tests?

cc @fxmarty @michaelbenayoun @HamidShojanazeri