### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/test_bettertransformer.yml
+++ b/.github/workflows/test_bettertransformer.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]  # TODO: add back 3.9 once https://github.com/microsoft/onnxruntime/issues/14663 is fixed
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_onnx.yml
+++ b/.github/workflows/test_onnx.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]  # TODO: add back 3.9 once https://github.com/microsoft/onnxruntime/issues/14663 is fixed
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]  # TODO: add back 3.9 once https://github.com/microsoft/onnxruntime/issues/14663 is fixed
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, windows-2019, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_optimum_common.yml
+++ b/.github/workflows/test_optimum_common.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, windows-2019, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     packages=find_namespace_packages(include=["optimum*"]),
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS_REQUIRE,
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     include_package_data=True,
     zip_safe=False,
     entry_points={"console_scripts": ["optimum-cli=optimum.commands.optimum_cli:main"]},

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     packages=find_namespace_packages(include=["optimum*"]),
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS_REQUIRE,
-    python_requires=">=3.8.0",
+    python_requires=">=3.7.0",
     include_package_data=True,
     zip_safe=False,
     entry_points={"console_scripts": ["optimum-cli=optimum.commands.optimum_cli:main"]},


### PR DESCRIPTION
As PyTorch did: https://github.com/pytorch/pytorch/releases/tag/v2.0.0