### PR TITLE
Replace `--for-ort` option in ONNX export by `--monolith`

### DIFF
--- a/.github/workflows/test_exporters_slow.yml
+++ b/.github/workflows/test_exporters_slow.yml
@@ -1,0 +1,33 @@
+name: Exporters slow / Python - Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 7 * * * # every day at 7am
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9]
+        os: [ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install .[tests,exporters-tf]
+    - name: Test with unittest
+      working-directory: tests
+      run: |
+        RUN_SLOW=1 pytest exporters -s --durations=0

--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -70,12 +70,15 @@ The Optimum ONNX export can be used through Optimum command-line:
 ```bash
 optimum-cli export onnx --help
 
-usage: optimum-cli <command> [<args>] export onnx [-h] -m MODEL [--task TASK] [--for-ort] [--device DEVICE] [--opset OPSET] [--atol ATOL]
-                                                  [--framework {pt,tf}] [--pad_token_id PAD_TOKEN_ID] [--cache_dir CACHE_DIR] [--batch_size BATCH_SIZE]
-                                                  [--sequence_length SEQUENCE_LENGTH] [--num_choices NUM_CHOICES] [--width WIDTH] [--height HEIGHT]
-                                                  [--num_channels NUM_CHANNELS] [--feature_size FEATURE_SIZE] [--nb_max_frames NB_MAX_FRAMES]
-                                                  [--audio_sequence_length AUDIO_SEQUENCE_LENGTH]
+usage: optimum-cli <command> [<args>] export onnx [-h] -m MODEL [--task TASK] [--monolith] [--device DEVICE] [--opset OPSET] [--atol ATOL]
+                                                  [--framework {pt,tf}] [--pad_token_id PAD_TOKEN_ID] [--cache_dir CACHE_DIR] [--trust-remote-code]
+                                                  [--batch_size BATCH_SIZE] [--sequence_length SEQUENCE_LENGTH] [--num_choices NUM_CHOICES] [--width WIDTH]
+                                                  [--height HEIGHT] [--num_channels NUM_CHANNELS] [--feature_size FEATURE_SIZE]
+                                                  [--nb_max_frames NB_MAX_FRAMES] [--audio_sequence_length AUDIO_SEQUENCE_LENGTH]
                                                   output
+
+optional arguments:
+  -h, --help            show this help message and exit
 
 Required arguments:
   -m MODEL, --model MODEL
@@ -86,10 +89,10 @@ Optional arguments:
   --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on the model. Available tasks depend on
                         the model, but are among: ['default', 'masked-lm', 'causal-lm', 'seq2seq-lm', 'sequence-classification', 'token-classification',
                         'multiple-choice', 'object-detection', 'question-answering', 'image-classification', 'image-segmentation', 'masked-im', 'semantic-
-                        segmentation', 'speech2seq-lm', 'stable-diffusion']. For decoder models, use `xxx-with-past` to export the model using past key
-                        values in the decoder.
-  --for-ort             This exports models ready to be run with Optimum's ORTModel. Useful for encoder-decoder models forconditional generation. If
-                        enabled the encoder and decoder of the model are exported separately.
+                        segmentation', 'speech2seq-lm', 'audio-classification', 'audio-frame-classification', 'audio-ctc', 'audio-xvector', 'vision2seq-
+                        lm', 'stable-diffusion']. For decoder models, use `xxx-with-past` to export the model using past key values in the decoder.
+  --monolith            Force to export the model as a single ONNX file. By default, the ONNX exporter may break the model in several ONNX files, for
+                        example for encoder-decoder models where the encoder should be run only once while thedecoder is looped over.
   --device DEVICE       The device to use to do the export. Defaults to "cpu".
   --opset OPSET         If specified, ONNX opset version to export the model with. Otherwise, the default opset will be used.
   --atol ATOL           If specified, the absolute difference tolerance when validating the model. Otherwise, the default atol for the model will be used.
@@ -187,7 +190,7 @@ optimum-cli export onnx --model keras-io/transformers-qa distilbert_base_cased_s
 
 ### Exporting a model to be used with Optimum's ORTModel
 
-Models exported through `optimum-cli export onnx` can be used directly in [`~onnxruntime.ORTModel`] by passing the parameter `--for-ort`. This is especially useful for encoder-decoder models, where in this case the export will split the encoder and decoder into two `.onnx` files, as the encoder is usually only run once while the decoder may be run several times in autogenerative tasks.
+Models exported through `optimum-cli export onnx` can be used directly in [`~onnxruntime.ORTModel`]. This is especially useful for encoder-decoder models, where in this case the export will split the encoder and decoder into two `.onnx` files, as the encoder is usually only run once while the decoder may be run several times in autogenerative tasks.
 
 ### Exporting a model using past keys/values in the decoder
 
@@ -198,7 +201,7 @@ In the ONNX export, the past keys/values are reused by default. This behavior co
 A model exported using past key/values can be reused directly into Optimum's [`~onnxruntime.ORTModel`]:
 
 ```bash
-optimum-cli export onnx --model gpt2 --for-ort --task causal-lm-with-past gpt2_onnx/
+optimum-cli export onnx --model gpt2 --task causal-lm-with-past gpt2_onnx/
 ```
 
 and

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -39,11 +39,12 @@ def parse_args_onnx(parser):
         ),
     )
     optional_group.add_argument(
-        "--for-ort",
+        "--monolith",
         action="store_true",
         help=(
-            "This exports models ready to be run with Optimum's ORTModel. Useful for encoder-decoder models for"
-            "conditional generation. If enabled the encoder and decoder of the model are exported separately."
+            "Force to export the model as a single ONNX file. By default, the ONNX exporter may break the model in several"
+            " ONNX files, for example for encoder-decoder models where the encoder should be run only once while the"
+            " decoder is looped over."
         ),
     )
     optional_group.add_argument(

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Defines the command line for the export with ONNX."""
 
+import argparse
 import subprocess
 from pathlib import Path
 
@@ -150,6 +151,9 @@ def parse_args_onnx(parser):
         default=DEFAULT_DUMMY_SHAPES["audio_sequence_length"],
         help=f"Audio tasks only. Audio sequence length {doc_input}",
     )
+
+    # deprecated argument
+    parser.add_argument("--for-ort", action="store_true", help=argparse.SUPPRESS)
 
 
 class ONNXExportCommand:

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -52,7 +52,7 @@ def main():
     if args.for_ort:
         logger.warning(
             "The option --for-ort was passed, but its behavior is now the default in the ONNX exporter"
-            "and passing it is not required anymore."
+            " and passing it is not required anymore."
         )
 
     # Infer the task

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -49,6 +49,12 @@ def main():
     if not args.output.parent.exists():
         args.output.parent.mkdir(parents=True)
 
+    if args.for_ort:
+        logger.warning(
+            "The option --for-ort was passed, but its behavior is now the default in the ONNX exporter"
+            "and passing it is not required anymore."
+        )
+
     # Infer the task
     task = args.task
     if task == "auto":

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -108,7 +108,7 @@ def main():
         maybe_save_preprocessors(args.model, args.output.parent)
 
     if task == "stable-diffusion" or (
-        args.for_ort and (model.config.is_encoder_decoder or task.startswith("causal-lm"))
+        not args.monolith and (model.config.is_encoder_decoder or task.startswith("causal-lm"))
     ):
         if task == "stable-diffusion":
             output_names = [
@@ -156,7 +156,7 @@ def main():
 
     try:
         if task == "stable-diffusion" or (
-            args.for_ort and (model.config.is_encoder_decoder or task.startswith("causal-lm"))
+            not args.monolith and (model.config.is_encoder_decoder or task.startswith("causal-lm"))
         ):
             validate_models_outputs(
                 models_and_onnx_configs=models_and_onnx_configs,

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -114,7 +114,7 @@ def main():
         maybe_save_preprocessors(args.model, args.output.parent)
 
     if task == "stable-diffusion" or (
-        not args.monolith and (model.config.is_encoder_decoder or task.startswith("causal-lm"))
+        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm")) and not args.monolith
     ):
         if task == "stable-diffusion":
             output_names = [
@@ -162,7 +162,7 @@ def main():
 
     try:
         if task == "stable-diffusion" or (
-            not args.monolith and (model.config.is_encoder_decoder or task.startswith("causal-lm"))
+            task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm")) and not args.monolith
         ):
             validate_models_outputs(
                 models_and_onnx_configs=models_and_onnx_configs,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -774,9 +774,6 @@ class ORTModelForSeq2SeqLM(ORTModelForConditionalGeneration, GenerationMixin):
             encoder_outputs = self.encoder(input_ids=input_ids, attention_mask=attention_mask)
 
         # Decode
-        if decoder_input_ids is None:
-            raise ValueError("You have to specify either decoder_input_ids.")
-
         if past_key_values is None or self.decoder_with_past is None:
             decoder_outputs = self.decoder(
                 input_ids=decoder_input_ids,

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -47,7 +47,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "deberta-v2": "hf-internal-testing/tiny-random-DebertaV2Model",
     "deit": "hf-internal-testing/tiny-random-DeiTModel",
     "convnext": "hf-internal-testing/tiny-random-convnext",
-    "detr": "hf-internal-testing/tiny-random-detr",
+    "detr": "hf-internal-testing/tiny-random-DetrModel",  # hf-internal-testing/tiny-random-detr is larger
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "flaubert": "hf-internal-testing/tiny-random-flaubert",

--- a/tests/exporters/test_exporters_onnx_cli.py
+++ b/tests/exporters/test_exporters_onnx_cli.py
@@ -80,19 +80,19 @@ class OnnxCLIExportTestCase(unittest.TestCase):
     Integration tests ensuring supported models are correctly exported.
     """
 
-    def _onnx_export(self, test_name: str, model_name: str, task: Optional[str], for_ort: bool = False):
+    def _onnx_export(self, test_name: str, model_name: str, task: Optional[str], monolith: bool = False):
 
         with TemporaryDirectory() as tmpdir:
-            for_ort = " --for-ort " if for_ort is True else " "
+            monolith = " --monolith " if monolith is True else " "
             if task is not None:
                 subprocess.run(
-                    f"python3 -m optimum.exporters.onnx --model {model_name}{for_ort}--task {task} {tmpdir}",
+                    f"python3 -m optimum.exporters.onnx --model {model_name}{monolith}--task {task} {tmpdir}",
                     shell=True,
                     check=True,
                 )
             else:
                 subprocess.run(
-                    f"python3 -m optimum.exporters.onnx --model {model_name}{for_ort}{tmpdir}",
+                    f"python3 -m optimum.exporters.onnx --model {model_name}{monolith}{tmpdir}",
                     shell=True,
                     check=True,
                 )
@@ -106,8 +106,8 @@ class OnnxCLIExportTestCase(unittest.TestCase):
     @parameterized.expand(_get_models_to_test(PYTORCH_EXPORT_MODELS_TINY))
     @require_torch
     @require_vision
-    def test_exporters_cli_pytorch(self, test_name: str, model_name: str, task: str, for_ort: bool):
-        self._onnx_export(test_name, model_name, task, for_ort)
+    def test_exporters_cli_pytorch(self, test_name: str, model_name: str, task: str, monolith: bool):
+        self._onnx_export(test_name, model_name, task, monolith)
 
     @parameterized.expand([(False,), (True,)])
     def test_external_data(self, use_cache: bool):
@@ -120,7 +120,7 @@ class OnnxCLIExportTestCase(unittest.TestCase):
                 task += "-with-past"
 
             subprocess.run(
-                f"python3 -m optimum.exporters.onnx --model hf-internal-testing/tiny-random-t5 --task {task} --for-ort {tmpdirname}",
+                f"python3 -m optimum.exporters.onnx --model hf-internal-testing/tiny-random-t5 --task {task} {tmpdirname}",
                 shell=True,
                 check=True,
             )
@@ -141,7 +141,7 @@ class OnnxCLIExportTestCase(unittest.TestCase):
     def test_trust_remote_code(self):
         with TemporaryDirectory() as tmpdirname:
             out = subprocess.run(
-                f"python3 -m optimum.exporters.onnx --model fxmarty/tiny-testing-gpt2-remote-code --task causal-lm --for-ort {tmpdirname}",
+                f"python3 -m optimum.exporters.onnx --model fxmarty/tiny-testing-gpt2-remote-code --task causal-lm {tmpdirname}",
                 shell=True,
                 capture_output=True,
             )
@@ -150,7 +150,7 @@ class OnnxCLIExportTestCase(unittest.TestCase):
 
         with TemporaryDirectory() as tmpdirname:
             out = subprocess.run(
-                f"python3 -m optimum.exporters.onnx --trust-remote-code --model fxmarty/tiny-testing-gpt2-remote-code --task causal-lm --for-ort {tmpdirname}",
+                f"python3 -m optimum.exporters.onnx --trust-remote-code --model fxmarty/tiny-testing-gpt2-remote-code --task causal-lm {tmpdirname}",
                 shell=True,
                 check=True,
             )

--- a/tests/onnx/test_onnx_graph_transformations.py
+++ b/tests/onnx/test_onnx_graph_transformations.py
@@ -46,7 +46,7 @@ class WeightSharingTestCase(TestCase):
                 task = "default"
                 with TemporaryDirectory() as tmpdir:
                     subprocess.run(
-                        f"python3 -m optimum.exporters.onnx --model {model_id} --for-ort --task {task} {tmpdir}",
+                        f"python3 -m optimum.exporters.onnx --model {model_id} --task {task} {tmpdir}",
                         shell=True,
                         check=True,
                     )
@@ -82,7 +82,7 @@ class OnnxMergingTestCase(TestCase):
 
         with TemporaryDirectory() as tmpdir:
             subprocess.run(
-                f"python3 -m optimum.exporters.onnx --model {model_id} --for-ort --task {task} {tmpdir}",
+                f"python3 -m optimum.exporters.onnx --model {model_id} --task {task} {tmpdir}",
                 shell=True,
                 check=True,
             )


### PR DESCRIPTION
As per title.

Breaking change: the old `--for-ort` behavior is now the default.

Additionally, the tests in `test_onnx_export.py` are now all slow.