### PR TITLE
Avoid initializing unwanted attributes for ORTModel's having several inference sessions

### DIFF
--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -363,6 +363,7 @@ class ORTModelDecoder(ORTModel):
             use_io_binding=use_io_binding,
             model_save_dir=model_save_dir,
         )
+        self.config = config
 
         # TODO: remove at version 2.0
         def show_deprecated_argument(arg_name):

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -358,6 +358,12 @@ class ORTModelDecoder(ORTModel):
             preprocessors (`Optional[List]`, defaults to `None`):
                 The list of the preprocessors (tokenizer, processor, feature_extractor) to save alongside the ORTModel.
         """
+        self.shared_attributes_init(
+            decoder_session,
+            use_io_binding=use_io_binding,
+            model_save_dir=model_save_dir,
+        )
+
         # TODO: remove at version 2.0
         def show_deprecated_argument(arg_name):
             if kwargs.pop(arg_name, None) is not None:
@@ -373,12 +379,6 @@ class ORTModelDecoder(ORTModel):
                 f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
             )
 
-        super().__init__(
-            decoder_session,
-            config,
-            use_io_binding=use_io_binding,
-            model_save_dir=model_save_dir,
-        )
         self.use_cache = decoder_with_past_session is not None
         self.decoder = ORTDecoder(
             session=decoder_session, config=self.config, device=self._device, use_io_binding=self.use_io_binding

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -767,14 +767,14 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
 
         ABC.__init__(self)
 
-        ORTModel.__init__(
+        self.shared_attributes_init(
             self,
             encoder_session,
-            config,
             use_io_binding=use_io_binding,
             model_save_dir=model_save_dir,
             preprocessors=preprocessors,
         )
+
         self.encoder = self._initialize_encoder(
             session=encoder_session, config=self.config, device=self._device, use_io_binding=self.use_io_binding
         )

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -768,7 +768,6 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         ABC.__init__(self)
 
         self.shared_attributes_init(
-            self,
             encoder_session,
             use_io_binding=use_io_binding,
             model_save_dir=model_save_dir,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -774,6 +774,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             model_save_dir=model_save_dir,
             preprocessors=preprocessors,
         )
+        self.config = config
 
         self.encoder = self._initialize_encoder(
             session=encoder_session, config=self.config, device=self._device, use_io_binding=self.use_io_binding


### PR DESCRIPTION
Attributes as `self.model`, `self.model_name`, `self.model_path` are unwanted and actually may take some RAM for no reason.

