### PR TITLE
Fix the ORTQuantizer loading from specific file

### DIFF
--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -134,7 +134,7 @@ class ORTQuantizer(OptimumQuantizer):
 
         if isinstance(model_or_path, ORTModelForConditionalGeneration):
             raise ValueError(ort_quantizer_error_message)
-        elif isinstance(model_or_path, Path):
+        elif isinstance(model_or_path, Path) and file_name is None:
             onnx_files = list(model_or_path.glob("*.onnx"))
             if len(onnx_files) == 0:
                 raise FileNotFoundError(f"Could not find any ONNX model file in {model_or_path}")


### PR DESCRIPTION
The `file_name` parameter of the `ORTQuantizer` `from_pretrained` method is currently discarded when it should be used if given by the users : resulting in errors when quantizing a seq2seq model as done in the current [documentation](https://huggingface.co/docs/optimum/onnxruntime/usage_guides/quantization#quantize-seq2seq-models)
 