### PR TITLE
Remove subprocess calls in ONNX export

### DIFF
--- a/optimum/commands/export/__init__.py
+++ b/optimum/commands/export/__init__.py
@@ -16,12 +16,13 @@ import sys
 from argparse import ArgumentParser, RawTextHelpFormatter
 
 from .. import BaseOptimumCLICommand
-from .onnx import ONNXExportCommand, parse_args_onnx
+from .onnx import ONNXExportCommand
+from .onnx_parser import parse_args_onnx
 from .tflite import TFLiteExportCommand, parse_args_tflite
 
 
-def onnx_export_factory(_):
-    return ONNXExportCommand(" ".join(sys.argv[3:]))
+def onnx_export_factory(args):
+    return ONNXExportCommand(args)
 
 
 def tflite_export_factory(_):

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -13,179 +13,35 @@
 # limitations under the License.
 """Defines the command line for the export with ONNX."""
 
-import argparse
-import subprocess
-from pathlib import Path
-
-from ...exporters import TasksManager
+from ...exporters.onnx.__main__ import main_export
 from ...utils import DEFAULT_DUMMY_SHAPES
 
 
-def parse_args_onnx(parser):
-    required_group = parser.add_argument_group("Required arguments")
-    required_group.add_argument(
-        "-m", "--model", type=str, required=True, help="Model ID on huggingface.co or path on disk to load model from."
-    )
-    required_group.add_argument(
-        "output", type=Path, help="Path indicating the directory where to store generated ONNX model."
-    )
-
-    optional_group = parser.add_argument_group("Optional arguments")
-    optional_group.add_argument(
-        "--task",
-        default="auto",
-        help=(
-            "The task to export the model for. If not specified, the task will be auto-inferred based on the model. Available tasks depend on the model, but are among:"
-            f" {str(list(TasksManager._TASKS_TO_AUTOMODELS.keys()))}. For decoder models, use `xxx-with-past` to export the model using past key values in the decoder."
-        ),
-    )
-    optional_group.add_argument(
-        "--monolith",
-        action="store_true",
-        help=(
-            "Force to export the model as a single ONNX file. By default, the ONNX exporter may break the model in several"
-            " ONNX files, for example for encoder-decoder models where the encoder should be run only once while the"
-            " decoder is looped over."
-        ),
-    )
-    optional_group.add_argument(
-        "--device",
-        type=str,
-        default="cpu",
-        help='The device to use to do the export. Defaults to "cpu".',
-    )
-    optional_group.add_argument(
-        "--fp16",
-        action="store_true",
-        help="Experimental option: use half precision during the export. PyTorch-only, requires `--device cuda`.",
-    )
-    optional_group.add_argument(
-        "--opset",
-        type=int,
-        default=None,
-        help="If specified, ONNX opset version to export the model with. Otherwise, the default opset will be used.",
-    )
-    optional_group.add_argument(
-        "--atol",
-        type=float,
-        default=None,
-        help="If specified, the absolute difference tolerance when validating the model. Otherwise, the default atol for the model will be used.",
-    )
-    optional_group.add_argument(
-        "--framework",
-        type=str,
-        choices=["pt", "tf"],
-        default=None,
-        help=(
-            "The framework to use for the ONNX export."
-            " If not provided, will attempt to use the local checkpoint's original framework"
-            " or what is available in the environment."
-        ),
-    )
-    optional_group.add_argument(
-        "--pad_token_id",
-        type=int,
-        default=None,
-        help=(
-            "This is needed by some models, for some tasks. If not provided, will attempt to use the tokenizer to guess"
-            " it."
-        ),
-    )
-    optional_group.add_argument("--cache_dir", type=str, default=None, help="Path indicating where to store cache.")
-    optional_group.add_argument(
-        "--trust-remote-code",
-        action="store_true",
-        help="Allows to use custom code for the modeling hosted in the model repository. This option should only be set for repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the model repository.",
-    )
-    optional_group.add_argument(
-        "--no-post-process",
-        action="store_true",
-        help=(
-            "Allows to disable any post-processing done by default on the exported ONNX models. For example, the merging of decoder"
-            " and decoder-with-past models into a single ONNX model file to reduce memory usage."
-        ),
-    )
-    optional_group.add_argument(
-        "--optimize",
-        type=str,
-        default=None,
-        choices=["O1", "O2", "O3", "O4"],
-        help=(
-            "Allows to run ONNX Runtime optimizations directly during the export. Some of these optimizations are specific to ONNX Runtime, and the resulting ONNX will not be usable with other runtime as OpenVINO or TensorRT. Possible options:\n"
-            "    - O1: Basic general optimizations\n"
-            "    - O2: Basic and extended general optimizations, transformers-specific fusions\n"
-            "    - O3: Same as O2 with GELU approximation\n"
-            "    - O4: Same as O3 with mixed precision (fp16, GPU-only, requires `--device cuda`)"
-        ),
-    )
-
-    input_group = parser.add_argument_group(
-        "Input shapes (if necessary, this allows to override the shapes of the input given to the ONNX exporter, that requires an example input.)"
-    )
-    doc_input = "to use in the example input given to the ONNX export."
-    input_group.add_argument(
-        "--batch_size",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["batch_size"],
-        help=f"Text tasks only. Batch size {doc_input}",
-    )
-    input_group.add_argument(
-        "--sequence_length",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["sequence_length"],
-        help=f"Text tasks only. Sequence length {doc_input}",
-    )
-    input_group.add_argument(
-        "--num_choices",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["num_choices"],
-        help=f"Text tasks only. Num choices {doc_input}",
-    )
-    input_group.add_argument(
-        "--width",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["width"],
-        help=f"Image tasks only. Width {doc_input}",
-    )
-    input_group.add_argument(
-        "--height",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["height"],
-        help=f"Image tasks only. Height {doc_input}",
-    )
-    input_group.add_argument(
-        "--num_channels",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["num_channels"],
-        help=f"Image tasks only. Number of channels {doc_input}",
-    )
-    input_group.add_argument(
-        "--feature_size",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["feature_size"],
-        help=f"Audio tasks only. Feature size {doc_input}",
-    )
-    input_group.add_argument(
-        "--nb_max_frames",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["nb_max_frames"],
-        help=f"Audio tasks only. Maximum number of frames {doc_input}",
-    )
-    input_group.add_argument(
-        "--audio_sequence_length",
-        type=int,
-        default=DEFAULT_DUMMY_SHAPES["audio_sequence_length"],
-        help=f"Audio tasks only. Audio sequence length {doc_input}",
-    )
-
-    # deprecated argument
-    parser.add_argument("--for-ort", action="store_true", help=argparse.SUPPRESS)
-
-
 class ONNXExportCommand:
