### PR TITLE
Fix ONNX export tests

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -356,12 +356,11 @@ class BartOnnxConfig(TextSeq2SeqOnnxConfig):
         dummy_decoder_text_input_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[1][task](
             self.task, self._normalized_config, **kwargs
         )
-        kwargs = {}
         if self.task != "causal-lm":
             kwargs["encoder_sequence_length"] = dummy_text_input_generator.sequence_length
 
         dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2][task](
-            self.task, self._normalized_config, batch_size=dummy_text_input_generator.batch_size, **kwargs
+            self.task, self._normalized_config, **kwargs
         )
         dummy_inputs_generators = [
             dummy_text_input_generator,

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -15,7 +15,7 @@
 
 VALIDATE_EXPORT_ON_SHAPES_SLOW = {
     "batch_size": [2, 4, 6],
-    "sequence_length": [8, 17, 33, 64, 96, 154],
+    "sequence_length": [8, 19, 33, 64, 96, 154],
     "num_choices": [2, 4],
 }
 

--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -255,11 +255,11 @@ class OnnxExportTestCase(TestCase):
                     input_shapes_iterator = grid_parameters(shapes_to_validate, yield_dict=True, add_test_name=False)
                     for input_shapes in input_shapes_iterator:
                         skip = False
-                        for model_onnx_conf in models_and_onnx_configs:
+                        for _, model_onnx_conf in models_and_onnx_configs.items():
                             if (
                                 hasattr(model_onnx_conf[0].config, "max_position_embeddings")
-                                and model_onnx_conf[0].config.max_position_embeddings
-                                >= input_shapes["sequence_length"]
+                                and input_shapes["sequence_length"]
+                                >= model_onnx_conf[0].config.max_position_embeddings
                             ):
                                 skip = True
                                 break

--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -314,7 +314,7 @@ class OnnxExportTestCase(TestCase):
     @require_vision
     @pytest.mark.run_slow
     @slow
-    def test_pytorch_export(
+    def test_pytorch_export_on_cpu(
         self,
         test_name,
         name,


### PR DESCRIPTION
A few slow tests were yet again broken due to the monolith + with-past deprecation, and due to the testing on several shapes.