### PR TITLE
[TFLite Export] Adds support for ResNet

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -582,9 +582,7 @@ class TasksManager:
             onnx="PoolFormerOnnxConfig",
         ),
         "resnet": supported_tasks_mapping(
-            "default",
-            "image-classification",
-            onnx="ResNetOnnxConfig",
+            "default", "image-classification", onnx="ResNetOnnxConfig", tflite="ResNetTFLiteConfig"
         ),
         "roberta": supported_tasks_mapping(
             "default",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -126,6 +126,7 @@ class TasksManager:
             "default": "TFAutoModel",
             "masked-lm": "TFAutoModelForMaskedLM",
             "causal-lm": "TFAutoModelForCausalLM",
+            "image-classification": "TFAutoModelForImageClassification",
             "seq2seq-lm": "TFAutoModelForSeq2SeqLM",
             "sequence-classification": "TFAutoModelForSequenceClassification",
             "token-classification": "TFAutoModelForTokenClassification",

--- a/optimum/exporters/tflite/config.py
+++ b/optimum/exporters/tflite/config.py
@@ -31,3 +31,11 @@ class TextEncoderTFliteConfig(TFLiteConfig):
 
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator,)
     MANDATORY_AXES = ("batch_size", "sequence_length", ("multiple-choice", "num_choices"))
+
+
+class VisionTFLiteConfig(TFLiteConfig):
+    """
+    Handles vision architectures.
+    """
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator,)

--- a/optimum/exporters/tflite/config.py
+++ b/optimum/exporters/tflite/config.py
@@ -38,4 +38,4 @@ class VisionTFLiteConfig(TFLiteConfig):
     Handles vision architectures.
     """
 
-    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator,)
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)

--- a/optimum/exporters/tflite/config.py
+++ b/optimum/exporters/tflite/config.py
@@ -17,7 +17,7 @@ Common TensorFlow Lite configuration classes that handle most of the features fo
 configurations.
 """
 
-from ...utils import DummyTextInputGenerator, logging
+from ...utils import DummyTextInputGenerator, DummyVisionInputGenerator, logging
 from .base import TFLiteConfig
 
 
@@ -39,3 +39,4 @@ class VisionTFLiteConfig(TFLiteConfig):
     """
 
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)
+    MANDATORY_AXES = ("batch_size", "num_channels", "width", "height")

--- a/optimum/exporters/tflite/model_configs.py
+++ b/optimum/exporters/tflite/model_configs.py
@@ -99,11 +99,9 @@ class DebertaV2TFLiteConfig(DebertaTFLiteConfig):
     pass
 
 
-class ViTTFLiteConfig(VisionTFLiteConfig):
+class ResNetTFLiteConfig(VisionTFLiteConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedConfigManager.get_normalized_config_class("resnet")
+
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:
         return {"pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}}
-
-
-class ResNetTFLiteConfig(ViTTFLiteConfig):
-    NORMALIZED_CONFIG_CLASS = NormalizedConfigManager.get_normalized_config_class("resnet")

--- a/optimum/exporters/tflite/model_configs.py
+++ b/optimum/exporters/tflite/model_configs.py
@@ -15,10 +15,10 @@
 """Model specific TensorFlow Lite configurations."""
 
 
-from typing import List
+from typing import Dict, List
 
 from ...utils.normalized_config import NormalizedConfigManager
-from .config import TextEncoderTFliteConfig
+from .config import TextEncoderTFliteConfig, VisionTFLiteConfig
 
 
 class BertTFLiteConfig(TextEncoderTFliteConfig):
@@ -97,3 +97,13 @@ class DebertaTFLiteConfig(BertTFLiteConfig):
 
 class DebertaV2TFLiteConfig(DebertaTFLiteConfig):
     pass
+
+
+class ViTTFLiteConfig(VisionTFLiteConfig):
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {"pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}}
+
+
+class ResNetTFLiteConfig(ViTTFLiteConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedConfigManager.get_normalized_config_class("resnet")

--- a/optimum/exporters/tflite/model_configs.py
+++ b/optimum/exporters/tflite/model_configs.py
@@ -15,7 +15,7 @@
 """Model specific TensorFlow Lite configurations."""
 
 
-from typing import Dict, List
+from typing import List
 
 from ...utils.normalized_config import NormalizedConfigManager
 from .config import TextEncoderTFliteConfig, VisionTFLiteConfig
@@ -103,5 +103,5 @@ class ResNetTFLiteConfig(VisionTFLiteConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedConfigManager.get_normalized_config_class("resnet")
 
     @property
-    def inputs(self) -> Dict[str, Dict[int, str]]:
+    def inputs(self) -> List[str]:
         return ["pixel_values"]

--- a/optimum/exporters/tflite/model_configs.py
+++ b/optimum/exporters/tflite/model_configs.py
@@ -104,4 +104,4 @@ class ResNetTFLiteConfig(VisionTFLiteConfig):
 
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:
-        return {"pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}}
+        return ["pixel_values"]


### PR DESCRIPTION
Adds ResNet support for TFLite export. 

I tried testing it with the following in isolation:

```python
from optimum.exporters.tflite import export, validate_model_outputs
from optimum.exporters.tasks import TasksManager
from transformers import AutoConfig
from optimum.exporters.tflite.model_configs import ResNetTFLiteConfig
from tempfile import NamedTemporaryFile
from pathlib import Path

task = "image-classification"
model_name = "microsoft/resnet-50"

model_class = TasksManager.get_model_class_for_task(task, framework="tf")
config = AutoConfig.from_pretrained(model_name)
model = model_class.from_config(config)
tflite_config = ResNetTFLiteConfig(model.config, task)
atol = tflite_config.ATOL_FOR_VALIDATION

with NamedTemporaryFile("w") as output:
    try:
        _, tflite_outputs = export(
            model=model,
            config=tflite_config,
            output=Path(output.name),
        )

        validate_model_outputs(
            config=tflite_config,
            reference_model=model,
            tflite_model_path=Path(output.name),
            tflite_named_outputs=tflite_outputs,
            atol=atol,
        )
    except (RuntimeError, ValueError) as e:
        print(f"{task} -> {e}")

```

It's leading to:

```bash
Traceback (most recent call last):
  File "test.py", line 19, in <module>
    _, tflite_outputs = export(
  File "/home/jupyter/optimum/optimum/exporters/tflite/convert.py", line 171, in export
    signatures = config.model_to_signatures(model)
  File "/home/jupyter/optimum/optimum/exporters/tflite/base.py", line 285, in model_to_signatures
    function = tf.function(forward, input_signature=self.inputs_specs).get_concrete_function()
  File "/home/jupyter/optimum/optimum/exporters/tflite/base.py", line 165, in __getattr__
    raise AttributeError(attr_name)
AttributeError: inputs_specs
```

My TensorFlow version is 2.10.1. 

Am I missing out on something? 
