### PR TITLE
`optimun-cli onnxruntime quantize / optimize` output argument is now required

### DIFF
--- a/docs/source/onnxruntime/usage_guides/optimization.mdx
+++ b/docs/source/onnxruntime/usage_guides/optimization.mdx
@@ -163,29 +163,29 @@ The Optimum ONNX Runtime optimization tools can be used directly through Optimum
 
 ```bash
 optimum-cli onnxruntime optimize --help
-usage: optimum-cli <command> [<args>] onnxruntime optimize [-h] --onnx_model ONNX_MODEL [-o OUTPUT] (-O1 | -O2 | -O3 | -O4)
+usage: optimum-cli <command> [<args>] onnxruntime optimize [-h] --onnx_model ONNX_MODEL -o OUTPUT (-O1 | -O2 | -O3 | -O4 | -c CONFIG)
 
 options:
   -h, --help            show this help message and exit
   -O1                   Basic general optimizations (see: https://huggingface.co/docs/optimum/onnxruntime/usage_guides/optimization for more details).
-  -O2                   Basic and extended general optimizations, transformers-specific fusions (see: https://huggingface.co/docs/optimum/onnxruntime/usage_guides/optimization for more details).
+  -O2                   Basic and extended general optimizations, transformers-specific fusions (see: https://huggingface.co/docs/optimum/onnxruntime/usage_guides/optimization for more
+                        details).
   -O3                   Same as O2 with Gelu approximation (see: https://huggingface.co/docs/optimum/onnxruntime/usage_guides/optimization for more details).
   -O4                   Same as O3 with mixed precision (see: https://huggingface.co/docs/optimum/onnxruntime/usage_guides/optimization for more details).
-  -c, --config          `ORTConfig` file to use to optimize the model.
+  -c CONFIG, --config CONFIG
+                        `ORTConfig` file to use to optimize the model.
 
 Required arguments:
   --onnx_model ONNX_MODEL
-                        Path indicating where the ONNX models to optimize are located.
-
-Optional arguments:
+                        Path to the repository where the ONNX models to optimize are located.
   -o OUTPUT, --output OUTPUT
-                        Path indicating the directory where to store generated ONNX model. (defaults to --onnx_model value).
+                        Path to the directory where to store generated ONNX model.
 ```
 
 Optimizing an ONNX model can be done as follows:
 
 ```bash
- optimum-cli onnxruntime optimize --onnx_model onnx_model_location/ -O1
+ optimum-cli onnxruntime optimize --onnx_model onnx_model_location/ -O1 -o optimized_model/
 ```
 
-This optimizes all the ONNX files in `onnx_model_location` with the basic general optimizations. The optimized models will be created in the same directory by default unless the `--output` argument is specified.
+This optimizes all the ONNX files in `onnx_model_location` with the basic general optimizations. 

--- a/docs/source/onnxruntime/usage_guides/quantization.mdx
+++ b/docs/source/onnxruntime/usage_guides/quantization.mdx
@@ -34,7 +34,7 @@ The Optimum ONNX Runtime quantization tool can be used through Optimum command-l
 
 ```bash
 optimum-cli onnxruntime quantize --help
-usage: optimum-cli <command> [<args>] onnxruntime quantize [-h] --onnx_model ONNX_MODEL [-o OUTPUT] (--arm64 | --avx2 | --avx512 | --avx512_vnni | --tensorrt)
+usage: optimum-cli <command> [<args>] onnxruntime quantize [-h] --onnx_model ONNX_MODEL -o OUTPUT [--per_channel] (--arm64 | --avx2 | --avx512 | --avx512_vnni | --tensorrt | -c CONFIG)
 
 options:
   -h, --help            show this help message and exit
@@ -43,21 +43,24 @@ options:
   --avx512              Quantization with AVX-512 instructions.
   --avx512_vnni         Quantization with AVX-512 and VNNI instructions.
   --tensorrt            Quantization for NVIDIA TensorRT optimizer.
-  -c, --config          `ORTConfig` file to use to optimize the model.
+  -c CONFIG, --config CONFIG
+                        `ORTConfig` file to use to optimize the model.
 
 Required arguments:
   --onnx_model ONNX_MODEL
-                        Path indicating where the ONNX models to quantize are located.
+                        Path to the repository where the ONNX models to quantize are located.
+  -o OUTPUT, --output OUTPUT
+                        Path to the directory where to store generated ONNX model.
 
 Optional arguments:
-  -o OUTPUT, --output OUTPUT
-                        Path indicating the directory where to store generated ONNX model. (defaults to --onnx_model value).
+  --per_channel         Compute the quantization parameters on a per-channel basis.
+
 ```
 
 Quantizing an ONNX model can be done as follows:
 
 ```bash
- optimum-cli onnxruntime quantize --onnx_model onnx_model_location/ --avx512
+ optimum-cli onnxruntime quantize --onnx_model onnx_model_location/ --avx512 -o quantized_model
 ```
 
 This quantize all the ONNX files in `onnx_model_location` with the AVX-512 instructions. The quantized models will be created in the same directory by default unless the `--output` argument is specified.

