### PR TITLE
Adding support for Facebook's OPT models

### DIFF
--- a/docs/source/exporters/onnx/overview.mdx
+++ b/docs/source/exporters/onnx/overview.mdx
@@ -45,6 +45,7 @@ Supported architectures:
 - GPT-J
 - GPT-Neo
 - GPT-NeoX
+- OPT
 - GroupVit
 - Hubert
 - IBert

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -192,6 +192,11 @@ class GPTNeoXOnnxConfig(TextDecoderOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
 
 
+class OPTOnnxConfig(TextDecoderOnnxConfig):
+    DEFAULT_ONNX_OPSET = 13
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+
+
 class BloomDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
     def generate(self, input_name: str, framework: str = "pt"):
         past_key_shape = (

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -416,15 +416,6 @@ class TasksManager:
             "causal-lm-with-past",
             onnx="GPTNeoXOnnxConfig",
         ),
-        "opt": supported_tasks_mapping(
-            "default",
-            "default-with-past",
-            "causal-lm",
-            "causal-lm-with-past",
-            "question-answering",
-            "sequence-classification",
-            onnx="OPTOnnxConfig",
-        ),
         "groupvit": supported_tasks_mapping(
             "default",
             onnx="GroupViTOnnxConfig",
@@ -572,6 +563,15 @@ class TasksManager:
         #     "zero-shot-object-detection",
         #     onnx="OwlViTOnnxConfig",
         # ),
+        "opt": supported_tasks_mapping(
+            "default",
+            "default-with-past",
+            "causal-lm",
+            "causal-lm-with-past",
+            "question-answering",
+            "sequence-classification",
+            onnx="OPTOnnxConfig",
+        ),
         "pegasus": supported_tasks_mapping(
             "default",
             "default-with-past",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -423,7 +423,7 @@ class TasksManager:
             "causal-lm-with-past",
             "question-answering",
             "sequence-classification",
-            onnx="OPTJOnnxConfig",
+            onnx="OPTOnnxConfig",
         ),
         "groupvit": supported_tasks_mapping(
             "default",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -416,6 +416,15 @@ class TasksManager:
             "causal-lm-with-past",
             onnx="GPTNeoXOnnxConfig",
         ),
+        "opt": supported_tasks_mapping(
+            "default",
+            "default-with-past",
+            "causal-lm",
+            "causal-lm-with-past",
+            "question-answering",
+            "sequence-classification",
+            onnx="OPTJOnnxConfig",
+        ),
         "groupvit": supported_tasks_mapping(
             "default",
             onnx="GroupViTOnnxConfig",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -74,6 +74,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "mpnet": "hf-internal-testing/tiny-random-MPNetModel",
     "mt5": "lewtun/tiny-random-mt5",
     "nystromformer": "hf-internal-testing/tiny-random-NystromformerModel",
+    "opt": "hf-internal-testing/tiny-random-OPTModel",
     # "owlvit": "google/owlvit-base-patch32",
     "pegasus": "hf-internal-testing/tiny-random-PegasusModel",
     "perceiver": {


### PR DESCRIPTION
# What does this PR do?

I noticed that there is still no support for exporting to ONNX `facebook/opt-{x}` models when I needed them. Therefore, I propose very simple changes that add this support.

I checked the ability to export models with 350M, 1.3B and 6.7B parameters on A100 40GB, as you can see from the results, they can be used. Although, not all outputs for 1.3B and 6.7B models are successfully checked for closeness, in my experience, this is not something terrible.

I am [attaching](https://pastebin.com/xtRgtRYF) the export log of the 1.3B model with the `causal-lm-with-past` task.

_Note: 80GB of free RAM is not enough to export 13B OPT model._
