### PR TITLE
Update ONNX Runtime training doc - use torchrun

### DIFF
--- a/examples/onnxruntime/training/image-classification/README.md
+++ b/examples/onnxruntime/training/image-classification/README.md
@@ -27,7 +27,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example trains ViT on beans dataset with mixed precision (fp16).
 
 ```bash
-python run_image_classification.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_image_classification.py \
     --model_name_or_path google/vit-base-patch16-224-in21k \
     --dataset_name beans \
     --output_dir ./beans_outputs/ \

--- a/examples/onnxruntime/training/language-modeling/README.md
+++ b/examples/onnxruntime/training/language-modeling/README.md
@@ -29,7 +29,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example trains GPT2 on wikitext-2 with mixed precision (fp16).
 
 ```bash
-python run_clm.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_clm.py \
     --model_name_or_path gpt2 \
     --dataset_name wikitext \
     --dataset_config_name wikitext-2-raw-v1 \

--- a/examples/onnxruntime/training/question-answering/README.md
+++ b/examples/onnxruntime/training/question-answering/README.md
@@ -33,7 +33,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example fine-tunes a BERT on the SQuAD 1.0 dataset.
 
 ```bash
-python run_qa.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_qa.py \
     --model_name_or_path bert-base-uncased \
     --dataset_name squad \
     --do_train \

--- a/examples/onnxruntime/training/summarization/README.md
+++ b/examples/onnxruntime/training/summarization/README.md
@@ -38,7 +38,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example fine-tunes a BERT on the SQuAD 1.0 dataset.
 
 ```bash
-python run_summarization.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_summarization.py \
     --model_name_or_path t5-small \
     --dataset_name cnn_dailymail \
     --dataset_config "3.0.0" \

--- a/examples/onnxruntime/training/text-classification/README.md
+++ b/examples/onnxruntime/training/text-classification/README.md
@@ -31,7 +31,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example fine-tunes a BERT on the sst-2 task.
 
 ```bash
-python run_glue.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_glue.py \
     --model_name_or_path bert-base-uncased \
     --task_name sst2 \
     --do_train \

--- a/examples/onnxruntime/training/token-classification/README.md
+++ b/examples/onnxruntime/training/token-classification/README.md
@@ -31,7 +31,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example fine-tunes a BERT on the sst-2 task.
 
 ```bash
-python run_ner.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_ner.py \
     --model_name_or_path bert-base-cased \
     --dataset_name conll2003 \
     --do_train \

--- a/examples/onnxruntime/training/translation/README.md
+++ b/examples/onnxruntime/training/translation/README.md
@@ -38,7 +38,7 @@ __The following example applies the acceleration features powered by ONNX Runtim
 The following example fine-tunes a T5 large model on the wmt16 dataset.
 
 ```bash
-python run_translation.py \
+torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_translation.py \
     --model_name_or_path t5-large \
     --dataset_name wmt16 \
     --dataset_config ro-en \


### PR DESCRIPTION
# What does this PR do?

Update readmes to use torchrun for DDP, as the current snippets use DP which are not suggested by PyTorch anymore.