### PR TITLE
Update ORT Training to 1.14.0

### DIFF
--- a/docs/source/onnxruntime/usage_guides/trainer.mdx
+++ b/docs/source/onnxruntime/usage_guides/trainer.mdx
@@ -56,12 +56,12 @@ To use `ORTTrainer` or `ORTSeq2SeqTrainer`, you need to install ONNX Runtime Tra
 To set up the environment, we __strongly recommend__ you install the dependencies with Docker to ensure that the versions are correct and well
 configured. You can find dockerfiles with various combinations [here](https://github.com/huggingface/optimum/tree/main/examples/onnxruntime/training/docker).
 
-Here below we take the installation of `onnxruntime-training 1.13.1` as an example:
+Here below we take the installation of `onnxruntime-training 1.14.0` as an example:
 
-* If you want to install `onnxruntime-training 1.13.1` via [Dockerfile](https://github.com/huggingface/optimum/blob/main/examples/onnxruntime/training/docker/Dockerfile-ort1.13.1-cu116):
+* If you want to install `onnxruntime-training 1.14.0` via [Dockerfile](https://github.com/huggingface/optimum/blob/main/examples/onnxruntime/training/docker/Dockerfile-ort1.14.0-cu116):
 
 ```bash
-docker build -f Dockerfile-ort1.13.1-cu116 -t <imagename:tag> .
+docker build -f Dockerfile-ort1.14.0-cu116 -t ort/train:1.14.0 .
 ```
 
 * If you want to install the dependencies beyond in a local Python environment. You can pip install them once you have [CUDA 11.6](https://docs.nvidia.com/cuda/archive/11.6.2/) and [cuDNN 8](https://developer.nvidia.com/cudnn) well installed.
@@ -69,7 +69,7 @@ docker build -f Dockerfile-ort1.13.1-cu116 -t <imagename:tag> .
 ```bash
 pip install onnx ninja
 pip install torch==1.13.1+cu116 torchvision==0.14.1 -f https://download.pytorch.org/whl/cu116/torch_stable.html
-pip install onnxruntime-training==1.13.1 -f https://download.onnxruntime.ai/onnxruntime_stable_cu116.html
+pip install onnxruntime-training==1.14.0 -f https://download.onnxruntime.ai/onnxruntime_stable_cu116.html
 pip install torch-ort
 pip install --upgrade protobuf==3.20.2
 ```

--- a/examples/onnxruntime/training/docker/Dockerfile-ort1.14.0-cu116
+++ b/examples/onnxruntime/training/docker/Dockerfile-ort1.14.0-cu116
@@ -1,0 +1,50 @@
+# Use nvidia/cuda image
+FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
+CMD nvidia-smi
+
+# Ignore interactive questions during `docker build`
+ENV DEBIAN_FRONTEND noninteractive
+
+# Bash shell
+RUN chsh -s /bin/bash
+SHELL ["/bin/bash", "-c"]
+
+# Versions
+ARG TORCH_CUDA_VERSION=cu116
+ARG TORCH_VERSION=1.13.1
+ARG TORCHVISION_VERSION=0.14.1
+
+# Install and update tools to minimize security vulnerabilities
+RUN apt-get update
+RUN apt-get install -y software-properties-common wget apt-utils patchelf git libprotobuf-dev protobuf-compiler cmake \
+    bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 mercurial subversion libopenmpi-dev && \
+    apt-get clean
+RUN unattended-upgrade
+RUN apt-get autoremove -y
+
+# Install Pythyon (3.8 as default)
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN apt-get install -y python3-pip
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN pip install -U pip
+RUN pip install pygit2 pgzip
+
+# (Optional) Intall test dependencies
+RUN pip install git+https://github.com/huggingface/transformers
+RUN pip install datasets accelerate evaluate coloredlogs absl-py rouge_score seqeval scipy sacrebleu nltk scikit-learn parameterized sentencepiece
+RUN pip install fairscale deepspeed mpi4py
+# RUN pip install optuna ray sigopt wandb
+
+# Install onnxruntime-training dependencies
+RUN pip install onnx ninja
+RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION} -f https://download.pytorch.org/whl/cu116/torch_stable.html
+RUN pip install onnxruntime-training==1.14.0 -f https://download.onnxruntime.ai/onnxruntime_stable_cu116.html
+RUN pip install torch-ort
+RUN pip install --upgrade protobuf==3.20.2
+
+ARG TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
+
+WORKDIR .
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
# What does this PR do?

- [x] Create Dockerfile for onnxruntime-training 1.14.0
- [x] Update trainer documentation
- [x] Complete the fix in #737 (I only did the patch for `evaluation_loop_ort()` but not for `prediction_loop_ort`, but it is the same content)

