### PR TITLE
Add support for LongT5 optimization using ORT transformer optimizer script

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -263,7 +263,7 @@ class MT5OnnxConfig(T5OnnxConfig):
 
 
 class LongT5OnnxConfig(T5OnnxConfig):
-    pass
+    DEFAULT_ONNX_OPSET = 14
 
 
 class BartDummyTextInputGenerator(DummyTextInputGenerator):

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -88,6 +88,7 @@ class ORTConfigManager:
         "electra": "bert",
         "gpt2": "gpt2",
         "gpt_neo": "gpt2",
+        "longt5": "bert",
         "marian": "bart",
         "mbart": "bart",
         "mt5": "bart",

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -188,6 +188,7 @@ class NormalizedConfigManager:
         "gpt2": GPT2LikeNormalizedTextConfig,
         "gpt_neo": NormalizedTextConfig.with_args(num_attention_heads="num_heads"),
         "gptj": GPT2LikeNormalizedTextConfig,
+        "longt5": T5LikeNormalizedTextConfig,
         "marian": BartLikeNormalizedTextConfig,
         "mbart": BartLikeNormalizedTextConfig,
         "mt5": T5LikeNormalizedTextConfig,

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -72,6 +72,8 @@ class ORTOptimizerTest(unittest.TestCase):
     SUPPORTED_SEQ2SEQ_ARCHITECTURES_WITH_MODEL_ID = (
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-bart", False),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-bart", True),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-LongT5ForConditionalGeneration", False),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-LongT5ForConditionalGeneration", True),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-marian", False),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-marian", True),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-mbart", False),


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR adds support for optimizing LongT5 using the ORT transformer optimizer script.

Example usage:
```
from optimum.onnxruntime import ORTModelForSeq2SeqLM, AutoOptimizationConfig, ORTOptimizer
import torch
import time

model_name = 'google/long-t5-local-base'
device = 'cuda'
batch_size = 4
sequence_length = 16
inputs = {
     'input_ids': torch.ones((batch_size, sequence_length), dtype=torch.int64).to(device),
     'attention_mask': torch.ones((batch_size, sequence_length), dtype=torch.int64).to(device),
     'decoder_input_ids': torch.ones((batch_size, sequence_length), dtype=torch.int64).to(device)
}

model = ORTModelForSeq2SeqLM.from_pretrained(model_name, from_transformers=True, use_io_binding=True, provider='CUDAExecutionProvider')
start_time = time.time()
outputs_before = model(**inputs)
end_time = time.time()
print(f"Latency before optimization: {end_time - start_time}")

optimized_dir = './long-t5-local-base-optimized'
config = AutoOptimizationConfig.with_optimization_level('O3', for_gpu=True)
optimizer = ORTOptimizer.from_pretrained(model)
optimizer.optimize(save_dir=optimized_dir, optimization_config=config)

model_optimized = ORTModelForSeq2SeqLM.from_pretrained(optimized_dir, use_io_binding=True, provider='CUDAExecutionProvider')
start_time = time.time()
outputs_after = model_optimized(**inputs)
end_time = time.time()
print(f"Latency after optimization: {end_time - start_time}")

print(f"Are logits close? {torch.allclose(outputs_before.logits, outputs_after.logits)}")
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

