### PR TITLE
Temporarily disable segformer TensorRT test

### DIFF
--- a/.github/workflows/test_onnxruntime_gpu.yml
+++ b/.github/workflows/test_onnxruntime_gpu.yml
@@ -62,7 +62,7 @@ jobs:
           docker build -f tests/onnxruntime/Dockerfile_onnxruntime_gpu -t onnxruntime-gpu .
       - name: Test with unittest within docker container
         run: |
-          docker run --rm --gpus all --workdir=/workspace/optimum/tests onnxruntime-gpu:latest
+          docker run --rm --gpus all -v $(pwd)/hf_cache:/root/.cache/huggingface --workdir=/workspace/optimum/tests onnxruntime-gpu:latest
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/tests/onnxruntime/Dockerfile_onnxruntime_gpu
+++ b/tests/onnxruntime/Dockerfile_onnxruntime_gpu
@@ -17,11 +17,11 @@ RUN apt-get autoremove -y
 RUN python -m pip install -U pip
 
 RUN pip install transformers torch onnxruntime-gpu
-RUN pip install datasets evaluate scipy
+RUN pip install datasets evaluate diffusers scipy
 
 # Install Optimum
 COPY . /workspace/optimum
 RUN pip install /workspace/optimum[onnxruntime-gpu,tests]
 
 ENV TEST_LEVEL=1
-CMD pytest onnxruntime/test_*.py --durations=0 -s -m gpu_test
+CMD pytest onnxruntime/test_*.py --durations=0 -s -vvvvv -m gpu_test

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -2402,10 +2402,9 @@ class ORTModelForSemanticSegmentationIntegrationTest(ORTModelTestMixin):
         self.assertTrue(outputs[0]["mask"] is not None)
         self.assertTrue(isinstance(outputs[0]["label"], str))
 
+    # TODO: enable TensorrtExecutionProvider test once https://github.com/huggingface/optimum/issues/798 is fixed
     @parameterized.expand(
-        grid_parameters(
-            {"model_arch": SUPPORTED_ARCHITECTURES, "provider": ["CUDAExecutionProvider", "TensorrtExecutionProvider"]}
-        )
+        grid_parameters({"model_arch": SUPPORTED_ARCHITECTURES, "provider": ["CUDAExecutionProvider"]})
     )
     @require_torch_gpu
     @pytest.mark.gpu_test


### PR DESCRIPTION
As it yields a core dump that stops the workflow.