### PR TITLE
Fix loading of an ONNX stable diffusion model when config doesn't match

### DIFF
--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -220,8 +220,10 @@ class ORTStableDiffusionPipeline(ORTModel, StableDiffusionPipelineMixin):
         sub_models = {}
 
         if not os.path.isdir(model_id):
-            allow_patterns = [os.path.join(k, "*") for k in config.keys() if not k.startswith("_")]
-            allow_patterns += list(
+            patterns = set(config.keys())
+            patterns.update({"vae_encoder", "vae_decoder"})
+            allow_patterns = {os.path.join(k, "*") for k in patterns if not k.startswith("_")}
+            allow_patterns.update(
                 {
                     vae_decoder_file_name,
                     text_encoder_file_name,


### PR DESCRIPTION
In this PR we enable the loading of stable diffusion ONNX model even when the model configuration is the model original configuration