### PR TITLE
Fix GPU tests

### DIFF
--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -251,7 +251,10 @@ class ORTDecoder(ORTModelPart):
         attention_mask: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
         labels: Optional[torch.LongTensor] = None,
+        use_cache_branch: None = None,
     ) -> CausalLMOutputWithCrossAttentions:
+        # adding use_cache_branch in the signature here is just a hack for IO Binding
+
         # Flatten the past_key_values
         if past_key_values is not None:
             past_key_values = [past_key_value for pkv_per_layer in past_key_values for past_key_value in pkv_per_layer]

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -284,6 +284,9 @@ class ORTModel(OptimizedModel):
         """
         device, provider_options = parse_device(device)
 
+        if device.type == "cuda" and self.providers[0] == "TensorrtExecutionProvider":
+            return self
+
         if device.type == "cuda" and self._use_io_binding is False:
             self.use_io_binding = True
             logger.info(

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -290,7 +290,7 @@ class ORTEncoderForWhisper(ORTEncoder):
     ) -> BaseModelOutput:
         if self.parent_model.device.type == "cuda" and self.parent_model.use_io_binding:
             io_binding, output_shapes, output_buffers = self.parent_model._prepare_io_binding(
-                self.session, input_features
+                self.session, input_features, ordered_input_names=self._ordered_input_names
             )
 
             io_binding.synchronize_inputs()
@@ -324,7 +324,7 @@ class ORTEncoderForVisionEncoderDecoder(ORTEncoder):
     ) -> BaseModelOutput:
         if self.parent_model.device.type == "cuda" and self.parent_model.use_io_binding:
             io_binding, output_shapes, output_buffers = self.parent_model._prepare_io_binding(
-                self.session, pixel_values
+                self.session, pixel_values, ordered_input_names=self._ordered_input_names
             )
 
             io_binding.synchronize_inputs()
@@ -805,6 +805,9 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             `ORTModel`: the model placed on the requested device.
         """
         device, provider_options = parse_device(device)
+
+        if device.type == "cuda" and self.providers[0] == "TensorrtExecutionProvider":
+            return self
 
         provider = get_provider_for_device(device)
         validate_provider_availability(provider)  # raise error if the provider is not available

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1952,6 +1952,7 @@ class ORTModelForCausalLMIntegrationTest(ORTModelTestMixin):
 
             pipe = pipeline("text-generation", model=onnx_model, tokenizer=tokenizer, device=0)
             text = "My Name is Philipp and i live"
+
             outputs = pipe(text)
             # check model device
             self.assertEqual(pipe.model.device.type.lower(), "cuda")


### PR DESCRIPTION
Some tests started failing following https://github.com/huggingface/optimum/pull/796

The tests
```
test_pipeline_on_trt_execution_provider_0_t5_True
test_pipeline_on_trt_execution_provider_1_t5_False
```

are still failing with shape inference error:
```
E       onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Exception during initialization: /onnxruntime_src/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc:897 SubGraphCollection_t onnxruntime::TensorrtExecutionProvider::GetSupportedList(SubGraphCollection_t, int, int, const onnxruntime::GraphViewer&, bool*) const [ONNXRuntimeError] : 1 : FAIL : TensorRT input: /block.0/layer.0/SelfAttention/Abs_output_0 has no shape specified. Please run shape inference on the onnx model first. Details can be found in https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#shape-inference-for-tensorrt-subgraphs
```