### PR TITLE
[`BT`] Add fp16 support

### DIFF
--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -215,9 +215,10 @@ class CodegenAttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 # torch.Tensor.expand does no memory copy
                 causal_mask = causal_mask.expand(batch_size, -1, -1, -1)
 
-                mask_value = torch.finfo(value.dtype).min
-                attention_mask = torch.full([], mask_value, dtype=value.dtype).to(value.device)
+                # sum masks
+                attention_mask = causal_mask + attention_mask
 
+            attention_mask = attention_mask.to(value.device, value.dtype)
             query = query.to(value.dtype)
             key = key.to(value.dtype)
 

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -80,6 +80,7 @@ class GPT2AttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 causal_mask = causal_mask.expand(batch_size, -1, -1, -1)
                 attention_mask = causal_mask + attention_mask
 
+            attention_mask = attention_mask.to(torch.bool)
             sdpa_result = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
             )
@@ -143,7 +144,7 @@ class GPTNeoAttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 # torch.Tensor.expand does no memory copy
                 causal_mask = causal_mask.expand(batch_size, -1, -1, -1)
             attention_mask = causal_mask + attention_mask
-
+            attention_mask = attention_mask.to(torch.bool)
             sdpa_result = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
             )
@@ -209,6 +210,7 @@ class CodegenAttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 # we use torch.min to avoid having tensor(-inf)
                 attention_mask = torch.min(causal_mask, attention_mask)
 
+            attention_mask = attention_mask.to(torch.bool)
             sdpa_result = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
             )

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -216,8 +216,8 @@ class CodegenAttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 # torch.Tensor.expand does no memory copy
                 causal_mask = causal_mask.expand(batch_size, -1, -1, -1)
 
-                # sum masks
-                attention_mask = causal_mask + attention_mask
+                # we use torch.min to avoid having tensor(-inf)
+                attention_mask = torch.min(causal_mask, attention_mask)
 
             # in codegen the query and key are always in fp32 regardless of the dtype of the model
             # https://github.com/huggingface/transformers/blob/5b28b7833297adf65c5160a685425ddb1eee5ce2/src/transformers/models/codegen/modeling_codegen.py#L226

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -52,8 +52,7 @@ class GPT2AttentionLayerBetterTransformer(BetterTransformerBaseLayer):
         raise_on_head_mask(head_mask)
         batch_size = query.shape[0]
 
-        mask_value = torch.finfo(value.dtype).min
-        attention_mask = torch.full([], mask_value, dtype=value.dtype).to(value.device)
+        attention_mask = attention_mask.to(value.device, value.dtype)
 
         if batch_size == 1 and attention_mask is not None and attention_mask[0, 0, 0, -1] < -1:
             raise ValueError("BetterTransformer does not support padding='max_length' with a batch size of 1.")
@@ -128,8 +127,7 @@ class GPTNeoAttentionLayerBetterTransformer(BetterTransformerBaseLayer):
         query = query * self.scale
         batch_size = query.shape[0]
 
-        mask_value = torch.finfo(value.dtype).min
-        attention_mask = torch.full([], mask_value, dtype=value.dtype).to(value.device)
+        attention_mask = attention_mask.to(value.device, value.dtype)
 
         if batch_size == 1 and attention_mask is not None and attention_mask[0, 0, 0, -1] < -1:
             raise ValueError("BetterTransformer does not support padding='max_length' with a batch size of 1.")

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -81,6 +81,10 @@ class GPT2AttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 attention_mask = causal_mask + attention_mask
 
             attention_mask = attention_mask.to(torch.bool)
+
+            query = query.to(value.dtype)
+            key = key.to(value.dtype)
+
             sdpa_result = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
             )
@@ -211,6 +215,10 @@ class CodegenAttentionLayerBetterTransformer(BetterTransformerBaseLayer):
                 attention_mask = torch.min(causal_mask, attention_mask)
 
             attention_mask = attention_mask.to(torch.bool)
