### PR TITLE
Automatic support for large ONNX models in ORTOptimizer

### DIFF
--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -447,6 +447,7 @@ def export_pytorch(
                 )
 
             # check if external data was exported
+            # TODO: this is quite inefficient as we load in memory if models are <2GB without external data
             onnx_model = onnx.load(str(output), load_external_data=False)
             model_uses_external_data = check_model_uses_external_data(onnx_model)
 

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -129,7 +129,7 @@ class ORTOptimizer:
         optimization_config: OptimizationConfig,
         save_dir: Union[str, os.PathLike],
         file_suffix: Optional[str] = "optimized",
-        use_external_data_format: bool = None,
+        use_external_data_format: Optional[bool] = None,
         one_external_file: bool = True,
     ):
         """
@@ -142,7 +142,7 @@ class ORTOptimizer:
                 The path used to save the optimized model.
             file_suffix (`str`, defaults to `"optimized"`):
                 The file suffix used to save the optimized model.
-            use_external_data_format (`bool`, defaults to `False`):
+            use_external_data_format (`Optional[bool]`, defaults to `None`):
                 Whether to use external data format to store model of size >= 2Gb. This argument is deprecated.
             one_external_file (`bool`, defaults to `True`):
                 When `use_external_data_format=True`, whether to save all tensors to one external file.

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -13,18 +13,19 @@
 #  limitations under the License.
 """Main class for performing graph optimization with ONNX Runtime."""
 
-import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+import onnx
 from onnx import load_model
 from transformers.models.auto.configuration_auto import AutoConfig
 
 from onnxruntime.transformers.onnx_model_bert import BertOnnxModel
 from onnxruntime.transformers.optimizer import optimize_model
 
-from ..utils import CONFIG_NAME, NormalizedConfigManager
+from ..onnx.utils import check_model_uses_external_data
+from ..utils import CONFIG_NAME, NormalizedConfigManager, logging
 from ..utils.save_utils import maybe_save_preprocessors
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_decoder import ORTModelForCausalLM
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.get_logger()
 
 
 class ORTOptimizer:
@@ -122,7 +123,7 @@ class ORTOptimizer:
         optimization_config: OptimizationConfig,
         save_dir: Union[str, os.PathLike],
         file_suffix: Optional[str] = "optimized",
-        use_external_data_format: bool = False,
+        use_external_data_format: bool = None,
         one_external_file: bool = True,
     ):
         """
@@ -136,12 +137,18 @@ class ORTOptimizer:
             file_suffix (`str`, defaults to `"optimized"`):
                 The file suffix used to save the optimized model.
             use_external_data_format (`bool`, defaults to `False`):
-                Whether to use external data format to store model of size >= 2Gb.
+                Whether to use external data format to store model of size >= 2Gb. This argument is deprecated.
             one_external_file (`bool`, defaults to `True`):
                 When `use_external_data_format=True`, whether to save all tensors to one external file.
-                If false, save each tensor to a file named with the tensor name.
+                If False, save each tensor to a file named with the tensor name.
 
         """
+        if use_external_data_format is not None:
+            logger.warning(
+                "The argument use_external_data_format in the ORTOptimizer.optimize() method is deprecated and will"
+                " be removed in optimum 2.0."
+            )
+
         save_dir = Path(save_dir)
         save_dir.mkdir(parents=True, exist_ok=True)
         ORTConfigManager.check_optimization_supported_model(self.model_type, optimization_config)
@@ -149,17 +156,26 @@ class ORTOptimizer:
         self.config.save_pretrained(save_dir)
         maybe_save_preprocessors(self.onnx_model_path[0].parent, save_dir)
 
-        # Create and save the configuration summarizing all the parameters related to optimization
-        ort_config = ORTConfig(
-            optimization=optimization_config,
-            use_external_data_format=use_external_data_format,
-            one_external_file=one_external_file,
-        )
-
         model_type = ORTConfigManager.get_model_ort_type(self.config.model_type)
         optimization_options = optimization_config.create_fusion_options(model_type)
 
-        LOGGER.info("Optimizing model...")
+        logger.info("Optimizing model...")
+
+        # TODO: this is quite inefficient as we load in memory if models are <2GB without external data
+        model_uses_external_data = False
+        for model_path in self.onnx_model_path:
+            # check if external data was exported
+            onnx_model = onnx.load(str(model_path), load_external_data=False)
+            if check_model_uses_external_data(onnx_model) is True:
+                model_uses_external_data = True
+                break
+
+        # Create and save the configuration summarizing all the parameters related to optimization
+        ort_config = ORTConfig(
+            optimization=optimization_config,
+            use_external_data_format=model_uses_external_data,
+            one_external_file=one_external_file,
+        )
 
         for model_path in self.onnx_model_path:
             try:
@@ -189,15 +205,21 @@ class ORTOptimizer:
 
             suffix = f"_{file_suffix}" if file_suffix else ""
             output_path = save_dir.joinpath(f"{model_path.stem}{suffix}").with_suffix(model_path.suffix)
-            optimizer.save_model_to_file(output_path.as_posix(), use_external_data_format, one_external_file)
+
+            # TODO: ORT save_model_to_file will save as `.data` although we save as `.onnx_data` in the export
+            optimizer.save_model_to_file(
+                output_path.as_posix(),
+                use_external_data_format=model_uses_external_data,
+                all_tensors_to_one_file=one_external_file,
+            )
 
         # Save the model configuration
         self.config.save_pretrained(save_dir)
         ort_config.save_pretrained(save_dir)
 
-        LOGGER.info(
+        logger.info(
             f"Optimized model saved at: {save_dir} (external data format: "
-            f"{use_external_data_format}; saved all tensor to one file: "
+            f"{model_uses_external_data}; saved all tensor to one file: "
             f"{one_external_file})"
         )
 
@@ -217,7 +239,7 @@ class ORTOptimizer:
         """
         onnx_optimized_model = BertOnnxModel(load_model(onnx_model_path))
         fused_operator = onnx_optimized_model.get_fused_operator_statistics()
