### PR TITLE
Add onnx support for FNet

### DIFF
--- a/docs/source/exporters/onnx/package_reference/configuration.mdx
+++ b/docs/source/exporters/onnx/package_reference/configuration.mdx
@@ -87,6 +87,7 @@ They specify which input generators should be used for the dummy inputs, but rem
 - DistilBert
 - Electra
 - Flaubert
+- FNet
 - GPT-2
 - GPT-J
 - GPT-Neo

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -110,6 +110,10 @@ class SplinterOnnxConfig(BertOnnxConfig):
     pass
 
 
+class FNetOnnxConfig(BertOnnxConfig):
+    pass
+
+
 class DistilBertOnnxConfig(BertOnnxConfig):
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -381,6 +381,15 @@ class TasksManager:
             onnx="FlaubertOnnxConfig",
             tflite="FlaubertTFLiteConfig",
         ),
+        "fnet": supported_tasks_mapping(
+            "default",
+            "masked-lm",
+            "sequence-classification",
+            "multiple-choice",
+            "token-classification",
+            "question-answering",
+            onnx="FNetOnnxConfig",
+        ),
         "gpt2": supported_tasks_mapping(
             "default",
             "default-with-past",

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -191,6 +191,7 @@ class NormalizedConfigManager:
         "deit": NormalizedVisionConfig,
         "distilbert": NormalizedTextConfig.with_args(num_attention_heads="n_heads", hidden_size="dim"),
         "electra": NormalizedTextConfig,
+        "fnet": NormalizedTextConfig,
         "gpt2": GPT2LikeNormalizedTextConfig,
         "gpt_neo": NormalizedTextConfig.with_args(num_attention_heads="num_heads"),
         "gpt_neox": NormalizedTextConfig,

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -52,6 +52,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "flaubert": "hf-internal-testing/tiny-random-flaubert",
+    "fnet": "hf-internal-testing/tiny-random-FNetModel",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "gpt-neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "gpt-neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
@@ -151,6 +152,7 @@ PYTORCH_EXPORT_MODELS_LARGE = {
     "distilbert": "distilbert-base-cased",
     "electra": "google/electra-base-generator",
     "flaubert": "hf-internal-testing/tiny-random-flaubert",  # TODO
+    "fnet": "google/fnet-base",
     "gpt2": "gpt2",
     "gpt-neo": "EleutherAI/gpt-neo-125M",
     "gpt-neox": "EleutherAI/gpt-neox-20b",


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #555

Add support for [FNet](https://huggingface.co/docs/transformers/model_doc/fnet), an architecture similar to BERT. 

@fxmarty, @ChainYo  & @michaelbenayoun,  could you give me a few pointers as to how to test the integration locally?

I did try to check the integration by following this [doc](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/contribute#exporting-the-model) but I'm not quite sure why I keep getting `ModuleNotFoundError: No module named 'onnx'` error text despite setting up the my devlopement setup such that
1. create a virtual environment
2. install dev packages in the virenv by running `pip install -e ".[dev]"`

## Before submitting
- [ ] Did you write any new necessary tests?