+
+            query = query.to(value.dtype)
+            key = key.to(value.dtype)
+
             sdpa_result = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
             )

--- a/tests/bettertransformer/test_decoder.py
+++ b/tests/bettertransformer/test_decoder.py
@@ -15,7 +15,6 @@
 import unittest
 
 import pytest
-from optimum.utils.testing_utils import require_torch_gpu
 import torch
 from packaging.version import parse
 from parameterized import parameterized
@@ -24,7 +23,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from optimum.bettertransformer import BetterTransformer, BetterTransformerManager
 from optimum.utils import DummyPastKeyValuesGenerator, NormalizedConfigManager
-from optimum.utils.testing_utils import grid_parameters
+from optimum.utils.testing_utils import grid_parameters, require_torch_gpu
 
 
 class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCase):

--- a/tests/bettertransformer/test_decoder.py
+++ b/tests/bettertransformer/test_decoder.py
@@ -67,15 +67,16 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         grid_parameters(
             {
                 "model_type": SUPPORTED_ARCH,
+                "use_to_operator": [True, False],
             }
         )
     )
     @pytest.mark.fp16
-    def test_fp16_inference(self, test_name: str, model_type: str):
+    def test_fp16_inference(self, test_name: str, model_type: str, use_to_operator: bool):
         self._skip_on_torch_version(model_type)
 
         model_id = MODELS_DICT[model_type]
-        super()._test_fp16_inference(model_id)
+        super()._test_fp16_inference(model_id, use_to_operator=use_to_operator)
 
     @parameterized.expand(
         grid_parameters(

--- a/tests/bettertransformer/test_decoder.py
+++ b/tests/bettertransformer/test_decoder.py
@@ -15,6 +15,7 @@
 import unittest
 
 import pytest
+from optimum.utils.testing_utils import require_torch_gpu
 import torch
 from packaging.version import parse
 from parameterized import parameterized
@@ -72,6 +73,7 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         )
     )
     @pytest.mark.fp16
+    @require_torch_gpu
     def test_fp16_inference(self, test_name: str, model_type: str, use_to_operator: bool):
         self._skip_on_torch_version(model_type)
 

--- a/tests/bettertransformer/test_decoder.py
+++ b/tests/bettertransformer/test_decoder.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import unittest
 
+import pytest
 import torch
 from packaging.version import parse
 from parameterized import parameterized
@@ -61,6 +62,20 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
 
         model_id = MODELS_DICT[model_type]
         super()._test_logits(model_id, padding=padding, batch_size=batch_size)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_type": SUPPORTED_ARCH,
