### PR TITLE
Fix exporters GPU CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ EXTRAS_REQUIRE = {
         "protobuf>=3.20.1",
     ],
     "exporters": ["onnx", "onnxruntime", "timm"],
+    "exporters-gpu": ["onnx", "onnxruntime-gpu", "timm"],
     "exporters-tf": ["tensorflow>=2.4,<2.11", "tf2onnx", "onnx", "onnxruntime", "timm", "h5py", "numpy<1.24.0"],
     "intel": "optimum-intel",
     "openvino": "optimum-intel[openvino]",

--- a/tests/exporters/Dockerfile_exporters_gpu
+++ b/tests/exporters/Dockerfile_exporters_gpu
@@ -16,12 +16,14 @@ RUN apt-get autoremove -y
 
 RUN python -m pip install -U pip
 
-RUN pip install transformers torch onnxruntime-gpu
-RUN pip install datasets evaluate diffusers scipy
+RUN pip install torch scipy datasets evaluate diffusers
+
+RUN pip install transformers
+RUN pip install onnxruntime-gpu
 
 # Install Optimum
 COPY . /workspace/optimum
-RUN pip install /workspace/optimum[onnxruntime-gpu,tests,exporters]
+RUN pip install /workspace/optimum[onnxruntime-gpu,tests,exporters-gpu]
 
 ENV TEST_LEVEL=1
 ENV RUN_SLOW=1


### PR DESCRIPTION
Fixing it yet again, this time due to a conflicting `onnxruntime` and `onnxruntime-gpu` install.