### PR TITLE
Fix ORTModel MRO for whisper

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -405,6 +405,8 @@ def main_export(
 
         # Saving the model config and preprocessor as this is needed sometimes.
         model.config.save_pretrained(output)
+        if hasattr(model, "generation_config"):
+            model.generation_config.save_pretrained(output)
         maybe_save_preprocessors(model_name_or_path, output)
 
     if task == "stable-diffusion":

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -405,7 +405,7 @@ def main_export(
 
         # Saving the model config and preprocessor as this is needed sometimes.
         model.config.save_pretrained(output)
-        if hasattr(model, "generation_config"):
+        if hasattr(model, "generation_config") and model.generation_config is not None:
             model.generation_config.save_pretrained(output)
         maybe_save_preprocessors(model_name_or_path, output)
 

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -405,8 +405,9 @@ def main_export(
 
         # Saving the model config and preprocessor as this is needed sometimes.
         model.config.save_pretrained(output)
-        if hasattr(model, "generation_config") and model.generation_config is not None:
-            model.generation_config.save_pretrained(output)
+        generation_config = getattr(model, "generation_config")
+        if generation_config is not None:
+            generation_config.save_pretrained(output)
         maybe_save_preprocessors(model_name_or_path, output)
 
     if task == "stable-diffusion":

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -405,7 +405,7 @@ def main_export(
 
         # Saving the model config and preprocessor as this is needed sometimes.
         model.config.save_pretrained(output)
-        generation_config = getattr(model, "generation_config")
+        generation_config = getattr(model, "generation_config", None)
         if generation_config is not None:
             generation_config.save_pretrained(output)
         maybe_save_preprocessors(model_name_or_path, output)

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -575,6 +575,8 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             dst_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(src_path, dst_path)
 
+        self.generation_config.save_pretrained(save_directory)
+
     @classmethod
     def _from_pretrained(
         cls,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -18,7 +18,7 @@ Transformers.
 
 import logging
 import shutil
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -26,7 +26,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import torch
 from huggingface_hub import hf_hub_download
-from transformers import AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq, AutoModelForVision2Seq, GenerationConfig
+from transformers import (
+    AutoModelForSeq2SeqLM,
+    AutoModelForSpeechSeq2Seq,
+    AutoModelForVision2Seq,
+    GenerationConfig,
+    WhisperForConditionalGeneration,
+)
 from transformers.file_utils import add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 
@@ -1045,6 +1051,53 @@ class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin
     def can_generate(self):
         """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
         return True
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id: Union[str, Path],
+        config: "PretrainedConfig",
+        **kwargs,
+    ):
+        if "WhisperForConditionalGeneration" in config.architectures:
+            return _ORTModelForWhisper._from_pretrained(model_id, config, **kwargs)
+        else:
+            return super()._from_pretrained(model_id, config, **kwargs)
+
+
+class MetaClassRemoveParentsAndReorder(ABCMeta):
+    def mro(cls):
+        """
+        Avoids inheritting from PreTrainedModel, nn.Module, ModuleUtilsMixin, PushToHubMixin,
+        and put GenerationMixin at the end of the MRO
+        """
+        top_inheritance_index = ORTModelForSpeechSeq2Seq.__mro__.index(GenerationMixin)
+        return (
+            (cls,)
+            + ORTModelForSpeechSeq2Seq.__mro__[:top_inheritance_index]
+            + (WhisperForConditionalGeneration,)
+            + ORTModelForSpeechSeq2Seq.__mro__[top_inheritance_index:]
+        )
+
+
+class _ORTModelForWhisper(
+    ORTModelForSpeechSeq2Seq, WhisperForConditionalGeneration, metaclass=MetaClassRemoveParentsAndReorder
+):
+    """
+    Whisper implements its own generate() method
+    """
+
+    def generate(self, **kwargs):
+        return super().generate(**kwargs)
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id: Union[str, Path],
+        config: "PretrainedConfig",
+        **kwargs,
+    ):
+        return super(ORTModelForSpeechSeq2Seq, cls)._from_pretrained(model_id, config, **kwargs)
 
 
 class ORTModelForVision2Seq(ORTModelForConditionalGeneration, GenerationMixin):

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -1089,9 +1089,6 @@ class _ORTModelForWhisper(
     Whisper implements its own generate() method.
     """
 
-    def generate(self, **kwargs):
-        return super().generate(**kwargs)
-
     @classmethod
     def _from_pretrained(
         cls,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -1086,7 +1086,7 @@ class _ORTModelForWhisper(
     ORTModelForSpeechSeq2Seq, WhisperForConditionalGeneration, metaclass=MetaClassRemoveParentsAndReorder
 ):
     """
-    Whisper implements its own generate() method
+    Whisper implements its own generate() method.
     """
 
     def generate(self, **kwargs):

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -3386,13 +3386,9 @@ class ORTModelForSpeechSeq2SeqIntegrationTest(ORTModelTestMixin):
         data = self._generate_random_audio_data()
         features = processor.feature_extractor(data, return_tensors="pt")
 
-        outputs = model.generate(inputs=features["input_features"], return_timestamps=True)
+        outputs = model.generate(inputs=features["input_features"])
         res = processor.tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertIsInstance(res[0], str)
-        self.assertTrue("chunks" in outputs)
-
-        outputs = model.generate(inputs=features["input_features"], return_timestamps=False)
-        self.assertTrue("chunks" in outputs)
 
         gc.collect()
 
@@ -3457,13 +3453,16 @@ class ORTModelForSpeechSeq2SeqIntegrationTest(ORTModelTestMixin):
             feature_extractor=processor.feature_extractor,
         )
         data = self._generate_random_audio_data()
-        outputs = pipe(data, return_timestamps=True)
+        outputs = pipe(data)
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertIsInstance(outputs["text"], str)
-        self.assertTrue("chunks" in outputs)
 
-        outputs = pipe(data, return_timestamps=False)
-        self.assertTrue("chunks" not in outputs)
+        if model_arch == "whisper":
+            outputs = pipe(data, return_timestamps=True)
+            self.assertTrue("chunks" in outputs)
+
+            outputs = pipe(data, return_timestamps=False)
+            self.assertTrue("chunks" not in outputs)
 
         gc.collect()
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -3386,9 +3386,13 @@ class ORTModelForSpeechSeq2SeqIntegrationTest(ORTModelTestMixin):
         data = self._generate_random_audio_data()
         features = processor.feature_extractor(data, return_tensors="pt")
 
-        outputs = model.generate(inputs=features["input_features"])
+        outputs = model.generate(inputs=features["input_features"], return_timestamps=True)
         res = processor.tokenizer.batch_decode(outputs, skip_special_tokens=True)
         self.assertIsInstance(res[0], str)
+        self.assertTrue("chunks" in outputs)
+
+        outputs = model.generate(inputs=features["input_features"], return_timestamps=False)
+        self.assertTrue("chunks" in outputs)
 
         gc.collect()
 
@@ -3453,9 +3457,13 @@ class ORTModelForSpeechSeq2SeqIntegrationTest(ORTModelTestMixin):
             feature_extractor=processor.feature_extractor,
         )
         data = self._generate_random_audio_data()
-        outputs = pipe(data)
+        outputs = pipe(data, return_timestamps=True)
         self.assertEqual(pipe.device, onnx_model.device)
         self.assertIsInstance(outputs["text"], str)
+        self.assertTrue("chunks" in outputs)
+
+        outputs = pipe(data, return_timestamps=False)
+        self.assertTrue("chunks" not in outputs)
 
         gc.collect()
 


### PR DESCRIPTION
As per title, fixes https://github.com/huggingface/optimum/issues/905, https://github.com/huggingface/optimum/issues/906

This bug is introduced by https://github.com/huggingface/transformers/pull/21252 that moves `generate()` implementation in `WhisperForConditionalGeneration`, hence breaking the inheritance order in transformers.