### PR TITLE
TAPASonnx `optimum.exporters.onnx` support

### DIFF
--- a/docs/source/exporters/onnx/package_reference/configuration.mdx
+++ b/docs/source/exporters/onnx/package_reference/configuration.mdx
@@ -122,6 +122,7 @@ They specify which input generators should be used for the dummy inputs, but rem
 - SqueezeBert
 - Stable Diffusion
 - T5
+- TAPAS
 - UniSpeech
 - UniSpeech SAT
 - Vit

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -93,6 +93,8 @@ class RoFormerOnnxConfig(BertOnnxConfig):
 class SqueezeBertOnnxConfig(BertOnnxConfig):
     pass
 
+class TAPASOnnxConfig(BertOnnxConfig):
+    pass
 
 class MobileBertOnnxConfig(BertOnnxConfig):
     pass

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -97,6 +97,7 @@ class ORTConfigManager:
         "nystromformer": "bert",
         "roberta": "bert",
         "t5": "t5",
+        "TAPAS": "bert",
         "whisper": "whisper",
         "xlm-roberta": "bert",
     }

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -88,6 +88,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "splinter": "hf-internal-testing/tiny-random-SplinterModel",
     "squeezebert": "hf-internal-testing/tiny-random-SqueezeBertModel",
     "swin": "hf-internal-testing/tiny-random-SwinModel",
+    "TAPAS": "hf-internal-testing/tiny-random-TapasModel", 
     "t5": "hf-internal-testing/tiny-random-t5",
     "vit": "hf-internal-testing/tiny-random-vit",
     "yolos": "hf-internal-testing/tiny-random-YolosModel",

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -39,6 +39,7 @@ class ORTOptimizerTest(unittest.TestCase):
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-gpt2"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-roberta"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-xlm-roberta"),
+        (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-TapasModel"),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_MODEL_ID)
@@ -75,12 +76,13 @@ class ORTOptimizerTest(unittest.TestCase):
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-LongT5ForConditionalGeneration", True),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-marian", False),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-marian", True),
-        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-mbart", False),
-        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-mbart", True),
-        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-onnx-mt5", False),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-onnx-mt5", True),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-m2m_100", False),
         (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-m2m_100", True),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-mbart", False),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-mbart", True),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-onnx-mt5", False),
+        (ORTModelForSeq2SeqLM, "hf-internal-testing/tiny-random-TapasModel", True)
     )
 
     @parameterized.expand(SUPPORTED_SEQ2SEQ_ARCHITECTURES_WITH_MODEL_ID)


### PR DESCRIPTION
# What does this PR do?
Added changes for TAPAS model. And rearranged alphabetical order in test_optimization.py files.

<!-- Remove if not applicable -->

Fixes #555 issue
