### PR TITLE
Fix WavLM onnx export upon torch 2.0 release

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -17,6 +17,7 @@ import random
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from packaging import version
+from transformers.utils import is_tf_available
 
 from ...utils import (
     DEFAULT_DUMMY_SHAPES,
@@ -52,9 +53,13 @@ from .model_patcher import WavLMModelPatcher
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
+    from transformers.modeling_utils import PreTrainedModel
 
     from ...utils import DummyInputGenerator
     from .model_patcher import ModelPatcher
+
+    if is_tf_available():
+        from transformers.modeling_tf_utils import TFPreTrainedModel
 
 logger = logging.get_logger(__name__)
 


### PR DESCRIPTION
WavLM uses `torch.nn.functional.multi_head_attention_forward` that dispatches on `scaled_dot_product_attention` that is not supported by the ONNX export in PyTorch 2.0. We need to patch the model to avoid this call.

Reference: https://github.com/pytorch/pytorch/blob/c263bd43e8e8502d4726643bc6fd046f0130ac0e/torch/nn/functional.py#L5293-L5342