### PR TITLE
Add ORTModelForVision2Seq for VisionEncoderDecoder models inference

### DIFF
--- a/docs/source/onnxruntime/package_reference/modeling_ort.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_ort.mdx
@@ -62,3 +62,7 @@ specific language governing permissions and limitations under the License.
 ## ORTModelForTokenClassification
 
 [[autodoc]] onnxruntime.ORTModelForTokenClassification
+
+## ORTModelForVision2Seq
+
+[[autodoc]] onnxruntime.ORTModelForVision2Seq

--- a/docs/source/onnxruntime/usage_guides/pipelines.mdx
+++ b/docs/source/onnxruntime/usage_guides/pipelines.mdx
@@ -24,6 +24,7 @@ Currently the supported tasks are:
 * `translation`
 * `image-classification`
 * `automatic-speech-recognition`
+* `image-to-text`
 
 ## Optimum pipeline usage
 

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -39,7 +39,7 @@ _import_structure = {
         "ORTModelForSequenceClassification",
         "ORTModelForTokenClassification",
     ],
-    "modeling_seq2seq": ["ORTModelForSeq2SeqLM", "ORTModelForSpeechSeq2Seq"],
+    "modeling_seq2seq": ["ORTModelForSeq2SeqLM", "ORTModelForSpeechSeq2Seq", "ORTModelForVision2Seq"],
     "modeling_decoder": ["ORTModelForCausalLM"],
     "optimization": ["ORTOptimizer"],
     "quantization": ["ORTQuantizer"],

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -115,10 +115,10 @@ class ORTDecoder(ORTModelPart):
         if len(self.key_value_output_names) == 0:
             self.key_value_output_names = [key for key in self.output_names if "key_values" in key]
 
-        if self.parent_model.use_cache is True or len(self.key_value_output_names) != 0:
-            if len(self.key_value_output_names) == 0:
-                raise RuntimeError("Could not find the past key values in the provided model.")
+        if self.parent_model.use_cache is True and len(self.key_value_output_names) == 0:
+            raise RuntimeError("Could not find the past key values in the provided model.")
 
+        if len(self.key_value_output_names) != 0:
             # Attributes useful when computing the past key/values output shapes.
             self.expected_key_symbolic_shape = None
             self.expected_value_symbolic_shape = None

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -114,7 +114,6 @@ class ORTDecoder(ORTModelPart):
             self.key_value_input_names = [key for key in self.input_names if "key_values" in key]
         if len(self.key_value_output_names) == 0:
             self.key_value_output_names = [key for key in self.output_names if "key_values" in key]
-        # from pdb import set_trace; set_trace()
 
         if self.parent_model.use_cache is True or len(self.key_value_output_names) != 0:
             if len(self.key_value_output_names) == 0:

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -114,40 +114,42 @@ class ORTDecoder(ORTModelPart):
             self.key_value_input_names = [key for key in self.input_names if "key_values" in key]
         if len(self.key_value_output_names) == 0:
             self.key_value_output_names = [key for key in self.output_names if "key_values" in key]
+        # from pdb import set_trace; set_trace()
 
-        if len(self.key_value_output_names) == 0:
-            raise RuntimeError("Could not find the past key values in the provided model.")
+        if self.parent_model.use_cache is True or len(self.key_value_output_names) != 0:
+            if len(self.key_value_output_names) == 0:
+                raise RuntimeError("Could not find the past key values in the provided model.")
 
-        # Attributes useful when computing the past key/values output shapes.
-        self.expected_key_symbolic_shape = None
-        self.expected_value_symbolic_shape = None
-        for output in self.session.get_outputs():
-            if ".key" in output.name:
-                self.expected_key_symbolic_shape = output.shape
-            elif ".value" in output.name:
-                self.expected_value_symbolic_shape = output.shape
-            # To handle the old case when past_key_values were following the format: past_key_values_{idx}
-            elif "key_values" in output.name:
-                if self.expected_key_symbolic_shape is None:
+            # Attributes useful when computing the past key/values output shapes.
+            self.expected_key_symbolic_shape = None
+            self.expected_value_symbolic_shape = None
+            for output in self.session.get_outputs():
+                if ".key" in output.name:
                     self.expected_key_symbolic_shape = output.shape
