### PR TITLE
Remove positional-only parameters not support by python < v3.8

### DIFF
--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -34,7 +34,7 @@ if is_accelerate_available():
 ERROR_MESSAGE = r"The Better Transformers implementation for the model {model_name} has not been implemented yet. Please open an issue requesting the addition of this model with its `BetterTransformer` implementation."
 
 
-def raise_save_or_push_incompatible(dummy, /, *_, **__):
+def raise_save_or_push_incompatible(*_, **__):
     r"""
     Simply raise an error if the user tries to save or push a model that is not compatible with
     `BetterTransformer` and needs to be reverted to the original model before calling these


### PR DESCRIPTION
The [syntax](https://peps.python.org/pep-0570/) for specifying positional-only parameters in python function was introduced in python v3.8 and will throw error for lower version (for `v3.7` in our case)