+            }
+        )
+    )
+    @pytest.mark.fp16
+    def test_fp16_inference(self, test_name: str, model_type: str):
+        self._skip_on_torch_version(model_type)
+
+        model_id = MODELS_DICT[model_type]
+        super()._test_fp16_inference(model_id)
 
     @parameterized.expand(
         grid_parameters(

--- a/tests/bettertransformer/testing_utils.py
+++ b/tests/bettertransformer/testing_utils.py
@@ -104,10 +104,15 @@ class BetterTransformersTestMixin:
             has not been converted to a fast model. The check is done above.
             """
             torch.manual_seed(0)
-            _ = hf_random_model.generate(**inputs)
+            output_hf = hf_random_model.generate(**inputs)
 
             torch.manual_seed(0)
-            _ = converted_model.generate(**inputs)
+            output_bt = converted_model.generate(**inputs)
+
+            self.assertTrue(
+                torch.allclose(output_hf, output_bt, atol=1e-4),
+                f"The logits of the converted model {converted_model.__class__.__name__} are not equal to the logits of the original model {hf_random_model.__class__.__name__}.",  
+            )
 
     def _test_logits(self, model_id: str, **preprocessor_kwargs):
         r"""

--- a/tests/bettertransformer/testing_utils.py
+++ b/tests/bettertransformer/testing_utils.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 import torch
-from transformers import AutoModel
+from transformers import AutoModel, AutoModelForCausalLM
 
 from optimum.bettertransformer import BetterTransformer
-from optimum.utils.testing_utils import flatten_dict
+from optimum.utils.testing_utils import flatten_dict, require_torch_gpu
 
 
 MODELS_DICT = {
@@ -78,6 +78,36 @@ class BetterTransformersTestMixin:
 
     def prepare_inputs_for_class(self, model_id=None):
         raise NotImplementedError
+
+    @require_torch_gpu
+    def _test_fp16_inference(self, model_id: str, **preprocessor_kwargs):
+        r"""
+        This tests if the converted model runs fine under fp16.
+        """
+        # The first row of the attention mask needs to be all ones -> check: https://github.com/pytorch/pytorch/blob/19171a21ee8a9cc1a811ac46d3abd975f0b6fc3b/test/test_nn.py#L5283
+        inputs = self.prepare_inputs_for_class(model_id=model_id, **preprocessor_kwargs).to(0)
+
+        torch.manual_seed(0)
+        hf_random_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16).eval().to(0)
+
+        torch.manual_seed(0)
+        converted_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)
+
+        self.assertFalse(
+            hasattr(hf_random_model, "use_bettertransformer"),
+            f"The model {hf_random_model.__class__.__name__} has been converted to a `fast` model by mistake.",
+        )
+
+        with torch.no_grad():
+            r"""
+            Make sure the models are in eval mode! Make also sure that the original model
+            has not been converted to a fast model. The check is done above.
+            """
+            torch.manual_seed(0)
+            _ = hf_random_model.generate(**inputs)
+
+            torch.manual_seed(0)
+            _ = converted_model.generate(**inputs)
 
     def _test_logits(self, model_id: str, **preprocessor_kwargs):
         r"""

--- a/tests/bettertransformer/testing_utils.py
+++ b/tests/bettertransformer/testing_utils.py
@@ -111,7 +111,7 @@ class BetterTransformersTestMixin:
 
             self.assertTrue(
                 torch.allclose(output_hf, output_bt, atol=1e-4),
-                f"The logits of the converted model {converted_model.__class__.__name__} are not equal to the logits of the original model {hf_random_model.__class__.__name__}.",  
+                f"The logits of the converted model {converted_model.__class__.__name__} are not equal to the logits of the original model {hf_random_model.__class__.__name__}.",
             )
 
     def _test_logits(self, model_id: str, **preprocessor_kwargs):

--- a/tests/bettertransformer/testing_utils.py
+++ b/tests/bettertransformer/testing_utils.py
@@ -80,7 +80,7 @@ class BetterTransformersTestMixin:
         raise NotImplementedError
 
     @require_torch_gpu
-    def _test_fp16_inference(self, model_id: str, **preprocessor_kwargs):
+    def _test_fp16_inference(self, model_id: str, use_to_operator=False, **preprocessor_kwargs):
         r"""
         This tests if the converted model runs fine under fp16.
         """
@@ -88,7 +88,10 @@ class BetterTransformersTestMixin:
         inputs = self.prepare_inputs_for_class(model_id=model_id, **preprocessor_kwargs).to(0)
 
         torch.manual_seed(0)
-        hf_random_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16).eval().to(0)
+        if not use_to_operator:
+            hf_random_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16).to(0)
+        else:
+            hf_random_model = AutoModelForCausalLM.from_pretrained(model_id).to(0, torch.float16)
 
         torch.manual_seed(0)
         converted_model = BetterTransformer.transform(hf_random_model, keep_original_model=True)


### PR DESCRIPTION
# What does this PR do?

Currently on the `main` branch the fp16 inference for BetterTransformer decoder models is not supported, this PR aims to fix this

## TODO

- [x] add tests


cc @fxmarty 