--- a/docs/source/onnxruntime/usage_guides/quantization.mdx
+++ b/docs/source/onnxruntime/usage_guides/quantization.mdx
@@ -60,10 +60,10 @@ Optional arguments:
 Quantizing an ONNX model can be done as follows:
 
 ```bash
- optimum-cli onnxruntime quantize --onnx_model onnx_model_location/ --avx512 -o quantized_model
+ optimum-cli onnxruntime quantize --onnx_model onnx_model_location/ --avx512 -o quantized_model/
 ```
 
-This quantize all the ONNX files in `onnx_model_location` with the AVX-512 instructions. The quantized models will be created in the same directory by default unless the `--output` argument is specified.
+This quantize all the ONNX files in `onnx_model_location` with the AVX-512 instructions. 
 
 ## Creating an `ORTQuantizer`
 

--- a/optimum/commands/onnxruntime/optimize.py
+++ b/optimum/commands/onnxruntime/optimize.py
@@ -12,13 +12,12 @@ def parse_args_onnxruntime_optimize(parser):
         required=True,
         help="Path to the repository where the ONNX models to optimize are located.",
     )
-
-    optional_group = parser.add_argument_group("Optional arguments")
-    optional_group.add_argument(
+    required_group.add_argument(
         "-o",
         "--output",
         type=Path,
-        help="Path to the directory where to store generated ONNX model. (defaults to --onnx_model value).",
+        required=True,
+        help="Path to the directory where to store generated ONNX model.",
     )
 
     level_group = parser.add_mutually_exclusive_group(required=True)
@@ -55,13 +54,12 @@ class ONNXRuntimmeOptimizeCommand:
         self.args = args
 
     def run(self):
-        if not self.args.output:
-            save_dir = self.args.onnx_model
-        else:
-            save_dir = self.args.output
+        if self.args.output == self.args.onnx_model:
+            raise ValueError(f"The output directory must be different than the directory hosting the ONNX model.")
+
+        save_dir = self.args.output
 
         file_names = [model.name for model in self.args.onnx_model.glob("*.onnx")]
-
         optimizer = ORTOptimizer.from_pretrained(self.args.onnx_model, file_names)
 
         if self.args.config:

--- a/optimum/commands/onnxruntime/optimize.py
+++ b/optimum/commands/onnxruntime/optimize.py
@@ -55,7 +55,7 @@ class ONNXRuntimmeOptimizeCommand:
 
     def run(self):
         if self.args.output == self.args.onnx_model:
-            raise ValueError(f"The output directory must be different than the directory hosting the ONNX model.")
+            raise ValueError("The output directory must be different than the directory hosting the ONNX model.")
 
         save_dir = self.args.output
 

--- a/optimum/commands/onnxruntime/quantize.py
+++ b/optimum/commands/onnxruntime/quantize.py
@@ -49,7 +49,7 @@ class ONNXRuntimmeQuantizeCommand:
 
     def run(self):
         if self.args.output == self.args.onnx_model:
-            raise ValueError(f"The output directory must be different than the directory hosting the ONNX model.")
+            raise ValueError("The output directory must be different than the directory hosting the ONNX model.")
 
         save_dir = self.args.output
         quantizers = []

--- a/optimum/commands/onnxruntime/quantize.py
+++ b/optimum/commands/onnxruntime/quantize.py
@@ -12,14 +12,15 @@ def parse_args_onnxruntime_quantize(parser):
         required=True,
         help="Path to the repository where the ONNX models to quantize are located.",
     )
