### PR TITLE
Fix used shapes, device at ONNX export

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -193,6 +193,7 @@ def main():
                 output_dir=args.output.parent,
                 output_names=output_names,
                 device=args.device,
+                input_shapes=input_shapes,
             )
         else:
             validate_model_outputs(
@@ -202,6 +203,7 @@ def main():
                 onnx_named_outputs=onnx_outputs,
                 atol=args.atol,
                 device=args.device,
+                input_shapes=input_shapes,
             )
 
         logger.info(f"The ONNX export succeeded and the exported model was saved at: {args.output.parent.as_posix()}")

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -21,7 +21,6 @@ import functools
 import gc
 import inspect
 import itertools
-import os
 import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -283,7 +282,7 @@ class OnnxConfig(ExportConfig, ABC):
         common_outputs = self._TASK_TO_COMMON_OUTPUTS[self.task]
         return copy.deepcopy(common_outputs)
 
-    def fix_dynamic_axes(self, model_path: "Path"):
+    def fix_dynamic_axes(self, model_path: "Path", device: str = "cpu", input_shapes: Dict = None):
         """
         Fixes potential issues with dynamic axes.
 
@@ -300,10 +299,10 @@ class OnnxConfig(ExportConfig, ABC):
         for output in self.outputs.values():
             allowed_dynamic_axes |= set(output.values())
 
-        if os.environ.get("ORT_CUDA_UNAVAILABLE", "0") == "1":
-            providers = ["CPUExecutionProvider"]
-        else:
+        if device.startswith("cuda"):
             providers = ["CUDAExecutionProvider"]
+        else:
+            providers = ["CPUExecutionProvider"]
 
         session = InferenceSession(model_path.as_posix(), providers=providers)
 
@@ -315,7 +314,9 @@ class OnnxConfig(ExportConfig, ABC):
 
         # We branch here to avoid doing an unnecessary forward pass.
         if to_fix:
-            dummy_inputs = self.generate_dummy_inputs(framework="np")
+            if input_shapes is None:
+                input_shapes = {}
+            dummy_inputs = self.generate_dummy_inputs(framework="np", **input_shapes)
             dummy_inputs = self.generate_dummy_inputs_for_validation(dummy_inputs)
             onnx_inputs = {}
             for name, value in dummy_inputs.items():

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -647,5 +647,5 @@ def export(
             "You either provided a PyTorch model with only TensorFlow installed, or a TensorFlow model with only PyTorch installed."
         )
 
-    config.fix_dynamic_axes(output)
+    config.fix_dynamic_axes(output, device=device, input_shapes=input_shapes)
     return export_output


### PR DESCRIPTION
Passing `CUDA_VISIBLE_DEVICES=""` made the export fail. Besides, `_ld_preload.py` is not a reliable source to detect the CUDA/TRT install on Windows.