-                else:
+                elif ".value" in output.name:
                     self.expected_value_symbolic_shape = output.shape
-            if self.expected_key_symbolic_shape is not None and self.expected_value_symbolic_shape is not None:
-                break
+                # To handle the old case when past_key_values were following the format: past_key_values_{idx}
+                elif "key_values" in output.name:
+                    if self.expected_key_symbolic_shape is None:
+                        self.expected_key_symbolic_shape = output.shape
+                    else:
+                        self.expected_value_symbolic_shape = output.shape
+                if self.expected_key_symbolic_shape is not None and self.expected_value_symbolic_shape is not None:
+                    break
 
-        self.key_sequence_length_idx = -2
-        if (
-            isinstance(self.expected_key_symbolic_shape[-1], str)
-            and "sequence_length" in self.expected_key_symbolic_shape[-1]
-        ):
-            self.key_sequence_length_idx = -1
+            self.key_sequence_length_idx = -2
+            if (
+                isinstance(self.expected_key_symbolic_shape[-1], str)
+                and "sequence_length" in self.expected_key_symbolic_shape[-1]
+            ):
+                self.key_sequence_length_idx = -1
 
-        self.value_sequence_length_idx = -2
-        if (
-            isinstance(self.expected_value_symbolic_shape[-1], str)
-            and "sequence_length" in self.expected_value_symbolic_shape[-1]
-        ):
-            self.value_sequence_length_idx = -1
+            self.value_sequence_length_idx = -2
+            if (
+                isinstance(self.expected_value_symbolic_shape[-1], str)
+                and "sequence_length" in self.expected_value_symbolic_shape[-1]
+            ):
+                self.value_sequence_length_idx = -1
 
     def compute_past_key_values_output_shapes(
         self, input_ids: torch.Tensor, past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -58,7 +58,7 @@ DECODER_INPUTS_DOCSTRING = r"""
         attention_mask (`torch.LongTensor`, *optional*):
             Mask to avoid performing attention on padding token indices, of shape
             `(batch_size, sequence_length)`. Mask values selected in `[0, 1]`.
-        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*, defaults to `None`)`
             Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
             The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`.
@@ -71,7 +71,7 @@ CAUSALLM_ONNX_MODEL_DOCSTRING = r"""
         attention_mask (`torch.LongTensor`):
             Mask to avoid performing attention on padding token indices, of shape
             `(batch_size, sequence_length)`. Mask values selected in `[0, 1]`.
-        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*, defaults to `None`)`
             Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
             The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`.

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -271,13 +271,6 @@ class ORTEncoderForVisionEncoderDecoder(ORTEncoder):
             The ONNX Runtime inference session associated to the encoder.
     """
 
-    # def __init__(self, session: InferenceSession, parent_model: "ORTModel"):
-    #     super().__init__(session, parent_model)
-
-    #     self.normalized_config = NormalizedConfigManager.get_normalized_config_class(
-    #         self.parent_model.config.encoder.model_type
-    #     )(self.parent_model.config.encoder)
-
     @add_start_docstrings_to_model_forward(VISION_ENCODER_INPUTS_DOCSTRING)
     def forward(
         self,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -24,18 +24,20 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
-from transformers import AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq, GenerationConfig
+from transformers import AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq, AutoModelForVision2Seq, GenerationConfig
 from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 
 import onnxruntime as ort
 from huggingface_hub import hf_hub_download
+from onnxruntime import InferenceSession
 
 from ..exporters.onnx import export_models, get_encoder_decoder_models_for_export
 from ..exporters.tasks import TasksManager
 from ..onnx.utils import _get_external_data_paths
 from ..utils import check_if_transformers_greater
 from ..utils.file_utils import validate_file_exists
+from ..utils.normalized_config import NormalizedConfigManager
 from ..utils.save_utils import maybe_load_preprocessors, maybe_save_preprocessors
 from .base import ORTDecoder, ORTDecoderForSeq2Seq, ORTEncoder
 from .modeling_ort import ORTModel
@@ -79,6 +81,12 @@ WHISPER_ENCODER_INPUTS_DOCSTRING = r"""
             Mel features extracted from the raw speech waveform. `(batch_size, feature_size, encoder_sequence_length)`.
 """
 
+VISION_ENCODER_INPUTS_DOCSTRING = r"""
+    Args:
+        pixel_values (`torch.FloatTensor`):
+            Featuers extracted from an Image. `(batch_size, num_channels, height, width)`.
+"""
+
 
 DECODER_INPUTS_DOCSTRING = r"""
     Args:
@@ -119,6 +127,22 @@ SPEECH_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
         input_features (`torch.FloatTensor`):
             Mel features extracted from the raw speech waveform.
             `(batch_size, feature_size, encoder_sequence_length)`.
+        decoder_input_ids (`torch.LongTensor`):
+            Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, decoder_sequence_length)`.
+        encoder_outputs (`torch.FloatTensor`):
+            The encoder `last_hidden_state` of shape `(batch_size, encoder_sequence_length, hidden_size)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+            Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
+            The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, decoder_sequence_length, embed_size_per_head)` and 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+"""
+
+VISION_ENCODER_DECODER_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
+    Args:
+        pixel_values (`torch.FloatTensor`):
+            Featuers extracted from an Image.
+            `(batch_size, num_channels, height, width)`.
         decoder_input_ids (`torch.LongTensor`):
             Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, decoder_sequence_length)`.
         encoder_outputs (`torch.FloatTensor`):
@@ -238,6 +262,47 @@ class ORTEncoderForWhisper(ORTEncoder):
         return BaseModelOutput(last_hidden_state=last_hidden_state)
 
 
+class ORTEncoderForVisionEncoderDecoder(ORTEncoder):
+    """
+    Encoder model for ONNX Runtime inference for VisionEncoderDecoder models.
+
+    Args:
+        session (`ort.InferenceSession`):
+            The ONNX Runtime inference session associated to the encoder.
+    """
+
+    # def __init__(self, session: InferenceSession, parent_model: "ORTModel"):
+    #     super().__init__(session, parent_model)
+
+    #     self.normalized_config = NormalizedConfigManager.get_normalized_config_class(
+    #         self.parent_model.config.encoder.model_type
+    #     )(self.parent_model.config.encoder)
+
+    @add_start_docstrings_to_model_forward(VISION_ENCODER_INPUTS_DOCSTRING)
+    def forward(
+        self,
+        pixel_values: torch.FloatTensor,
+        **kwargs,
+    ) -> BaseModelOutput:
+        if self.parent_model.device.type == "cuda" and self.parent_model.use_io_binding:
+            io_binding, output_shapes, output_buffers = self.parent_model._prepare_io_binding(
+                self.session, pixel_values
+            )
+
+            io_binding.synchronize_inputs()
+            self.session.run_with_iobinding(io_binding)
+            io_binding.synchronize_outputs()
+
+            last_hidden_state = output_buffers["last_hidden_state"].view(output_shapes["last_hidden_state"])
+        else:
+            onnx_inputs = {"pixel_values": pixel_values.cpu().detach().numpy()}
+
+            outputs = self.session.run(None, onnx_inputs)
+            last_hidden_state = torch.from_numpy(outputs[self.output_names["last_hidden_state"]]).to(self.device)
+
+        return BaseModelOutput(last_hidden_state=last_hidden_state)
+
+
 class ORTModelForConditionalGeneration(ORTModel, ABC):
     """
     Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
@@ -335,6 +400,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             preprocessors=preprocessors,
         )
         self.config = config
+        self.use_cache = decoder_with_past_session is not None
 
         self.encoder = self._initialize_encoder(encoder_session)
         self.encoder_model_path = Path(encoder_session._model_path)
@@ -343,8 +409,6 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         self.decoder = ORTDecoderForSeq2Seq(decoder_session, self)
         self.decoder_model_path = Path(decoder_session._model_path)
         self.decoder_model_name = self.decoder_model_path.name
-
-        self.use_cache = decoder_with_past_session is not None
 
         # If a decoder_with_past_path is provided, an inference session for the decoder with past key/values as inputs
         # will be enabled
@@ -884,6 +948,133 @@ class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin
         # Encode if needed : first prediction pass
         if encoder_outputs is None:
             encoder_outputs = self.encoder(input_features=input_features)
+
+        # Decode
+        if past_key_values is None or self.decoder_with_past is None:
+            decoder_outputs = self.decoder(
+                input_ids=decoder_input_ids,
+                encoder_hidden_states=encoder_outputs.last_hidden_state,
+                labels=labels,
+            )
+        else:
+            decoder_outputs = self.decoder_with_past(
+                input_ids=decoder_input_ids[:, -1:],  # Cut decoder_input_ids if past is used
+                past_key_values=past_key_values,
+                encoder_hidden_states=encoder_outputs.last_hidden_state,
+                labels=labels,
+            )
+
+        return Seq2SeqLMOutput(
+            loss=decoder_outputs.get("loss", None),
+            logits=decoder_outputs.logits,
+            past_key_values=decoder_outputs.past_key_values,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past=None,
+        head_mask=None,
+        decoder_head_mask=None,
+        cross_attn_head_mask=None,
+        use_cache=None,
+        encoder_outputs=None,
+        **kwargs
+    ) -> Dict:
+
+        return {
+            "decoder_input_ids": input_ids,
+            "past_key_values": past,
+            "encoder_outputs": encoder_outputs,
+            "head_mask": head_mask,
+            "decoder_head_mask": decoder_head_mask,
+            "cross_attn_head_mask": cross_attn_head_mask,
+            "use_cache": use_cache,
+        }
+
+    def get_encoder(self) -> ORTEncoder:
+        return self.encoder
+
+    # Copied from transformers.models.bart.modeling_bart.BartForConditionalGeneration._reorder_cache
+    @staticmethod
+    def _reorder_cache(past, beam_idx) -> Tuple[Tuple[torch.FloatTensor]]:
+        reordered_past = ()
+        for layer_past in past:
+            # Cached cross_attention states don't have to be reordered -> they are always the same
+            reordered_past += (
+                tuple(past_state.index_select(0, beam_idx) for past_state in layer_past[:2]) + layer_past[2:],
+            )
+        return reordered_past
+
+    def can_generate(self):
+        """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
+        return True
+
+
+class ORTModelForVision2Seq(ORTModelForConditionalGeneration, GenerationMixin):
+    """
+    Speech Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
+    """
+
+    auto_model_class = AutoModelForVision2Seq
+    main_input_name = "pixel_values"
+
+    def __init__(
+        self,
+        encoder_session: ort.InferenceSession,
+        decoder_session: ort.InferenceSession,
+        config: "PretrainedConfig",
+        decoder_with_past_session: Optional[ort.InferenceSession] = None,
+        use_io_binding: Optional[bool] = None,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        preprocessors: Optional[List] = None,
+        generation_config: Optional[GenerationConfig] = None,
+        **kwargs
+    ):
+        super().__init__(
+            encoder_session,
+            decoder_session,
+            config,
+            decoder_with_past_session,
+            use_io_binding,
+            model_save_dir,
+            preprocessors,
+            generation_config,
+            **kwargs,
+        )
+
+        self.encoder.normalized_config = NormalizedConfigManager.get_normalized_config_class(
+            config.encoder.model_type
+        )(config.encoder)
+
+        self.decoder.normalized_config = NormalizedConfigManager.get_normalized_config_class(
+            config.decoder.model_type
+        )(config.decoder)
+
+    def _initialize_encoder(self, session: ort.InferenceSession) -> ORTEncoder:
+        return ORTEncoderForVisionEncoderDecoder(session, self)
+
+    @add_start_docstrings_to_model_forward(
+        VISION_ENCODER_DECODER_SEQ2SEQ_ONNX_MODEL_DOCSTRING.format("batch_size, num_channels, height, width")
+        + AUTOMATIC_SPEECH_RECOGNITION_EXAMPLE.format(
+            processor_class=_PROCESSOR_FOR_DOC,
+            model_class="ORTModelForVision2Seq",
+            checkpoint="nlpconnect/vit-gpt2-image-captioning",
+        )
+    )
+    def forward(
+        self,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        decoder_input_ids: Optional[torch.LongTensor] = None,
+        encoder_outputs: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        labels: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Seq2SeqLMOutput:
+
+        # Encode if needed : first prediction pass
+        if encoder_outputs is None:
+            encoder_outputs = self.encoder(pixel_values=pixel_values)
 
         # Decode
         if past_key_values is None or self.decoder_with_past is None:

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -1006,7 +1006,7 @@ class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin
 
 class ORTModelForVision2Seq(ORTModelForConditionalGeneration, GenerationMixin):
     """
-    Speech Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
+    VisionEncoderDecoder Sequence-to-sequence model with a language modeling head for ONNX Runtime inference.
     """
 
     auto_model_class = AutoModelForVision2Seq

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -84,7 +84,7 @@ WHISPER_ENCODER_INPUTS_DOCSTRING = r"""
 VISION_ENCODER_INPUTS_DOCSTRING = r"""
     Args:
         pixel_values (`torch.FloatTensor`):
-            Featuers extracted from an Image. `(batch_size, num_channels, height, width)`.
+            Features extracted from an Image. This tensor should be of shape `(batch_size, num_channels, height, width)`.
 """
 
 
@@ -141,7 +141,7 @@ SPEECH_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
 VISION_ENCODER_DECODER_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
     Args:
         pixel_values (`torch.FloatTensor`):
-            Featuers extracted from an Image.
+            Features extracted from an Image. This tensor should be of shape 
             `(batch_size, num_channels, height, width)`.
         decoder_input_ids (`torch.LongTensor`):
             Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, decoder_sequence_length)`.
@@ -156,6 +156,7 @@ VISION_ENCODER_DECODER_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
 
 _TOKENIZER_FOR_DOC = "AutoTokenizer"
 _PROCESSOR_FOR_DOC = "AutoProcessor"
+_IMAGE_PROCESSOER_FOR_DOC = "AutoImageProcessor"
 
 TRANSLATION_EXAMPLE = r"""
     Example of text generation:
@@ -220,6 +221,51 @@ AUTOMATIC_SPEECH_RECOGNITION_EXAMPLE = r"""
 
     >>> ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
     >>> pred = speech_recognition(ds[0]["audio"]["array"])
+    ```
+"""
+
+
+IMAGE_TO_TEXT_EXAMPLE = r"""
+    Example of text generation:
+
+    ```python
+    >>> from transformers import {processor_class}, {tokenizer_class}
+    >>> from optimum.onnxruntime import {model_class}
+    >>> from PIL import Image
+    >>> import requests
+
+
+    >>> processor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> tokenizer = {tokenizer_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}", from_transformers=True)
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> image = Image.open(requests.get(url, stream=True).raw)
+    >>> inputs = processor(image, return_tensors="pt")
+
+    >>> gen_tokens = model.generate(**inputs)
+    >>> outputs = tokenizer.batch_decode(gen_tokens, skip_special_tokens=True)
+
+    ```
+
+    Example using `transformers.pipeline`:
+
+    ```python
+    >>> from transformers import {processor_class}, {tokenizer_class}, pipeline
+    >>> from optimum.onnxruntime import {model_class}
+    >>> from PIL import Image
+    >>> import requests
+
+
+    >>> processor = {processor_class}.from_pretrained("{checkpoint}")
+    >>> tokenizer = {tokenizer_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}", from_transformers=True)
+
+    >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    >>> image = Image.open(requests.get(url, stream=True).raw)
+
+    >>> image_to_text = pipeline("image-to-text", model=model, tokenizer=tokenizer, feature_extractor=processor, image_processor=processor)
+    >>> pred = image_to_text(image)
     ```
 """
 
@@ -1049,8 +1095,9 @@ class ORTModelForVision2Seq(ORTModelForConditionalGeneration, GenerationMixin):
 
     @add_start_docstrings_to_model_forward(
         VISION_ENCODER_DECODER_SEQ2SEQ_ONNX_MODEL_DOCSTRING.format("batch_size, num_channels, height, width")
-        + AUTOMATIC_SPEECH_RECOGNITION_EXAMPLE.format(
-            processor_class=_PROCESSOR_FOR_DOC,
+        + IMAGE_TO_TEXT_EXAMPLE.format(
+            processor_class=_IMAGE_PROCESSOER_FOR_DOC,
+            tokenizer_class=_TOKENIZER_FOR_DOC,
             model_class="ORTModelForVision2Seq",
             checkpoint="nlpconnect/vit-gpt2-image-captioning",
         )

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -96,7 +96,7 @@ DECODER_INPUTS_DOCSTRING = r"""
             The encoder `last_hidden_state` of shape `(batch_size, encoder_sequence_length, hidden_size)`.
         encoder_attention_mask (`torch.LongTensor`, *optional*):
             Mask to avoid performing cross-attention on padding tokens indices of encoder `input_ids`.
-        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*, defaults to `None`)`
             Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
             The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
             `(batch_size, num_heads, decoder_sequence_length, embed_size_per_head)` and 2 additional tensors of shape
@@ -114,7 +114,7 @@ SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
             Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, decoder_sequence_length)`.
         encoder_outputs (`torch.FloatTensor`):
             The encoder `last_hidden_state` of shape `(batch_size, encoder_sequence_length, hidden_size)`.
-        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*, defaults to `None`)`
             Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
             The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
             `(batch_size, num_heads, decoder_sequence_length, embed_size_per_head)` and 2 additional tensors of shape
@@ -131,7 +131,7 @@ SPEECH_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
             Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, decoder_sequence_length)`.
         encoder_outputs (`torch.FloatTensor`):
             The encoder `last_hidden_state` of shape `(batch_size, encoder_sequence_length, hidden_size)`.
-        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*, defaults to `None`)`
             Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
             The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
             `(batch_size, num_heads, decoder_sequence_length, embed_size_per_head)` and 2 additional tensors of shape
@@ -147,7 +147,7 @@ VISION_ENCODER_DECODER_SEQ2SEQ_ONNX_MODEL_DOCSTRING = r"""
             Indices of decoder input sequence tokens in the vocabulary of shape `(batch_size, decoder_sequence_length)`.
         encoder_outputs (`torch.FloatTensor`):
             The encoder `last_hidden_state` of shape `(batch_size, encoder_sequence_length, hidden_size)`.
-        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*)`
+        past_key_values (`tuple(tuple(torch.FloatTensor), *optional*, defaults to `None`)`
             Contains the precomputed key and value hidden states of the attention blocks used to speed up decoding.
             The tuple is of length `config.n_layers` with each tuple having 2 tensors of shape
             `(batch_size, num_heads, decoder_sequence_length, embed_size_per_head)` and 2 additional tensors of shape

--- a/optimum/pipelines.py
+++ b/optimum/pipelines.py
@@ -22,6 +22,7 @@ from transformers import (
     FillMaskPipeline,
     ImageClassificationPipeline,
     ImageSegmentationPipeline,
+    ImageToTextPipeline,
     Pipeline,
     PreTrainedTokenizer,
     PreTrainedTokenizerFast,
@@ -58,6 +59,7 @@ if is_onnxruntime_available():
         ORTModelForSequenceClassification,
         ORTModelForSpeechSeq2Seq,
         ORTModelForTokenClassification,
+        ORTModelForVision2Seq,
     )
     from .onnxruntime.modeling_ort import ORTModel
 
@@ -138,6 +140,12 @@ if is_onnxruntime_available():
             "impl": AutomaticSpeechRecognitionPipeline,
             "class": (ORTModelForSpeechSeq2Seq,),
             "default": "openai/whisper-tiny.en",
+            "type": "multimodal",
+        },
+        "image-to-text": {
+            "impl": ImageToTextPipeline,
+            "class": (ORTModelForVision2Seq,),
+            "default": "nlpconnect/vit-gpt2-image-captioning",
             "type": "multimodal",
         },
     }

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -133,6 +133,13 @@ WhisperLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
     hidden_size="d_model",
 )
 
+TrOCRLikeNormalizedTextConfig = NormalizedSeq2SeqConfig.with_args(
+    decoder_num_layers="decoder_layers",
+    num_layers="decoder_layers",
+    decoder_num_attention_heads="decoder_attention_heads",
+    hidden_size="cross_attention_hidden_size",
+)
+
 
 class NormalizedConfigManager:
     """
@@ -166,7 +173,6 @@ class NormalizedConfigManager:
         'roformer',
         'segformer',
         'squeezebert',
-        'vit',
     """
 
     # Contribution note: Please add new models in alphabetical order
@@ -200,7 +206,10 @@ class NormalizedConfigManager:
         "roberta": NormalizedTextConfig,
         "splinter": NormalizedTextConfig,
         "t5": T5LikeNormalizedTextConfig,
+        "trocr": TrOCRLikeNormalizedTextConfig,
         "whisper": WhisperLikeNormalizedTextConfig,
+        "vision-encoder-decoder": NormalizedEncoderDecoderConfig,
+        "vit": NormalizedVisionConfig,
         "xlm-roberta": NormalizedTextConfig,
         "yolos": NormalizedVisionConfig,
     }

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -189,6 +189,7 @@ class NormalizedConfigManager:
         "codegen": GPT2LikeNormalizedTextConfig,
         "deberta": NormalizedTextConfig,
         "deberta-v2": NormalizedTextConfig,
+        "deit": NormalizedVisionConfig,
         "distilbert": NormalizedTextConfig.with_args(num_attention_heads="n_heads", hidden_size="dim"),
         "electra": NormalizedTextConfig,
         "gpt2": GPT2LikeNormalizedTextConfig,

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -158,7 +158,6 @@ class NormalizedConfigManager:
         'convnext',
         'data2vec-text',
         'data2vec-vision',
-        'deit',
         'detr',
         'flaubert',
         'groupvit',

--- a/optimum/utils/testing_utils.py
+++ b/optimum/utils/testing_utils.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 import unittest
-from typing import Any, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 from packaging import version
 
@@ -102,7 +102,10 @@ def require_diffusers(test_case):
 
 
 def grid_parameters(
-    parameters: Dict[str, Iterable[Any]], yield_dict: bool = False, add_test_name: bool = True
+    parameters: Dict[str, Iterable[Any]],
+    yield_dict: bool = False,
+    add_test_name: bool = True,
+    filter_params_func: Optional[Callable[[Tuple], Tuple]] = None,
 ) -> Iterable:
     """
     Generates an iterable over the grid of all combinations of parameters.
@@ -114,8 +117,16 @@ def grid_parameters(
             If True, a dictionary with all keys, and sampled values will be returned. Otherwise, return sampled values as a list.
         `add_test_name` (`bool`, defaults to `True`):
             Whether to add the test name in the yielded list or dictionary.
+        filter_params_func (`Optional[Callable[[Tuple], Tuple]]`, defaults to `None`):
+            A function that can modify or exclude the current set of parameters. The function should take a tuple of the
+            parameters and return the same. If a parameter set is to be excluded, the function should return an empty tuple.
     """
     for params in itertools.product(*parameters.values()):
+        if filter_params_func is not None:
+            params = filter_params_func(list(params))
+            if params is None:
+                continue
+
         test_name = "_".join([str(param) for param in params])
         if yield_dict is True:
             res_dict = {}


### PR DESCRIPTION
# What does this PR do?

This PR enables the inference of the `VisionEncoderDecoder` models using ONNXRuntime. The PR adds `ORTModelForVision2Seq` for doing inference similar to `AutoModelForVision2Seq` by changing just a few lines.

# Usage

```diff
>>> from PIL import Image
>>> from transformers import GPT2TokenizerFast, ViTImageProcessor
->>>  from transformers import AutoModelForVision2Seq
+>>>  from optimum.onnxruntime import ORTModelForVision2Seq
>>> import requests

>>> model_name = "nlpconnect/vit-gpt2-image-captioning"
->>> model = AutoModelForVision2Seq.from_pretrained(model_name)
+>>> model = ORTModelForVision2Seq.from_pretrained(model_name, from_transformers=True)
>>> tokenizer = GPT2TokenizerFast.from_pretrained(model_name)
>>> image_processor = ViTImageProcessor.from_pretrained(model_name)

>>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
>>> image = Image.open(requests.get(url, stream=True).raw)
>>> pixel_values = image_processor(image, return_tensors="pt").pixel_values

>>> generated_ids = model.generate(pixel_values)
>>> generated_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
>>> print(generated_text)
```

## Limitations
- `Donut` model not supported
- `TrOCR` model not supported with `use_cache=True`.
-  IObinding not supported

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
