### PR TITLE
Fix GPU tests

### DIFF
--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -150,11 +150,10 @@ class OnnxCLIExportTestCase(unittest.TestCase):
         for optimization_level in ["O1", "O2", "O3"]:
             try:
                 self._onnx_export(model_name, task, monolith, no_post_process, optimization_level=optimization_level)
-            except subprocess.CalledProcessError as e:
-                if (
-                    "Tried to use ORTOptimizer for the model type" in e.stderr
-                    or "doesn't support the graph optimization" in e.stderr
-                ):
+            except NotImplementedError as e:
+                if "Tried to use ORTOptimizer for the model type" in str(
+                    e
+                ) or "doesn't support the graph optimization" in str(e):
                     self.skipTest("unsupported model type in ORTOptimizer")
                 else:
                     raise e
@@ -174,11 +173,10 @@ class OnnxCLIExportTestCase(unittest.TestCase):
 
         try:
             self._onnx_export(model_name, task, monolith, no_post_process, optimization_level="O4", device="cuda")
-        except subprocess.CalledProcessError as e:
-            if (
-                "Tried to use ORTOptimizer for the model type" in e.stderr
-                or "doesn't support the graph optimization" in e.stderr
-            ):
+        except NotImplementedError as e:
+            if "Tried to use ORTOptimizer for the model type" in str(
+                e
+            ) or "doesn't support the graph optimization" in str(e):
                 self.skipTest("unsupported model type in ORTOptimizer")
             else:
                 raise e

--- a/tests/onnxruntime/docker/Dockerfile_onnxruntime_gpu
+++ b/tests/onnxruntime/docker/Dockerfile_onnxruntime_gpu
@@ -1,6 +1,5 @@
-# use version with cudnn 8.5 to match torch==1.13.1 that uses 8.5.0.96
-# has Python 3.8.10
-FROM nvcr.io/nvidia/tensorrt:22.08-py3
+# use version with CUDA 11.8 and TensorRT 8.5.1.7 to match ORT 1.14 requirements
+FROM nvcr.io/nvidia/tensorrt:22.12-py3
 CMD nvidia-smi
 
 # Ignore interactive questions during `docker build`


### PR DESCRIPTION
Some were broken due to https://github.com/huggingface/optimum/pull/897 & not doing subprocess calls anymore, others due to outdated TRT / ONNX Runtime versions.