-        LOGGER.info(
+        logger.info(
             f"The following operators were fused : { ', '.join([k for k,v in fused_operator.items() if v > 0])}"
         )
         return {k: v for k, v in fused_operator.items() if v > 0}
@@ -245,7 +267,7 @@ class ORTOptimizer:
         nodes_number_onnx_model = len(onnx_model.nodes())
         nodes_number_onnx_optimized_model = len(onnx_optimized_model.nodes())
         difference_nodes_number = nodes_number_onnx_model - nodes_number_onnx_optimized_model
-        LOGGER.info(
+        logger.info(
             f"There are {nodes_number_onnx_model} nodes before optimization and {nodes_number_onnx_optimized_model}"
             f"nodes after. The number of nodes removed is {difference_nodes_number}"
         )

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Main class for performing graph optimization with ONNX Runtime."""
 
+import gc
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
@@ -174,6 +175,8 @@ class ORTOptimizer:
             if check_model_uses_external_data(onnx_model) is True:
                 model_uses_external_data = True
                 break
+        del onnx_model
+        gc.collect()
 
         # Create and save the configuration summarizing all the parameters related to optimization
         ort_config = ORTConfig(


### PR DESCRIPTION
Previously we had errors as

```
Traceback (most recent call last):
  File "/home/user/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/user/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/user/scripts/optimum/optimum/exporters/onnx/__main__.py", line 255, in <module>
    main()
  File "/home/user/scripts/optimum/optimum/exporters/onnx/__main__.py", line 212, in main
    optimizer.optimize(save_dir=args.output, optimization_config=optimization_config, file_suffix="")
  File "/home/user/scripts/optimum/optimum/onnxruntime/optimization.py", line 192, in optimize
    optimizer.save_model_to_file(output_path.as_posix(), use_external_data_format, one_external_file)
  File "/home/user/miniconda3/lib/python3.10/site-packages/onnxruntime/transformers/models/gpt2/../../onnx_model.py", line 994, in save_model_to_file
    OnnxModel.save(self.model, output_path, use_external_data_format, all_tensors_to_one_file)
  File "/home/user/miniconda3/lib/python3.10/site-packages/onnxruntime/transformers/models/gpt2/../../onnx_model.py", line 984, in save
    save_model(model, output_path)
  File "/home/user/miniconda3/lib/python3.10/site-packages/onnx/__init__.py", line 231, in save_model
    s = _serialize(proto)
  File "/home/user/miniconda3/lib/python3.10/site-packages/onnx/__init__.py", line 75, in _serialize
    raise ValueError(
ValueError: The proto size is larger than the 2 GB limit. Please use save_as_external_data to save tensors separately from the model file.
```

because the argument `use_external_data_format` was not automatically set automatically for `optimizer.save_model_to_file`. Here we use a hopefully decent heuristic that will help to avoid errors in the optimization & export for large models. One slight issue is that `optimizer.save_model_to_file` saves as `.data` the external data instead of `.onnx_data`, the convention we took in the ONNX export. I believe this is a non-issue, just style.