### PR TITLE
Update optimization.py to support ORTModelForSpeechSeq2Seq models

### DIFF
--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -29,7 +29,7 @@ from ..utils.save_utils import maybe_save_preprocessors
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_decoder import ORTModelForCausalLM
 from .modeling_ort import ORTModel
-from .modeling_seq2seq import ORTModelForSeq2SeqLM
+from .modeling_seq2seq import ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq
 from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
 
 
@@ -83,7 +83,7 @@ class ORTOptimizer:
         onnx_model_path = []
         config = None
         if isinstance(model_or_path, ORTModel):
-            if isinstance(model_or_path, ORTModelForSeq2SeqLM):
+            if isinstance(model_or_path, (ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq)):
                 onnx_model_path += [
                     model_or_path.encoder_model_path,
                     model_or_path.decoder_model_path,


### PR DESCRIPTION
# What does this PR do?

In the ORTOptimizer, models of ORTModelForSpeechSeq2Seq (like Whisper) which has encoder, decoder and decoder_with_past_model (as same as ORTModelForSeq2SeqLM) models are not supported
So ORTModelForSpeechSeq2Seq is added.

https://github.com/huggingface/optimum/blob/main/optimum/onnxruntime/optimization.py#L86

Fixes # (issue)


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

