### PR TITLE
Fix wrong shapes used at ONNX export and validation

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -73,10 +73,11 @@ def main():
         task, args.model, framework=args.framework, cache_dir=args.cache_dir, trust_remote_code=args.trust_remote_code
     )
 
-    if task == "causal-lm-with-past" and args.monolith is True:
+    if task.endswith("-with-past") and args.monolith is True:
+        task_non_past = task.replace("-with-past", "")
         raise ValueError(
-            "The task causal-lm-with-past is not compatible with --monolith. Please either use"
-            " `--task causal-lm --monolith`, or `--task causal-lm-with-past` without the monolith argument."
+            f"The task {task} is not compatible with the --monolith argument. Please either use"
+            f" `--task {task_non_past} --monolith`, or `--task {task}` without the monolith argument."
         )
 
     if task + "-with-past" in TasksManager.get_supported_tasks_for_model_type(

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -128,7 +128,7 @@ def main():
         maybe_save_preprocessors(args.model, args.output.parent)
 
     if task == "stable-diffusion" or (
-        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default")) and not args.monolith
+        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default-with-past")) and not args.monolith
     ):
         if task == "stable-diffusion":
             output_names = [
@@ -176,7 +176,7 @@ def main():
 
     try:
         if task == "stable-diffusion" or (
-            task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default"))
+            task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default-with-past"))
             and not args.monolith
         ):
             validate_models_outputs(

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -128,7 +128,7 @@ def main():
         maybe_save_preprocessors(args.model, args.output.parent)
 
     if task == "stable-diffusion" or (
-        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm")) and not args.monolith
+        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default")) and not args.monolith
     ):
         if task == "stable-diffusion":
             output_names = [
@@ -176,7 +176,8 @@ def main():
 
     try:
         if task == "stable-diffusion" or (
-            task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm")) and not args.monolith
+            task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default"))
+            and not args.monolith
         ):
             validate_models_outputs(
                 models_and_onnx_configs=models_and_onnx_configs,

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -74,6 +74,12 @@ def main():
         task, args.model, framework=args.framework, cache_dir=args.cache_dir, trust_remote_code=args.trust_remote_code
     )
 
+    if task == "causal-lm-with-past" and args.monolith is True:
+        raise ValueError(
+            "The task causal-lm-with-past is not compatible with --monolith. Please either use"
+            " `--task causal-lm --monolith`, or `--task causal-lm-with-past` without the monolith argument."
+        )
+
     if task + "-with-past" in TasksManager.get_supported_tasks_for_model_type(
         model.config.model_type.replace("_", "-"), "onnx"
     ):

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -128,7 +128,8 @@ def main():
         maybe_save_preprocessors(args.model, args.output.parent)
 
     if task == "stable-diffusion" or (
-        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default-with-past")) and not args.monolith
+        task.startswith(("causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm", "default-with-past"))
+        and not args.monolith
     ):
         if task == "stable-diffusion":
             output_names = [

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -557,7 +557,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                 if dummy_input_gen.supports_input(input_name):
                     # models from TextSeq2SeqOnnxConfig use decoder_input_ids as input name
                     # while models from TextDecoderOnnxConfig use input_ids, hence the check for both
-                    if self.use_past is True and input_name in ["decoder_input_ids", "input_ids"]:
+                    if self._behavior != ConfigBehavior.MONOLITH and self.use_past is True and input_name in ["decoder_input_ids", "input_ids"]:
                         sequence_length = dummy_input_gen.sequence_length
                         if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
                             logger.info(

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -503,7 +503,6 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         self,
         config: "PretrainedConfig",
         task: str = "default",
-        patching_specs: Optional[List[PatchingSpec]] = None,
         use_past: bool = False,
         use_past_in_inputs: Optional[bool] = None,
         use_present_in_outputs: Optional[bool] = None,

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -577,7 +577,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                     # models from TextSeq2SeqOnnxConfig use decoder_input_ids as input name
                     # while models from TextDecoderOnnxConfig use input_ids, hence the check for both
                     if (
-                        self._behavior != ConfigBehavior.MONOLITH
+                        self._behavior is not ConfigBehavior.MONOLITH
                         and self.use_past is True
                         and input_name in ["decoder_input_ids", "input_ids"]
                     ):

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -575,6 +575,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                     f'Could not generate dummy input for "{input_name}". Try adding a proper dummy input generator to the model ONNX config.'
                 )
 
+        # refer to https://github.com/huggingface/optimum/pull/764
         if self.use_past_in_inputs and "attention_mask" in dummy_inputs and self.PAD_ATTENTION_MASK_TO_PAST:
             past_length = dummy_inputs["past_key_values"][0][0].shape[2]
             dummy_inputs["attention_mask"] = DummyInputGenerator.pad_input_on_dim(

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -482,6 +482,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
     Inherits from [`~exporters.onnx.OnnxConfig`]. A base class to handle the ONNX configuration of decoder-only models.
     """
 
+    PAD_ATTENTION_MASK_TO_PAST: bool = False
     USE_PAST_IN_INPUTS: Optional[bool] = None
     USE_PRESENT_IN_OUTPUTS: Optional[bool] = None
 
@@ -574,7 +575,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                     f'Could not generate dummy input for "{input_name}". Try adding a proper dummy input generator to the model ONNX config.'
                 )
 
-        if self.use_past_in_inputs and "attention_mask" in dummy_inputs:
+        if self.use_past_in_inputs and "attention_mask" in dummy_inputs and self.PAD_ATTENTION_MASK_TO_PAST:
             past_length = dummy_inputs["past_key_values"][0][0].shape[2]
             dummy_inputs["attention_mask"] = DummyInputGenerator.pad_input_on_dim(
                 dummy_inputs["attention_mask"],

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -475,10 +475,10 @@ class OnnxConfig(ExportConfig, ABC):
 
 class ConfigBehavior(str, enum.Enum):
     """
-    Specifies the behavior of the [`~exporters.onnx.base.OnnxConfigWithPast`]:
-        - MONOLITH: the config can be used to export the whole encoder-decoder or decoder model as a single file.
-        - ENCODER: the config can be used to export the encoder part of the model, if any.
-        - DECODER: the config can be used to export the decoder part of the model.
+    Specifies the behavior of the [`~exporters.onnx.base.OnnxSeq2SeqConfigWithPast`]:
+        - MONOLITH: the config can be used to export the whole seq2seq model as a single file.
+        - ENCODER: the config can be used to export the encoder part of the seq2seq model.
+        - DECODER: the config can be used to export the decoder part of the seq2seq model.
     """
 
     MONOLITH = "monolith"
@@ -502,7 +502,6 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         use_past: bool = False,
         use_past_in_inputs: Optional[bool] = None,
         use_present_in_outputs: Optional[bool] = None,
-        behavior: ConfigBehavior = ConfigBehavior.MONOLITH,
     ):
         self.use_past = use_past
         if use_past_in_inputs is None:
@@ -523,10 +522,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                 f"use_past = {use_past} is different than use_present_in_outputs = {use_present_in_outputs}, the value "
                 "of use_present_in_outputs value will be used for the outputs."
             )
-
-        self._behavior = behavior
         super().__init__(config, task=task)
-        self.override_attributes_for_behavior()
 
     @classmethod
     def with_past(cls, config: "PretrainedConfig", task: str = "default") -> "OnnxConfigWithPast":
@@ -571,11 +567,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                 if dummy_input_gen.supports_input(input_name):
                     # models from TextSeq2SeqOnnxConfig use decoder_input_ids as input name
                     # while models from TextDecoderOnnxConfig use input_ids, hence the check for both
-                    if (
-                        self._behavior is not ConfigBehavior.MONOLITH
-                        and self.use_past is True
-                        and input_name in ["decoder_input_ids", "input_ids"]
-                    ):
+                    if self.use_past is True and input_name in ["decoder_input_ids", "input_ids"]:
                         sequence_length = dummy_input_gen.sequence_length
                         if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:
                             logger.info(
@@ -639,40 +631,6 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
         return flattened_output
 
-    def override_attributes_for_behavior(self):
-        """Override this to specify custom attribute change for a given behavior."""
-        if self._behavior is ConfigBehavior.ENCODER:
-            self.task = "default"
-            self.use_past_in_inputs = False
-            self.use_present_in_outputs = False
-        if self._behavior is ConfigBehavior.DECODER:
-            self.use_past_in_inputs = self.use_past
-            self.use_present_in_outputs = True
-
-    def with_behavior(
-        self, behavior: Union[str, ConfigBehavior], use_past: bool = False
-    ) -> "OnnxSeq2SeqConfigWithPast":
-        """
-        Creates a copy of the current OnnxConfig but with a different `ConfigBehavior` and `use_past` value.
-
-        Args:
-            behavior ([`ConfigBehavior`]):
-                The behavior to use for the new instance.
-            use_past (`bool`, defaults to `False`):
-                Whether or not the new instance should use past.
-
-        Returns:
-            `OnnxSeq2SeqConfigWithPast`
-        """
-        if isinstance(behavior, str) and not isinstance(behavior, ConfigBehavior):
-            behavior = ConfigBehavior(behavior)
-        return self.__class__(
-            self._config,
-            task=self.task,
-            use_past=use_past,
-            behavior=behavior,
-        )
-
 
 class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
     """
@@ -694,8 +652,8 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
             use_past=use_past,
             use_past_in_inputs=use_past_in_inputs,
             use_present_in_outputs=use_present_in_outputs,
-            behavior=behavior,
         )
+        self._behavior = behavior
         self.override_attributes_for_behavior()
 
     @property
@@ -751,6 +709,40 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         flattened_output[f"{name}.{idx}.decoder.value"] = t[1]
         flattened_output[f"{name}.{idx}.encoder.key"] = t[2]
         flattened_output[f"{name}.{idx}.encoder.value"] = t[3]
+
+    def override_attributes_for_behavior(self):
+        """Override this to specify custom attribute change for a given behavior."""
+        if self._behavior is ConfigBehavior.ENCODER:
+            self.task = "default"
+            self.use_past_in_inputs = False
+            self.use_present_in_outputs = False
+        if self._behavior is ConfigBehavior.DECODER:
+            self.use_past_in_inputs = self.use_past
+            self.use_present_in_outputs = True
+
+    def with_behavior(
+        self, behavior: Union[str, ConfigBehavior], use_past: bool = False
+    ) -> "OnnxSeq2SeqConfigWithPast":
+        """
+        Creates a copy of the current OnnxConfig but with a different `ConfigBehavior` and `use_past` value.
+
+        Args:
+            behavior ([`ConfigBehavior`]):
+                The behavior to use for the new instance.
+            use_past (`bool`, defaults to `False`):
+                Whether or not the new instance should use past.
+
+        Returns:
+            `OnnxSeq2SeqConfigWithPast`
+        """
+        if isinstance(behavior, str) and not isinstance(behavior, ConfigBehavior):
+            behavior = ConfigBehavior(behavior)
+        return self.__class__(
+            self._config,
+            task=self.task,
+            use_past=use_past,
+            behavior=behavior,
+        )
 
 
 class OnnxConfigWithLoss(OnnxConfig, ABC):

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -544,6 +544,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
     @add_dynamic_docstring(text=GENERATE_DUMMY_DOCSTRING, dynamic_elements=DEFAULT_DUMMY_SHAPES)
     def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        print("------------- IN THIS generate_dummy_inputs")
         dummy_inputs_generators = self._create_dummy_input_generator_classes(**kwargs)
 
         dummy_inputs = {}

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -531,6 +531,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
 
         self._behavior = behavior
         super().__init__(config, task=task)
+        self.override_attributes_for_behavior()
 
     @classmethod
     def with_past(cls, config: "PretrainedConfig", task: str = "default") -> "OnnxConfigWithPast":

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -550,6 +550,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         input_names = [key for key in self.inputs.keys() if not key.startswith("past_key_values")]
         if self.use_past:
             input_names.append("past_key_values")
+
         for input_name in input_names:
             input_was_inserted = False
             for dummy_input_gen in dummy_inputs_generators:

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -51,6 +51,7 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
     Handles decoder-based text architectures.
     """
 
+    PAD_ATTENTION_MASK_TO_PAST = True
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, DummyPastKeyValuesGenerator)
 
     @property

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -377,6 +377,18 @@ def export_pytorch(
 
         # Check that inputs match, and order them properly
         dummy_inputs = config.generate_dummy_inputs(framework="pt", **input_shapes)
+        print("---- AT EXPORT")
+        for name, val in dummy_inputs.items():
+            if isinstance(val, torch.Tensor):
+                print(name, val.shape)
+            else:
+                print(name)
+                for v in val:
+                    if isinstance(v, torch.Tensor):
+                        print("   ", v.shape)
+                    else:
+                        for a in v:
+                            print("   ", a.shape)
 
         device = torch.device(device)
         if device.type == "cuda" and torch.cuda.is_available():

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -377,6 +377,18 @@ def export_pytorch(
 
         # Check that inputs match, and order them properly
         dummy_inputs = config.generate_dummy_inputs(framework="pt", **input_shapes)
+        print("---- AT EXPORT")
+        for name, val in dummy_inputs.items():
+            if isinstance(val, torch.Tensor):
+                print(name, val.shape)
+            else:
+                print(name)
+                for v in val:
+                    if isinstance(v, torch.Tensor):
+                        print("   ", v.shape)
+                    else:
+                        for a in v:
+                            print("   ", a.shape)
         device = torch.device(device)
         if device.type == "cuda" and torch.cuda.is_available():
             model.to(device)

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -377,18 +377,6 @@ def export_pytorch(
 
         # Check that inputs match, and order them properly
         dummy_inputs = config.generate_dummy_inputs(framework="pt", **input_shapes)
-        print("---- AT EXPORT")
-        for name, val in dummy_inputs.items():
-            if isinstance(val, torch.Tensor):
-                print(name, val.shape)
-            else:
-                print(name)
-                for v in val:
-                    if isinstance(v, torch.Tensor):
-                        print("   ", v.shape)
-                    else:
-                        for a in v:
-                            print("   ", a.shape)
 
         device = torch.device(device)
         if device.type == "cuda" and torch.cuda.is_available():

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -377,18 +377,7 @@ def export_pytorch(
 
         # Check that inputs match, and order them properly
         dummy_inputs = config.generate_dummy_inputs(framework="pt", **input_shapes)
-        print("---- AT EXPORT")
-        for name, val in dummy_inputs.items():
-            if isinstance(val, torch.Tensor):
-                print(name, val.shape)
-            else:
-                print(name)
-                for v in val:
-                    if isinstance(v, torch.Tensor):
-                        print("   ", v.shape)
-                    else:
-                        for a in v:
-                            print("   ", a.shape)
+
         device = torch.device(device)
         if device.type == "cuda" and torch.cuda.is_available():
             model.to(device)

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -455,23 +455,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
                 flattened_output, name, idx, t
             )
 
-    def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-        if self._behavior is ConfigBehavior.DECODER:
-            reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
-            reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
-
-        return reference_model_inputs
-
-    @property
-    def torch_to_onnx_input_map(self) -> Mapping[str, str]:
-        if self._behavior is ConfigBehavior.DECODER:
-            return {
-                "decoder_input_ids": "input_ids",
-                "encoder_outputs": "encoder_hidden_states",
-                "attention_mask": "encoder_attention_mask",
-            }
-        return {}
-
 
 class MBartOnnxConfig(BartOnnxConfig):
     pass

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -456,6 +456,23 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
                 flattened_output, name, idx, t
             )
 
+    def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
+        if self._behavior is ConfigBehavior.DECODER and not self.task.startswith("causal-lm"):
+            reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
+            reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
+
+        return reference_model_inputs
+
+    @property
+    def torch_to_onnx_input_map(self) -> Mapping[str, str]:
+        if self._behavior is ConfigBehavior.DECODER and not self.task.startswith("causal-lm"):
+            return {
+                "decoder_input_ids": "input_ids",
+                "encoder_outputs": "encoder_hidden_states",
+                "attention_mask": "encoder_attention_mask",
+            }
+        return {}
+
 
 class MBartOnnxConfig(BartOnnxConfig):
     pass

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -456,7 +456,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
             )
 
     def generate_dummy_inputs_for_validation(self, reference_model_inputs: Mapping[str, Any]) -> Mapping[str, Any]:
-        if self._behavior is ConfigBehavior.DECODER and not self.task.startswith("causal-lm"):
+        if self._behavior is ConfigBehavior.DECODER:
             reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
             reference_model_inputs["encoder_hidden_states"] = reference_model_inputs.pop("encoder_outputs")[0]
 
@@ -464,7 +464,7 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
 
     @property
     def torch_to_onnx_input_map(self) -> Mapping[str, str]:
-        if self._behavior is ConfigBehavior.DECODER and not self.task.startswith("causal-lm"):
+        if self._behavior is ConfigBehavior.DECODER:
             return {
                 "decoder_input_ids": "input_ids",
                 "encoder_outputs": "encoder_hidden_states",

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -431,17 +431,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
                     }
         return common_outputs
 
-    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
-        # This will handle the attention mask padding when Bart is used for causal-lm.
-        if self.task == "causal-lm":
-            self.PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = True
-
-        dummy_inputs = super().generate_dummy_inputs(framework=framework, **kwargs)
-
-        # Setting it back to the default version.
-        self.PAD_ATTENTION_MASK_TO_MATCH_TOTAL_SEQUENCE_LENGTH = False
-        return dummy_inputs
-
     def flatten_past_key_values(self, flattened_output, name, idx, t):
         if self.task in ["default", "seq2seq-lm"]:
             flattened_output = super().flatten_past_key_values(flattened_output, name, idx, t)

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -380,20 +380,26 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
 
     @property
     def inputs_for_causal_lm(self):
-        common_inputs = {
-            "input_ids": {0: "batch_size", 1: "sequence_length"},
-            "attention_mask": {0: "batch_size", 1: "sequence_length"},
-        }
+
         if self.use_past_in_inputs:
+            common_inputs = {
+                "input_ids": {0: "batch_size"},
+                "attention_mask": {0: "batch_size", 1: "past_sequence_length + 1"},
+            }
             for i in range(self._normalized_config.decoder_num_layers):
                 common_inputs[f"past_key_values.{i}.key"] = {
                     0: "batch_size",
-                    2: "past_sequence_length + sequence_length",
+                    2: "past_sequence_length",
                 }
                 common_inputs[f"past_key_values.{i}.value"] = {
                     0: "batch_size",
-                    2: "past_sequence_length + sequence_length",
+                    2: "past_sequence_length",
                 }
+        else:
+            common_inputs = {
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+            }
 
         return common_inputs
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -431,14 +431,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
                     }
         return common_outputs
 
-    def flatten_past_key_values(self, flattened_output, name, idx, t):
-        if self.task in ["default", "seq2seq-lm"]:
-            flattened_output = super().flatten_past_key_values(flattened_output, name, idx, t)
-        else:
-            flattened_output = super(OnnxSeq2SeqConfigWithPast, self).flatten_past_key_values(
-                flattened_output, name, idx, t
-            )
-
     def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
         # This will handle the attention mask padding when Bart is used for causal-lm.
         if self.task == "causal-lm":
@@ -449,6 +441,14 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         # Setting it back to the default version.
         self.PAD_ATTENTION_MASK_TO_PAST = False
         return dummy_inputs
+
+    def flatten_past_key_values(self, flattened_output, name, idx, t):
+        if self.task in ["default", "seq2seq-lm"]:
+            flattened_output = super().flatten_past_key_values(flattened_output, name, idx, t)
+        else:
+            flattened_output = super(OnnxSeq2SeqConfigWithPast, self).flatten_past_key_values(
+                flattened_output, name, idx, t
+            )
 
 
 class MBartOnnxConfig(BartOnnxConfig):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -380,7 +380,6 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
 
     @property
     def inputs_for_causal_lm(self):
-
         if self.use_past_in_inputs:
             common_inputs = {
                 "input_ids": {0: "batch_size"},

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -439,6 +439,17 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
                 flattened_output, name, idx, t
             )
 
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        # This will handle the attention mask padding when Bart is used for causal-lm.
+        if self.task == "causal-lm":
+            self.PAD_ATTENTION_MASK_TO_PAST = True
+
+        dummy_inputs = super().generate_dummy_inputs(framework=framework, **kwargs)
+
+        # Setting it back to the default version.
+        self.PAD_ATTENTION_MASK_TO_PAST = False
+        return dummy_inputs
+
 
 class MBartOnnxConfig(BartOnnxConfig):
     pass

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -127,7 +127,7 @@ def get_decoder_models_for_export(
     models_for_export["decoder_model"] = (model, decoder_onnx_config)
 
     if config.use_past:
-        decoder_onnx_config_with_past = config.with_behavior(model.config, use_past=True)
+        decoder_onnx_config_with_past = config.with_behavior("decoder", use_past=True)
         models_for_export["decoder_with_past_model"] = (model, decoder_onnx_config_with_past)
 
     return models_for_export

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -123,12 +123,14 @@ def get_decoder_models_for_export(
     """
     models_for_export = {}
 
-    decoder_onnx_config = config.with_behavior("decoder", use_past=False)
-    models_for_export["decoder_model"] = (model, decoder_onnx_config)
+    onnx_config = config.__class__(
+        model.config, task=config.task, use_past_in_inputs=False, use_present_in_outputs=True
+    )
+    models_for_export["decoder_model"] = (model, onnx_config)
 
     if config.use_past:
-        decoder_onnx_config_with_past = config.with_behavior("decoder", use_past=True)
-        models_for_export["decoder_with_past_model"] = (model, decoder_onnx_config_with_past)
+        onnx_config_with_past = config.__class__(model.config, task=config.task, use_past=True)
+        models_for_export["decoder_with_past_model"] = (model, onnx_config_with_past)
 
     return models_for_export
 

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -123,14 +123,12 @@ def get_decoder_models_for_export(
     """
     models_for_export = {}
 
-    onnx_config = config.__class__(
-        model.config, task=config.task, use_past_in_inputs=False, use_present_in_outputs=True
-    )
-    models_for_export["decoder_model"] = (model, onnx_config)
+    decoder_onnx_config = config.with_behavior("decoder", use_past=False)
+    models_for_export["decoder_model"] = (model, decoder_onnx_config)
 
     if config.use_past:
-        onnx_config_with_past = config.__class__(model.config, task=config.task, use_past=True)
-        models_for_export["decoder_with_past_model"] = (model, onnx_config_with_past)
+        decoder_onnx_config_with_past = config.with_behavior(model.config, use_past=True)
+        models_for_export["decoder_with_past_model"] = (model, decoder_onnx_config_with_past)
 
     return models_for_export
 

--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -54,11 +54,15 @@ def _get_models_to_test(export_models_dict: Dict):
                 for task in tasks:
                     models_to_test.append((f"{model_type}_{task}", model_name, task, False))
 
-                    if any(
-                        task.startswith(ort_special_task)
-                        for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm"]
+                    # task = causal-lm-with-past and monolith case is absurd
+                    if (
+                        any(
+                            task.startswith(ort_special_task)
+                            for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm"]
+                        )
+                        and task != "causal-lm-with-past"
                     ):
-                        models_to_test.append((f"{model_type}_{task}_forort", model_name, task, True))
+                        models_to_test.append((f"{model_type}_{task}_monolith", model_name, task, True))
 
             # TODO: segformer task can not be automatically inferred
             # TODO: xlm-roberta model auto-infers causal-lm, but we don't support it
@@ -80,7 +84,6 @@ class OnnxCLIExportTestCase(unittest.TestCase):
     """
 
     def _onnx_export(self, test_name: str, model_name: str, task: Optional[str], monolith: bool = False):
-
         with TemporaryDirectory() as tmpdir:
             monolith = " --monolith " if monolith is True else " "
             if task is not None:
@@ -113,7 +116,6 @@ class OnnxCLIExportTestCase(unittest.TestCase):
         os.environ["FORCE_ONNX_EXTERNAL_DATA"] = "1"  # force exporting small model with external data
 
         with TemporaryDirectory() as tmpdirname:
-
             task = "seq2seq-lm"
             if use_cache:
                 task += "-with-past"

--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -54,13 +54,10 @@ def _get_models_to_test(export_models_dict: Dict):
                 for task in tasks:
                     models_to_test.append((f"{model_type}_{task}", model_name, task, False))
 
-                    # task = causal-lm-with-past and monolith case is absurd
-                    if (
-                        any(
-                            task.startswith(ort_special_task)
-                            for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm"]
-                        )
-                        and task != "causal-lm-with-past"
+                    # -with-past and monolith case are absurd, so we don't test them as not supported
+                    if any(
+                        task == ort_special_task
+                        for ort_special_task in ["causal-lm", "seq2seq-lm", "speech2seq-lm", "vision2seq-lm"]
                     ):
                         models_to_test.append((f"{model_type}_{task}_monolith", model_name, task, True))
 


### PR DESCRIPTION
**Breaking change:** The export with `--monolith` along with `--task ...-with-past` is no longer supported. It made no sense anyway.

As per title, for GPT2 for causallm, the right shapes should be along the lines of:

```
-----
input_ids: torch.Size([1, 13])
attention_mask torch.Size([1, 13])
encoder_hidden_states None
encoder_attention_mask None
-----
input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
    torch.Size([1, 4, 13, 8])
attention_mask torch.Size([1, 14])
encoder_hidden_states None
encoder_attention_mask None
-----
input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
    torch.Size([1, 4, 14, 8])
attention_mask torch.Size([1, 15])
encoder_hidden_states None
encoder_attention_mask None
```

For T5 for seq2seq, shapes should be along the lines of:
```
-----
input_ids: None
decoder_input_ids: torch.Size([1, 1])
attention_mask torch.Size([1, 30])
decoder_attention_mask None
encoder_outputs None
-----
input_ids: None
decoder_input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
    torch.Size([1, 4, 1, 8])
attention_mask torch.Size([1, 30])
decoder_attention_mask None
encoder_outputs None
-----
input_ids: None
decoder_input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
    torch.Size([1, 4, 2, 8])
attention_mask torch.Size([1, 30])
decoder_attention_mask None
encoder_outputs None
```

Bart as CausalLM:
```
-----
input_ids: torch.Size([1, 15])
attention_mask torch.Size([1, 15])
encoder_hidden_states None
encoder_attention_mask None
-----
input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 15, 4])
    torch.Size([1, 4, 15, 4])
    torch.Size([1, 4, 15, 4])
    torch.Size([1, 4, 15, 4])
attention_mask torch.Size([1, 16])
encoder_hidden_states None
encoder_attention_mask None
-----
input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 16, 4])
    torch.Size([1, 4, 16, 4])
    torch.Size([1, 4, 16, 4])
    torch.Size([1, 4, 16, 4])
attention_mask torch.Size([1, 17])
encoder_hidden_states None
encoder_attention_mask None
```

Bart as `BartForConditionalGeneration`:
```
input_ids: None
decoder_input_ids: torch.Size([1, 1])
attention_mask torch.Size([1, 15])
decoder_attention_mask None
encoder_outputs None
-----
input_ids: None
decoder_input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 1, 4])
    torch.Size([1, 4, 1, 4])
    torch.Size([1, 4, 1, 4])
    torch.Size([1, 4, 1, 4])
attention_mask torch.Size([1, 15])
decoder_attention_mask None
encoder_outputs None
-----
input_ids: None
decoder_input_ids: torch.Size([1, 1])
past_key_values
    torch.Size([1, 4, 2, 4])
    torch.Size([1, 4, 2, 4])
    torch.Size([1, 4, 2, 4])
    torch.Size([1, 4, 2, 4])
attention_mask torch.Size([1, 15])
decoder_attention_mask None
encoder_outputs None
```

I tested
```
optimum-cli export onnx --model hf-internal-testing/tiny-random-t5 t5_onnx
optimum-cli export onnx --model hf-internal-testing/tiny-random-bart --task causal-lm-with-past bart_onnx
optimum-cli export onnx --model hf-internal-testing/tiny-random-bart --task seq2seq-lm-with-past bart_onnx
optimum-cli export onnx --model hf-internal-testing/tiny-random-gpt2 --task causal-lm-with-past gpt2_onnx
optimum-cli export onnx --model hf-internal-testing/tiny-random-t5 --task seq2seq-lm-with-past t5_onnx
```

which go fine, so hopefully all tests pass.