### PR TITLE
Disable ONNX Runtime provider check on Windows

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -175,6 +175,9 @@ def validate_provider_availability(provider: str):
     Args:
         provider (str): Name of an ONNX Runtime execution provider.
     """
+    # disable on Windows as reported in https://github.com/huggingface/optimum/issues/769
+    if os.name == "nt":
+        return
     if provider in ["CUDAExecutionProvider", "TensorrtExecutionProvider"]:
         path_cuda_lib = os.path.join(ort.__path__[0], "capi", "libonnxruntime_providers_cuda.so")
         path_trt_lib = os.path.join(ort.__path__[0], "capi", "libonnxruntime_providers_tensorrt.so")

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -176,9 +176,7 @@ def validate_provider_availability(provider: str):
         provider (str): Name of an ONNX Runtime execution provider.
     """
     # disable on Windows as reported in https://github.com/huggingface/optimum/issues/769
-    if os.name == "nt":
-        return
-    if provider in ["CUDAExecutionProvider", "TensorrtExecutionProvider"]:
+    if os.name != "nt" and provider in ["CUDAExecutionProvider", "TensorrtExecutionProvider"]:
         path_cuda_lib = os.path.join(ort.__path__[0], "capi", "libonnxruntime_providers_cuda.so")
         path_trt_lib = os.path.join(ort.__path__[0], "capi", "libonnxruntime_providers_tensorrt.so")
         path_dependecy_loading = os.path.join(ort.__path__[0], "capi", "_ld_preload.py")


### PR DESCRIPTION
As per title, the reliance on `_ld_preload.py` is not robust on Windows as reported in https://github.com/huggingface/optimum/issues/769