### PR TITLE
Fix duplicate name merged decoder

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -277,9 +277,9 @@ class TasksManager:
         ),
         "codegen": supported_tasks_mapping(
             "default",
-            # "default-with-past",
+            "default-with-past",
             "causal-lm",
-            # "causal-lm-with-past",
+            "causal-lm-with-past",
             onnx="CodeGenOnnxConfig",
         ),
         "convbert": supported_tasks_mapping(


### PR DESCRIPTION
As per comment in the PR, we had duplicated initializer names pointing out to different data. This was the case for codegen.

All slow tests pass for codegen, merging this one for the release as requested.