-
-    optional_group = parser.add_argument_group("Optional arguments")
-    optional_group.add_argument(
+    required_group.add_argument(
         "-o",
         "--output",
         type=Path,
-        help="Path to the directory where to store generated ONNX model. (defaults to --onnx_model value).",
+        required=True,
+        help="Path to the directory where to store generated ONNX model.",
     )
+
+    optional_group = parser.add_argument_group("Optional arguments")
     optional_group.add_argument(
         "--per_channel",
         action="store_true",
@@ -47,15 +48,14 @@ class ONNXRuntimmeQuantizeCommand:
         self.args = args
 
     def run(self):
-        if not self.args.output:
-            save_dir = self.args.onnx_model
-        else:
-            save_dir = self.args.output
+        if self.args.output == self.args.onnx_model:
+            raise ValueError(f"The output directory must be different than the directory hosting the ONNX model.")
 
+        save_dir = self.args.output
         quantizers = []
 
         quantizers = [
-            ORTQuantizer.from_pretrained(save_dir, file_name=model.name)
+            ORTQuantizer.from_pretrained(self.args.onnx_model, file_name=model.name)
             for model in self.args.onnx_model.glob("*.onnx")
         ]
 
@@ -68,7 +68,7 @@ class ONNXRuntimmeQuantizeCommand:
         elif self.args.avx512_vnni:
             qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=self.args.per_channel)
         elif self.args.tensorrt:
-            qconfig = AutoQuantizationConfig.tensorrt(is_static=False, per_channel=self.args.per_channel)
+            qconfig = AutoQuantizationConfig.tensorrt(per_channel=self.args.per_channel)
         else:
             qconfig = ORTConfig.from_pretained(self.args.config).quantization
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -51,9 +51,9 @@ class TestCLI(unittest.TestCase):
                 f"optimum-cli export onnx --model hf-internal-testing/tiny-random-bart {tempdir}/encoder-decoder",
             ]
             optimize_commands = [
-                f"optimum-cli onnxruntime optimize --onnx_model {tempdir}/encoder -O1",
-                f"optimum-cli onnxruntime optimize --onnx_model {tempdir}/decoder -O1",
-                f"optimum-cli onnxruntime optimize --onnx_model {tempdir}/encoder-decoder -O1",
+                f"optimum-cli onnxruntime optimize --onnx_model {tempdir}/encoder -O1 -o {tempdir}/optimized_encoder",
+                f"optimum-cli onnxruntime optimize --onnx_model {tempdir}/decoder -O1 -o {tempdir}/optimized_decoder",
+                f"optimum-cli onnxruntime optimize --onnx_model {tempdir}/encoder-decoder -O1 -o {tempdir}/optimized_encoder_decoder",
             ]
 
             for export, optimize in zip(export_commands, optimize_commands):
@@ -69,9 +69,9 @@ class TestCLI(unittest.TestCase):
                 f"optimum-cli export onnx --model hf-internal-testing/tiny-random-t5 {tempdir}/encoder-decoder",
             ]
             quantize_commands = [
-                f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/encoder --avx2",
-                f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/decoder --avx2",
-                f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/encoder-decoder --avx2",
+                f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/encoder --avx2 -o {tempdir}/quantized_encoder",
+                f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/decoder --avx2 -o {tempdir}/quantized_decoder",
+                f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/encoder-decoder --avx2 -o {tempdir}/quantized_encoder_decoder",
             ]
 
             for export, quantize in zip(export_commands, quantize_commands):


### PR DESCRIPTION
# What does this PR do?

This PR makes the `-o` / `--output` argument for `optimum-cli onnxruntime optimize / quantize` mandatory and does not allow it to be the same as the original directory.

Still wondering whether we should raise an error or just a warning.
While saving everything under the same directory is completely working here, it makes it unusable with `ORTModel`s because multiple ONNX files are in the directory. While we could provide the filename explicitly, I feel like keeping a easy to use workflow is better. 