### PR TITLE
Fix speech2text export

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -973,8 +973,9 @@ class Speech2TextOnnxConfig(AudioToTextOnnxConfig):
     def outputs(self) -> Mapping[str, Mapping[int, str]]:
         common_outputs = super().outputs
         if self._behavior is ConfigBehavior.ENCODER:
-            # for whisper, we need to name the second axis as
-            # encoder_sequence_length / 2 as the axis name is used for dummy input generation
+            # for Speech2text, we need to name the second axis as
+            # encoder_sequence_length / 2 * self._config.num_conv_layers as the axis name is
+            # used for dummy input generation
             common_outputs["last_hidden_state"][
                 1
             ] = f"{common_outputs['last_hidden_state'][1]} / {( 2 * self._config.num_conv_layers)}"

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -948,10 +948,6 @@ class Speech2TextOnnxConfig(AudioToTextOnnxConfig):
 
     def _create_dummy_input_generator_classes(self, **kwargs) -> List["DummyInputGenerator"]:
         dummy_inputs_generators = super()._create_dummy_input_generator_classes(**kwargs)
-        # The generated encoder_hidden_states for Whisper has dimensions
-        # (batch_size, encoder_sequence_length / 2, hidden_size). Therefore,
-        # the sequence length is updated to generate the proper cross attention
-        # KVS in monolith case.
         if self._behavior is ConfigBehavior.MONOLITH:
             dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
                 self.task,


### PR DESCRIPTION
# What does this PR do?

Fixes export of `Speech2Text` models

1. Fixes #721 - Updated the `sequence_length` for  `past_key_values` generator for monolith case.
2. Updated normalised config for the model to fix export using decoder with past for some models.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

