### PR TITLE
Update modeling_ort.py

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -554,6 +554,7 @@ class ORTModel(OptimizedModel):
         provider_options: Optional[Dict[str, Any]] = None,
         use_io_binding: Optional[bool] = None,
         task: Optional[str] = None,
+        **kwargs
     ) -> "ORTModel":
         if task is None:
             task = cls._auto_model_to_task(cls.auto_model_class)


### PR DESCRIPTION
Fixes an issue when extra keyword args (e.g. file_name) are passed to this method

# What does this PR do?
I have a function that dynamically loads the appropriate ORTforXYZ model based on the task, optimization level, quantization method etc... It determines the `path` and `file_name` as required and everything generally works well.

However, if I also pass in `from_transformers=True`, I get an error because this method doesn't have a `**kwargs` parameter. 

My only workaround is to create a separate call with all the same parameters, except `file_name`. But if this kwargs parameter were added, I could just pass it in and it would be ignored by `_from_transformers()`

Fixes # n/a


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?