-    def __init__(self, args_string):
-        self.args_string = args_string
+    def __init__(self, args):
+        self.args = args
 
     def run(self):
-        full_command = f"python3 -m optimum.exporters.onnx {self.args_string}"
-        subprocess.run(full_command, shell=True, check=True)
+        # get the shapes to be used to generate dummy inputs
+        input_shapes = {}
+        for input_name in DEFAULT_DUMMY_SHAPES.keys():
+            input_shapes[input_name] = getattr(self.args, input_name)
+
+        main_export(
+            model_name_or_path=self.args.model,
+            output=self.args.output,
+            task=self.args.task,
+            opset=self.args.opset,
+            device=self.args.device,
+            fp16=self.args.fp16,
+            optimize=self.args.optimize,
+            monolith=self.args.monolith,
+            no_post_process=self.args.no_post_process,
+            framework=self.args.framework,
+            atol=self.args.atol,
+            cache_dir=self.args.cache_dir,
+            trust_remote_code=self.args.trust_remote_code,
+            pad_token_id=self.args.pad_token_id,
+            for_ort=self.args.for_ort,
+            **input_shapes,
+        )

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -66,6 +66,7 @@ def main_export(
     local_files_only: bool = False,
     use_auth_token: Optional[Union[bool, str]] = None,
     for_ort: bool = False,
+    do_validation: bool = True,
     **kwargs_shapes,
 ):
     """
@@ -306,32 +307,33 @@ def main_export(
                 f"The post-processing of the ONNX export failed. The export can still be performed by passing the option --no-post-process. Detailed error: {e}"
             )
 
-    try:
-        validate_models_outputs(
-            models_and_onnx_configs=models_and_onnx_configs,
-            onnx_named_outputs=onnx_outputs,
-            atol=atol,
-            output_dir=output,
-            onnx_files_subpaths=onnx_files_subpaths,
-            input_shapes=input_shapes,
-            device=device,
-            dtype=torch_dtype,
-        )
-        logger.info(f"The ONNX export succeeded and the exported model was saved at: {output.as_posix()}")
-    except ShapeError as e:
-        raise e
-    except AtolError as e:
-        logger.warning(
-            f"The ONNX export succeeded with the warning: {e}.\n The exported model was saved at: {output.as_posix()}"
-        )
-    except OutputMatchError as e:
-        logger.warning(
-            f"The ONNX export succeeded with the warning: {e}.\n The exported model was saved at: {output.as_posix()}"
-        )
-    except Exception as e:
-        raise Exception(
-            f"An error occured during validation, but the model was saved nonetheless at {output.as_posix()}. Detailed error: {e}."
-        )
+    if do_validation is True:
+        try:
+            validate_models_outputs(
+                models_and_onnx_configs=models_and_onnx_configs,
+                onnx_named_outputs=onnx_outputs,
+                atol=atol,
+                output_dir=output,
+                onnx_files_subpaths=onnx_files_subpaths,
+                input_shapes=input_shapes,
+                device=device,
+                dtype=torch_dtype,
+            )
+            logger.info(f"The ONNX export succeeded and the exported model was saved at: {output.as_posix()}")
+        except ShapeError as e:
+            raise e
+        except AtolError as e:
+            logger.warning(
+                f"The ONNX export succeeded with the warning: {e}.\n The exported model was saved at: {output.as_posix()}"
+            )
+        except OutputMatchError as e:
+            logger.warning(
+                f"The ONNX export succeeded with the warning: {e}.\n The exported model was saved at: {output.as_posix()}"
+            )
+        except Exception as e:
+            raise Exception(
+                f"An error occured during validation, but the model was saved nonetheless at {output.as_posix()}. Detailed error: {e}."
+            )
 
 
 def main():

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -484,12 +484,11 @@ class ORTModelDecoder(ORTModel):
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
 
-        # TODO: support subfolder, revision, local_files_only, force_download, use_auth_token
         main_export(
             model_name_or_path=model_id,
             output=save_dir_path,
             task=task,
-            validate=False,
+            do_validation=False,
             no_post_process=not use_merged,
             subfolder=subfolder,
             revision=revision,

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -26,8 +26,7 @@ from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
 
 import onnxruntime
 
-from ..exporters import TasksManager
-from ..exporters.onnx import export_models, get_decoder_models_for_export
+from ..exporters.onnx.__main__ import main_export
 from ..onnx.utils import _get_external_data_paths
 from ..utils import check_if_transformers_greater
 from ..utils.file_utils import validate_file_exists
@@ -485,38 +484,21 @@ class ORTModelDecoder(ORTModel):
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
 
-        model = TasksManager.get_model_from_task(
-            task,
-            model_id,
+        # TODO: support subfolder, revision, local_files_only, force_download, use_auth_token
+        main_export(
+            model_name_or_path=model_id,
+            output=save_dir_path,
+            task=task,
+            validate=False,
+            no_post_process=not use_merged,
             subfolder=subfolder,
             revision=revision,
             cache_dir=cache_dir,
-            config=config,
             use_auth_token=use_auth_token,
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
         )
-
-        onnx_config_constructor = TasksManager.get_exporter_config_constructor(model=model, exporter="onnx", task=task)
-        onnx_config = onnx_config_constructor(model.config, use_past=use_cache)
-
-        onnx_files_subpaths = [ONNX_DECODER_NAME]
-        if use_cache is True:
-            onnx_files_subpaths.append(ONNX_DECODER_WITH_PAST_NAME)
-
-        models_and_onnx_configs = get_decoder_models_for_export(model, onnx_config)
-        export_models(
-            models_and_onnx_configs=models_and_onnx_configs,
-            opset=onnx_config.DEFAULT_ONNX_OPSET,
-            output_dir=save_dir_path,
-            output_names=onnx_files_subpaths,
-        )
-
-        if use_merged is True:
-            _, _ = onnx_config.post_process_exported_models(
-                save_dir_path, models_and_onnx_configs, onnx_files_subpaths
-            )
 
         config.save_pretrained(save_dir_path)
         maybe_save_preprocessors(model_id, save_dir_path, src_subfolder=subfolder)

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -306,7 +306,7 @@ class ORTStableDiffusionPipeline(ORTModel, StableDiffusionPipelineMixin):
             model_name_or_path=model_id,
             output=save_dir_path,
             task=task,
-            validate=False,
+            do_validation=False,
             no_post_process=True,
             subfolder=subfolder,
             revision=revision,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -565,7 +565,7 @@ class ORTModel(OptimizedModel):
             model_name_or_path=model_id,
             output=save_dir_path,
             task=task,
-            validate=False,
+            do_validation=False,
             no_post_process=True,
             subfolder=subfolder,
             revision=revision,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -57,7 +57,7 @@ from transformers.modeling_outputs import (
 import onnxruntime as ort
 
 from ..exporters import TasksManager
-from ..exporters.onnx import export
+from ..exporters.onnx.__main__ import main_export
 from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
 from ..onnx.utils import _get_external_data_paths
 from ..utils.file_utils import find_files_matching_pattern
@@ -558,35 +558,32 @@ class ORTModel(OptimizedModel):
         if task is None:
             task = cls._auto_model_to_task(cls.auto_model_class)
 
-        kwargs_to_get_model = {
-            "subfolder": subfolder,
-            "revision": revision,
-            "trust_remote_code": trust_remote_code,
-        }
+        save_dir = TemporaryDirectory()
+        save_dir_path = Path(save_dir.name)
 
-        model = TasksManager.get_model_from_task(task, model_id, **kwargs_to_get_model)
-        onnx_config_class = TasksManager.get_exporter_config_constructor(
-            model=model, exporter="onnx", task=task, model_name=model_id
+        main_export(
+            model_name_or_path=model_id,
+            output=save_dir_path,
+            task=task,
+            validate=False,
+            no_post_process=True,
+            subfolder=subfolder,
+            revision=revision,
+            cache_dir=cache_dir,
+            use_auth_token=use_auth_token,
+            local_files_only=local_files_only,
+            force_download=force_download,
+            trust_remote_code=trust_remote_code,
         )
 
-        onnx_config = onnx_config_class(model.config)
-
-        tmp_dir = TemporaryDirectory()
-        tmp_dir_path = Path(tmp_dir.name)
-        export(
-            model=model,
-            config=onnx_config,
-            opset=onnx_config.DEFAULT_ONNX_OPSET,
-            output=tmp_dir_path / ONNX_WEIGHTS_NAME,
-        )
-        config.save_pretrained(tmp_dir_path)
-        maybe_save_preprocessors(model_id, tmp_dir_path, src_subfolder=subfolder)
+        config.save_pretrained(save_dir_path)
+        maybe_save_preprocessors(model_id, save_dir_path, src_subfolder=subfolder)
 
         return cls._from_pretrained(
-            tmp_dir_path,
+            save_dir_path,
             config,
             use_io_binding=use_io_binding,
-            model_save_dir=tmp_dir,
+            model_save_dir=save_dir,
             provider=provider,
             session_options=session_options,
             provider_options=provider_options,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -790,7 +790,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             model_name_or_path=model_id,
             output=save_dir_path,
             task=task,
-            validate=False,
+            do_validation=False,
             no_post_process=True,
             subfolder=subfolder,
             revision=revision,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -32,8 +32,7 @@ from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 
 import onnxruntime as ort
 
-from ..exporters.onnx import export_models, get_encoder_decoder_models_for_export
-from ..exporters.tasks import TasksManager
+from ..exporters.onnx.__main__ import main_export
 from ..onnx.utils import _get_external_data_paths
 from ..utils import check_if_transformers_greater
 from ..utils.file_utils import validate_file_exists
@@ -787,31 +786,19 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
 
-        model = TasksManager.get_model_from_task(
-            task,
-            model_id,
+        main_export(
+            model_name_or_path=model_id,
+            output=save_dir_path,
+            task=task,
+            validate=False,
+            no_post_process=True,
             subfolder=subfolder,
             revision=revision,
             cache_dir=cache_dir,
-            config=config,
             use_auth_token=use_auth_token,
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
-        )
-
-        onnx_config_constructor = TasksManager.get_exporter_config_constructor(model=model, exporter="onnx", task=task)
-        onnx_config = onnx_config_constructor(model.config, use_past=use_cache)
-
-        output_names = [ONNX_ENCODER_NAME, ONNX_DECODER_NAME]
-        if use_cache is True:
-            output_names.append(ONNX_DECODER_WITH_PAST_NAME)
-        models_and_onnx_configs = get_encoder_decoder_models_for_export(model, onnx_config)
-        export_models(
-            models_and_onnx_configs=models_and_onnx_configs,
-            opset=onnx_config.DEFAULT_ONNX_OPSET,
-            output_dir=save_dir_path,
-            output_names=output_names,
         )
 
         config.save_pretrained(save_dir_path)

--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 from transformers import is_torch_available
 from transformers.testing_utils import require_torch, require_torch_gpu, require_vision, slow
 
+from optimum.exporters.onnx.__main__ import main_export
 from optimum.onnxruntime import ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, ONNX_ENCODER_NAME
 
 
@@ -100,25 +101,16 @@ class OnnxCLIExportTestCase(unittest.TestCase):
         fp16: bool = False,
     ):
         with TemporaryDirectory() as tmpdir:
-            monolith = " --monolith " if monolith is True else " "
-            no_post_process = " --no-post-process " if no_post_process is True else " "
-            optimization_level = f" --optimize {optimization_level} " if optimization_level is not None else " "
-            task = f" --task {task} " if task is not None else " "
-            device = " --device cuda " if device == "cuda" else " "
-            fp16 = " --fp16 --device cuda " if fp16 is True else " "
-            command = f"python3 -m optimum.exporters.onnx --model {model_name}{monolith}{fp16}{optimization_level}{device}{no_post_process}{task}{tmpdir}"
-            print("\nRUNNING:", command)
-            out = subprocess.run(
-                command,
-                shell=True,
-                capture_output=True,
+            main_export(
+                model=model_name,
+                output=tmpdir,
+                task=task,
+                device=device,
+                fp16=fp16,
+                optimize=optimization_level,
+                monolith=monolith,
+                no_post_process=no_post_process,
             )
-            print(out.stdout.decode("utf-8"))
-            print(out.stderr.decode("utf-8"))  # logging's default output is stderr
-            if out.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    returncode=out.returncode, cmd=out.args, stderr=out.stderr.decode("utf-8")
-                )
 
     def test_all_models_tested(self):
         # make sure we test all models


### PR DESCRIPTION
This PR removes subprocess calls in the ONNX export, and unifies the export between the CLI and the integration in ORTModel.from_pretrained.