### PR TITLE
Support scaled_dot_product_attention for t5

### DIFF
--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -18,6 +18,7 @@ from .decoder_models import (
     GPT2AttentionLayerBetterTransformer,
     GPTNeoAttentionLayerBetterTransformer,
     OPTAttentionLayerBetterTransformer,
+    T5AttentionLayerBetterTransformer,
 )
 from .encoder_models import (
     AlbertLayerBetterTransformer,
@@ -66,6 +67,7 @@ class BetterTransformerManager:
         "roformer": ("RoFormerLayer", BertLayerBetterTransformer),
         "splinter": ("SplinterLayer", BertLayerBetterTransformer),
         "tapas": ("TapasLayer", BertLayerBetterTransformer),
+        "t5": ("T5Attention", T5AttentionLayerBetterTransformer),
         "vilt": ("ViltLayer", ViltLayerBetterTransformer),
         "vit": ("ViTLayer", ViTLayerBetterTransformer),
         "vit_mae": ("ViTMAELayer", ViTLayerBetterTransformer),
@@ -87,7 +89,6 @@ class BetterTransformerManager:
     CAN_NOT_BE_SUPPORTED = {
         "deberta-v2": "DeBERTa v2 does not use a regular attention mechanism, which is not supported in PyTorch's BetterTransformer.",
         "glpn": "GLPN has a convolutional layer present in the FFN network, which is not supported in PyTorch's BetterTransformer.",
-        "t5": "T5 uses attention bias, which is not supported in PyTorch's BetterTransformer.",
     }
 
     @staticmethod
@@ -121,7 +122,7 @@ class BetterTransformerManager:
             model_type (`str`):
                 The model type to check.
         """
-        if model_type in ["codegen", "gpt2", "gptj", "gpt_neo", "gpt_neox", "opt"]:
+        if model_type in ["codegen", "gpt2", "gptj", "gpt_neo", "gpt_neox", "opt", "t5"]:
             return False
         else:
             return True
@@ -135,7 +136,7 @@ class BetterTransformerManager:
             model_type (`str`):
                 The model type to check.
         """
-        if model_type in ["codegen", "gpt2", "gptj", "gpt_neo", "gpt_neox", "opt"]:
+        if model_type in ["codegen", "gpt2", "gptj", "gpt_neo", "gpt_neox", "opt", "t5"]:
             return False
         else:
             return True
@@ -149,7 +150,7 @@ class BetterTransformerManager:
             model_type (`str`):
                 The model type to check.
         """
-        if model_type in ["codegen", "gpt2", "gptj", "gpt_neo", "gpt_neox", "opt"]:
+        if model_type in ["codegen", "gpt2", "gptj", "gpt_neo", "gpt_neox", "opt", "t5"]:
             return True
         else:
             return False

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -347,6 +347,8 @@ class T5AttentionLayerBetterTransformer(BetterTransformerBaseLayer):
         use_cache=False,
         output_attentions=False,
     ):
+        super().forward_checker()
+        raise_on_head_mask(layer_head_mask)
         if len(self.layer.pruned_heads) > 0:
             raise ValueError(
                 f"Setting `pruned_heads` is unsupported with BetterTransformer, found {self.layer.pruned_heads}."

--- a/tests/bettertransformer/testing_utils.py
+++ b/tests/bettertransformer/testing_utils.py
@@ -42,7 +42,7 @@ MODELS_DICT = {
     "hubert": "ybelkada/hubert-tiny-random",
     "layoutlm": "hf-internal-testing/tiny-random-LayoutLMModel",
     "m2m_100": "hf-internal-testing/tiny-random-nllb",
-    "marian": "hf-internal-testing/tiny-random-marian",
+    "marian": "fxmarty/tiny-marian",  # the other tiny ones have a too small max_position_embeddings
     "markuplm": "hf-internal-testing/tiny-random-MarkupLMModel",
     "mbart": "hf-internal-testing/tiny-random-mbart",
     "opt": "hf-internal-testing/tiny-random-OPTModel",
@@ -52,6 +52,7 @@ MODELS_DICT = {
     "roformer": "hf-internal-testing/tiny-random-RoFormerModel",
     "splinter": "hf-internal-testing/tiny-random-SplinterModel",
     "tapas": "hf-internal-testing/tiny-random-TapasModel",
+    "t5": "hf-internal-testing/tiny-random-t5",
     "vilt": "hf-internal-testing/tiny-vilt-random-vqa",
     "vit": "hf-internal-testing/tiny-random-ViTModel",
     "vit_mae": "hf-internal-testing/tiny-random-ViTMAEModel",


### PR DESCRIPTION
This is only usable for the decoder, with [`T5LayerCrossAttention`](https://github.com/huggingface/transformers/blob/820c46a707ddd033975bc3b0549eea200e64c7da/src/transformers/models/t5/modeling_t5.py#L647) as discussed offline, due to the position bias present in `T5LayerSelfAttention`.