### PR TITLE
Register mechanism for the Optimum CLI

### DIFF
--- a/optimum/commands/__init__.py
+++ b/optimum/commands/__init__.py
@@ -12,16 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
-from argparse import ArgumentParser
-
-
-class BaseOptimumCLICommand(ABC):
-    @staticmethod
-    @abstractmethod
-    def register_subcommand(parser: ArgumentParser):
-        raise NotImplementedError()
-
-    @abstractmethod
-    def run(self):
-        raise NotImplementedError()
+from .base import BaseOptimumCLICommand, CommandInfo

--- a/optimum/commands/__init__.py
+++ b/optimum/commands/__init__.py
@@ -13,4 +13,7 @@
 # limitations under the License.
 
 from .base import BaseOptimumCLICommand, CommandInfo, RootOptimumCLICommand
+from .env import EnvironmentCommand
+from .export import ExportCommand, ONNXExportCommand, TFLiteExportCommand
+from .onnxruntime import ONNXRuntimeCommand, ONNXRuntimmeOptimizeCommand, ONNXRuntimmeQuantizeCommand
 from .optimum_cli import register_optimum_cli_subcommand

--- a/optimum/commands/__init__.py
+++ b/optimum/commands/__init__.py
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import BaseOptimumCLICommand, CommandInfo
+from .base import BaseOptimumCLICommand, CommandInfo, RootOptimumCLICommand
+from .optimum_cli import register_optimum_cli_subcommand

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -74,12 +74,10 @@ class BaseOptimumCLICommand(ABC):
                 raise ValueError(f"Subcommands must be instances of CommandInfo, but got {type(subcommand)} here.")
             self.register_subcommand(subcommand)
 
-
         self.args = args
 
     @property
     def defaults_factory(self):
-        
         def defaults_factory_func(args):
             return self.__class__(self.subparsers, args, command=self.COMMAND, from_defaults_factory=True)
 
@@ -95,7 +93,7 @@ class BaseOptimumCLICommand(ABC):
                     self.parser.set_defaults(func=self.defaults_factory)
             else:
                 self._subparsers = None
-        return self._subparsers 
+        return self._subparsers
 
     @subparsers.setter
     def subparsers(self, subparsers: Optional["_SubParsersAction"]):
@@ -112,7 +110,6 @@ class BaseOptimumCLICommand(ABC):
         pass
 
     def register_subcommand(self, command_info: CommandInfo):
-
         command_info.is_subcommand_info_or_raise()
         self.SUBCOMMANDS = self.SUBCOMMANDS + (command_info,)
         self.registered_subcommands.append(command_info.subcommand_class(self.subparsers, command=command_info))
@@ -124,12 +121,7 @@ class BaseOptimumCLICommand(ABC):
 class RootOptimumCLICommand(BaseOptimumCLICommand):
     COMMAND = CommandInfo(name="root", help="optimum-cli root command")
 
-    def __init__(
-        self,
-        cli_name: str,
-        usage: Optional[str] = None,
-        args: Optional["Namespace"] = None
-    ):
+    def __init__(self, cli_name: str, usage: Optional[str] = None, args: Optional["Namespace"] = None):
         self.parser = ArgumentParser(cli_name, usage=usage)
         self.subparsers = self.parser.add_subparsers()
         self.args = None

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -55,6 +55,21 @@ class BaseOptimumCLICommand(ABC):
         command: Optional[CommandInfo] = None,
         from_defaults_factory: bool = False,
     ):
+        """
+        Initializes the instance.
+
+        Args:
+            subparsers (`Optional[_SubParsersAction]`):
+                The parent subparsers this command will create its parser on.
+            args (`Optional[Namespace]`, defaults to `None`):
+                The arguments that are going to be parsed by the CLI.
+            command (`Optional[CommandInfo]`, defaults to `None`):
+                The command info for this instance. This can be used to set the class attribute `COMMAND`.
+            from_defaults_factory (`bool`, defaults to `False`):
+                When setting the parser defaults, we create a second instance of self. By setting
+                `from_defaults_factory=True`, we do not do unnecessary actions for setting the defaults, such as
+                creating a parser.
+        """
         if command is not None:
             self.COMMAND = command
 

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -40,10 +40,6 @@ class CommandInfo:
             raise ValueError(f"The command info must define a subcommand_class attribute, but got: {self}.")
 
 
-class InvalidCLICommand(Exception):
-    pass
-
-
 class BaseOptimumCLICommand(ABC):
     COMMAND: CommandInfo
     SUBCOMMANDS: Tuple[CommandInfo, ...] = ()

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -66,7 +66,6 @@ class BaseOptimumCLICommand(ABC):
                 raise ValueError(f"A subparsers instance is needed when from_defaults_factory=False, command: {self}.")
             self.parser = subparsers.add_parser(self.COMMAND.name, help=self.COMMAND.help)
             self.parse_args(self.parser)
-
             self.parser.set_defaults(func=self.defaults_factory)
 
         for subcommand in self.SUBCOMMANDS:
@@ -85,6 +84,11 @@ class BaseOptimumCLICommand(ABC):
 
     @property
     def subparsers(self):
+        """
+        This property handles how subparsers are created, which are only needed when registering a subcommand.
+        If `self` does not have any subcommand, no subparsers should be created or it will mess with the command.
+        This property ensures that we create subparsers only if needed.
+        """
         subparsers = getattr(self, "_subparsers", None)
         if subparsers is None:
             if self.SUBCOMMANDS:

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -96,14 +96,15 @@ class BaseOptimumCLICommand(ABC):
     def run(self):
         raise NotImplementedError()
 
+
 class RootOptimumCLICommand(BaseOptimumCLICommand):
     COMMAND = CommandInfo(name="root", help="root cli")
+
     def __init__(
         self,
         cli_name: str,
         usage: Optional[str] = None,
     ):
-        
         self.parser = ArgumentParser(cli_name, usage=usage)
         self.subparsers = self.parser.add_subparsers()
         self.args = None

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -98,13 +98,15 @@ class BaseOptimumCLICommand(ABC):
 
 
 class RootOptimumCLICommand(BaseOptimumCLICommand):
-    COMMAND = CommandInfo(name="root", help="root cli")
+    COMMAND = CommandInfo(name="root", help="optimum-cli root command")
 
     def __init__(
         self,
         cli_name: str,
         usage: Optional[str] = None,
+        args: Optional["Namespace"] = None
     ):
         self.parser = ArgumentParser(cli_name, usage=usage)
         self.subparsers = self.parser.add_subparsers()
+        # super().__init__(self.subparsers)
         self.args = None

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -67,7 +67,7 @@ class BaseOptimumCLICommand(ABC):
             self.parser = subparsers.add_parser(self.COMMAND.name, help=self.COMMAND.help)
             self.parse_args(self.parser)
 
-            self.parser.set_defaults(func=self.get_defaults_factory(None))
+            self.parser.set_defaults(func=self.defaults_factory)
 
         for subcommand in self.SUBCOMMANDS:
             if not isinstance(subcommand, CommandInfo):
@@ -77,10 +77,11 @@ class BaseOptimumCLICommand(ABC):
 
         self.args = args
 
-    def get_defaults_factory(self, subparsers: Optional["_SubParsersAction"]):
+    @property
+    def defaults_factory(self):
         
         def defaults_factory_func(args):
-            return self.__class__(subparsers, args, command=self.COMMAND, from_defaults_factory=True)
+            return self.__class__(self.subparsers, args, command=self.COMMAND, from_defaults_factory=True)
 
         return defaults_factory_func
 
@@ -91,7 +92,7 @@ class BaseOptimumCLICommand(ABC):
             if self.SUBCOMMANDS:
                 if self.parser is not None:
                     self._subparsers = self.parser.add_subparsers()
-                    self.parser.set_defaults(func=self.get_defaults_factory(self._subparsers))
+                    self.parser.set_defaults(func=self.defaults_factory)
             else:
                 self._subparsers = None
         return self._subparsers 

--- a/optimum/commands/base.py
+++ b/optimum/commands/base.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Optimum command-line interface base classes."""
+
+from abc import ABC, abstractmethod
+from argparse import RawTextHelpFormatter
+from dataclasses import dataclass
+from typing import Tuple, Type, Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+
+@dataclass(frozen=True)
+class CommandInfo:
+    name: str
+    help: str
+    subcommand_class: Optional[Type] = None
+    formatter_class: Type = RawTextHelpFormatter
+
+    @property
+    def is_subcommand_info(self):
+        return self.subcommand_class is not None
+    
+    def is_subcommand_info_or_raise(self):
+        if not self.is_subcommand_info:
+            raise ValueError(f"The command info must define a subcommand_class attribute, but got: {self}.")
+
+
+class InvalidCLICommand(Exception):
+    pass
+
+
+class BaseOptimumCLICommand(ABC):
+    COMMAND: CommandInfo
+    SUBCOMMANDS: Tuple[CommandInfo, ...] = tuple()
+
+    def __init__(self, parser: "ArgumentParser", args: Optional["Namespace"] = None, command: Optional[CommandInfo] = None):
+        if command is not None:
+            self.COMMAND = command
+
+        self.parser = parser.add_parser(self.COMMAND.name, help=self.COMMAND.help)
+        self.subparsers = self.parser.add_subparsers()
+        self.parse_args(self.parser)
+
+        def defaults_factory(args):
+            return self.__class__(self.subparsers, args, command=command)
+
+        self.parser.set_defaults(func=defaults_factory)
+
+        for subcommand in self.SUBCOMMANDS:
+            if not isinstance(subcommand, CommandInfo):
+                raise ValueError(f"Subcommands must be instances of CommandInfo, but got {type(subcommand)} here.")
+            self.register_subcommand(subcommand)
+
+        self.args = args
+
+    @classmethod
+    def add_subcommand(cls, command_info: CommandInfo):
+        command_info.is_subcommand_info_or_raise()
+        cls.SUBCOMMANDS = cls.SUBCOMMANDS + (command_info,)
+
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        pass
+
+
+    def register_subcommand(self, command_info: CommandInfo):
+        command_info.is_subcommand_info_or_raise()
+        command_info.subcommand_class(self.subparsers, command=command_info)
+
+    def run(self):
+        raise NotImplementedError()
+

--- a/optimum/commands/env.py
+++ b/optimum/commands/env.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import platform
-from argparse import ArgumentParser
 
 import huggingface_hub
 from transformers import __version__ as transformers_version
@@ -24,10 +23,7 @@ from . import BaseOptimumCLICommand, CommandInfo
 
 
 class EnvironmentCommand(BaseOptimumCLICommand):
-    COMMAND = CommandInfo(
-        name="env",
-        help="Get information about the environment used."
-    )
+    COMMAND = CommandInfo(name="env", help="Get information about the environment used.")
 
     @staticmethod
     def format_dict(d):
@@ -69,4 +65,3 @@ class EnvironmentCommand(BaseOptimumCLICommand):
         print(self.format_dict(info))
 
         return info
-

--- a/optimum/commands/env.py
+++ b/optimum/commands/env.py
@@ -20,18 +20,18 @@ from transformers import __version__ as transformers_version
 from transformers.utils import is_tf_available, is_torch_available
 
 from ..version import __version__ as version
-from . import BaseOptimumCLICommand
-
-
-def info_command_factory(_):
-    return EnvironmentCommand()
+from . import BaseOptimumCLICommand, CommandInfo
 
 
 class EnvironmentCommand(BaseOptimumCLICommand):
+    COMMAND = CommandInfo(
+        name="env",
+        help="Get information about the environment used."
+    )
+
     @staticmethod
-    def register_subcommand(parser: ArgumentParser):
-        download_parser = parser.add_parser("env", help="Get information about the environment used.")
-        download_parser.set_defaults(func=info_command_factory)
+    def format_dict(d):
+        return "\n".join([f"- {prop}: {val}" for prop, val in d.items()]) + "\n"
 
     def run(self):
         pt_version = "not installed"
@@ -70,6 +70,3 @@ class EnvironmentCommand(BaseOptimumCLICommand):
 
         return info
 
-    @staticmethod
-    def format_dict(d):
-        return "\n".join([f"- {prop}: {val}" for prop, val in d.items()]) + "\n"

--- a/optimum/commands/export/__init__.py
+++ b/optimum/commands/export/__init__.py
@@ -14,4 +14,3 @@
 
 
 from .base import ExportCommand
-

--- a/optimum/commands/export/__init__.py
+++ b/optimum/commands/export/__init__.py
@@ -14,3 +14,5 @@
 
 
 from .base import ExportCommand
+from .onnx import ONNXExportCommand
+from .tflite import TFLiteExportCommand

--- a/optimum/commands/export/__init__.py
+++ b/optimum/commands/export/__init__.py
@@ -13,13 +13,5 @@
 # limitations under the License.
 
 
-def onnx_export_factory(args):
-    return ONNXExportCommand(args)
-
-
-def tflite_export_factory(_):
-    return TFLiteExportCommand(" ".join(sys.argv[3:]))
-
-
 from .base import ExportCommand
 

--- a/optimum/commands/export/__init__.py
+++ b/optimum/commands/export/__init__.py
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-from argparse import ArgumentParser, RawTextHelpFormatter
-
-from ...exporters.onnx.__main__ import parse_args_onnx
-from .. import BaseOptimumCLICommand
-from .onnx import ONNXExportCommand
-from .tflite import TFLiteExportCommand, parse_args_tflite
-
 
 def onnx_export_factory(args):
     return ONNXExportCommand(args)
@@ -29,25 +21,5 @@ def tflite_export_factory(_):
     return TFLiteExportCommand(" ".join(sys.argv[3:]))
 
 
-class ExportCommand(BaseOptimumCLICommand):
-    @staticmethod
-    def register_subcommand(parser: ArgumentParser):
-        export_parser = parser.add_parser(
-            "export", help="Export PyTorch and TensorFlow models to several format (currently supported: onnx)."
-        )
-        export_sub_parsers = export_parser.add_subparsers()
+from .base import ExportCommand
 
-        onnx_parser = export_sub_parsers.add_parser(
-            "onnx", help="Export PyTorch and TensorFlow to ONNX.", formatter_class=RawTextHelpFormatter
-        )
-
-        parse_args_onnx(onnx_parser)
-        onnx_parser.set_defaults(func=onnx_export_factory)
-
-        tflite_parser = export_sub_parsers.add_parser("tflite", help="Export TensorFlow to TensorFlow Lite.")
-
-        parse_args_tflite(tflite_parser)
-        tflite_parser.set_defaults(func=tflite_export_factory)
-
-    def run(self):
-        raise NotImplementedError()

--- a/optimum/commands/export/base.py
+++ b/optimum/commands/export/base.py
@@ -14,12 +14,10 @@
 # limitations under the License.
 """optimum.exporters command-line interface base classes."""
 
-import sys
-from argparse import ArgumentParser, RawTextHelpFormatter
-
 from .. import BaseOptimumCLICommand, CommandInfo
 from .onnx import ONNXExportCommand
-from .tflite import TFLiteExportCommand, parse_args_tflite
+from .tflite import TFLiteExportCommand
+
 
 class ExportCommand(BaseOptimumCLICommand):
     COMMAND = CommandInfo(

--- a/optimum/commands/export/base.py
+++ b/optimum/commands/export/base.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""optimum.exporters command-line interface base classes."""
+
+import sys
+from argparse import ArgumentParser, RawTextHelpFormatter
+
+from .. import BaseOptimumCLICommand, CommandInfo
+from .onnx import ONNXExportCommand
+from .tflite import TFLiteExportCommand, parse_args_tflite
+
+class ExportCommand(BaseOptimumCLICommand):
+    COMMAND = CommandInfo(
+        name="export",
+        help="Export PyTorch and TensorFlow models to several format.",
+    )
+    SUBCOMMANDS = (
+        CommandInfo(
+            name="onnx",
+            help="Export PyTorch and TensorFlow to ONNX.",
+            subcommand_class=ONNXExportCommand,
+        ),
+        CommandInfo(
+            name="tflite",
+            help="Export TensorFlow to TensorFlow Lite.",
+            subcommand_class=TFLiteExportCommand,
+        ),
+    )

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -19,12 +19,12 @@ from ...exporters.onnx.__main__ import main_export, parse_args_onnx
 from ...utils import DEFAULT_DUMMY_SHAPES
 from ..base import BaseOptimumCLICommand
 
+
 if TYPE_CHECKING:
     from argparse import ArgumentParser
 
 
 class ONNXExportCommand(BaseOptimumCLICommand):
-
     @staticmethod
     def parse_args(parser: "ArgumentParser"):
         return parse_args_onnx(parser)

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -13,16 +13,24 @@
 # limitations under the License.
 """Defines the command line for the export with ONNX."""
 
-from ...exporters.onnx.__main__ import main_export
+from typing import TYPE_CHECKING
+
+from ...exporters.onnx.__main__ import main_export, parse_args_onnx
 from ...utils import DEFAULT_DUMMY_SHAPES
+from ..base import BaseOptimumCLICommand
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
 
 
-class ONNXExportCommand:
-    def __init__(self, args):
-        self.args = args
+class ONNXExportCommand(BaseOptimumCLICommand):
+
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        return parse_args_onnx(parser)
 
     def run(self):
-        # get the shapes to be used to generate dummy inputs
+        # Get the shapes to be used to generate dummy inputs
         input_shapes = {}
         for input_name in DEFAULT_DUMMY_SHAPES.keys():
             input_shapes[input_name] = getattr(self.args, input_name)

--- a/optimum/commands/export/tflite.py
+++ b/optimum/commands/export/tflite.py
@@ -23,6 +23,12 @@ from ...exporters.tflite import QuantizationApproach
 from ..base import BaseOptimumCLICommand
 
 
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
+
+    from ..base import CommandInfo
+
+
 def parse_args_tflite(parser: "ArgumentParser"):
     required_group = parser.add_argument_group("Required arguments")
     required_group.add_argument(
@@ -214,14 +220,16 @@ def parse_args_tflite(parser: "ArgumentParser"):
         help=("The name of the column containing the image in the dataset. Only for image-classification."),
     )
 
-if TYPE_CHECKING:
-    from argparse import ArgumentParser, Namespace
-    from ..base import CommandInfo
-
 
 class TFLiteExportCommand(BaseOptimumCLICommand):
-    def __init__(self, parser: "ArgumentParser", args: Optional["Namespace"] = None, command: Optional["CommandInfo"] = None):
-        super().__init__(parser, args, command=command)
+    def __init__(
+        self,
+        parser: "_SubParsersAction",
+        args: Optional["Namespace"] = None,
+        command: Optional["CommandInfo"] = None,
+        from_defaults_factory: bool = False,
+    ):
+        super().__init__(parser, args, command=command, from_defaults_factory=from_defaults_factory)
         # TODO: hack until TFLiteExportCommand does not use subprocess anymore.
         self.args_string = " ".join(sys.argv[3:])
 

--- a/optimum/commands/export/tflite.py
+++ b/optimum/commands/export/tflite.py
@@ -14,13 +14,16 @@
 """Defines the command line for the export with TensorFlow Lite."""
 
 import subprocess
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
 from ...exporters import TasksManager
 from ...exporters.tflite import QuantizationApproach
+from ..base import BaseOptimumCLICommand
 
 
-def parse_args_tflite(parser):
+def parse_args_tflite(parser: "ArgumentParser"):
     required_group = parser.add_argument_group("Required arguments")
     required_group.add_argument(
         "-m", "--model", type=str, required=True, help="Model ID on huggingface.co or path on disk to load model from."
@@ -211,10 +214,20 @@ def parse_args_tflite(parser):
         help=("The name of the column containing the image in the dataset. Only for image-classification."),
     )
 
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+    from ..base import CommandInfo
 
-class TFLiteExportCommand:
-    def __init__(self, args_string):
-        self.args_string = args_string
+
+class TFLiteExportCommand(BaseOptimumCLICommand):
+    def __init__(self, parser: "ArgumentParser", args: Optional["Namespace"] = None, command: Optional["CommandInfo"] = None):
+        super().__init__(parser, args, command=command)
+        # TODO: hack until TFLiteExportCommand does not use subprocess anymore.
+        self.args_string = " ".join(sys.argv[3:])
+
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        return parse_args_tflite(parser)
 
     def run(self):
         full_command = f"python3 -m optimum.exporters.tflite {self.args_string}"

--- a/optimum/commands/onnxruntime/__init__.py
+++ b/optimum/commands/onnxruntime/__init__.py
@@ -1,33 +1,16 @@
-import sys
-from argparse import ArgumentParser
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from .. import BaseOptimumCLICommand
-from .optimize import ONNXRuntimmeOptimizeCommand, parse_args_onnxruntime_optimize
-from .quantize import ONNXRuntimmeQuantizeCommand, parse_args_onnxruntime_quantize
-
-
-def onnxruntime_optimize_factory(args):
-    return ONNXRuntimmeOptimizeCommand(args)
-
-
-def onnxruntime_quantize_factory(args):
-    return ONNXRuntimmeQuantizeCommand(args)
-
-
-class ONNXRuntimeCommand(BaseOptimumCLICommand):
-    @staticmethod
-    def register_subcommand(parser: ArgumentParser):
-        onnxruntime_parser = parser.add_parser("onnxruntime", help="ONNX Runtime optimize and quantize utilities.")
-        onnxruntime_sub_parsers = onnxruntime_parser.add_subparsers()
-
-        optimize_parser = onnxruntime_sub_parsers.add_parser("optimize", help="Optimize ONNX models.")
-        quantize_parser = onnxruntime_sub_parsers.add_parser("quantize", help="Dynammic quantization for ONNX models.")
-
-        parse_args_onnxruntime_optimize(optimize_parser)
-        parse_args_onnxruntime_quantize(quantize_parser)
-
-        optimize_parser.set_defaults(func=onnxruntime_optimize_factory)
-        quantize_parser.set_defaults(func=onnxruntime_quantize_factory)
-
-    def run(self):
-        raise NotImplementedError()
+from .base import ONNXRuntimeCommand

--- a/optimum/commands/onnxruntime/base.py
+++ b/optimum/commands/onnxruntime/base.py
@@ -16,7 +16,7 @@
 
 from .. import BaseOptimumCLICommand, CommandInfo
 from .optimize import ONNXRuntimmeOptimizeCommand
-from .quantize import ONNXRuntimmeQuantizeCommand 
+from .quantize import ONNXRuntimmeQuantizeCommand
 
 
 class ONNXRuntimeCommand(BaseOptimumCLICommand):

--- a/optimum/commands/onnxruntime/base.py
+++ b/optimum/commands/onnxruntime/base.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""optimum.onnxruntime command-line interface base classes."""
+
+from .. import BaseOptimumCLICommand, CommandInfo
+from .optimize import ONNXRuntimmeOptimizeCommand
+from .quantize import ONNXRuntimmeQuantizeCommand 
+
+
+class ONNXRuntimeCommand(BaseOptimumCLICommand):
+    COMMAND = CommandInfo(
+        name="onnxruntime",
+        help="ONNX Runtime optimize and quantize utilities.",
+    )
+    SUBCOMMANDS = (
+        CommandInfo(
+            name="optimize",
+            help="Optimize ONNX models.",
+            subcommand_class=ONNXRuntimmeOptimizeCommand,
+        ),
+        CommandInfo(
+            name="quantize",
+            help="Dynammic quantization for ONNX models.",
+            subcommand_class=ONNXRuntimmeQuantizeCommand,
+        ),
+    )

--- a/optimum/commands/onnxruntime/optimize.py
+++ b/optimum/commands/onnxruntime/optimize.py
@@ -22,6 +22,7 @@ from optimum.commands.base import BaseOptimumCLICommand
 from ...onnxruntime.configuration import AutoOptimizationConfig, ORTConfig
 from ...onnxruntime.optimization import ORTOptimizer
 
+
 if TYPE_CHECKING:
     from argparse import ArgumentParser
 

--- a/optimum/commands/onnxruntime/optimize.py
+++ b/optimum/commands/onnxruntime/optimize.py
@@ -1,10 +1,32 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Optimization with ONNX Runtime command-line interface class."""
+
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+from optimum.commands.base import BaseOptimumCLICommand
 
 from ...onnxruntime.configuration import AutoOptimizationConfig, ORTConfig
 from ...onnxruntime.optimization import ORTOptimizer
 
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
 
-def parse_args_onnxruntime_optimize(parser):
+
+def parse_args_onnxruntime_optimize(parser: "ArgumentParser"):
     required_group = parser.add_argument_group("Required arguments")
     required_group.add_argument(
         "--onnx_model",
@@ -50,9 +72,10 @@ def parse_args_onnxruntime_optimize(parser):
     )
 
 
-class ONNXRuntimmeOptimizeCommand:
-    def __init__(self, args):
-        self.args = args
+class ONNXRuntimmeOptimizeCommand(BaseOptimumCLICommand):
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        return parse_args_onnxruntime_optimize(parser)
 
     def run(self):
         if not self.args.output:

--- a/optimum/commands/onnxruntime/quantize.py
+++ b/optimum/commands/onnxruntime/quantize.py
@@ -1,10 +1,33 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Quantization with ONNX Runtime command-line interface class."""
+
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 
 from ...onnxruntime.configuration import AutoQuantizationConfig, ORTConfig
 from ...onnxruntime.quantization import ORTQuantizer
 
+from .. import BaseOptimumCLICommand
 
-def parse_args_onnxruntime_quantize(parser):
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+def parse_args_onnxruntime_quantize(parser: "ArgumentParser"):
     required_group = parser.add_argument_group("Required arguments")
     required_group.add_argument(
         "--onnx_model",
@@ -42,9 +65,11 @@ def parse_args_onnxruntime_quantize(parser):
     )
 
 
-class ONNXRuntimmeQuantizeCommand:
-    def __init__(self, args):
-        self.args = args
+class ONNXRuntimmeQuantizeCommand(BaseOptimumCLICommand):
+
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        return parse_args_onnxruntime_quantize(parser)
 
     def run(self):
         if not self.args.output:

--- a/optimum/commands/onnxruntime/quantize.py
+++ b/optimum/commands/onnxruntime/quantize.py
@@ -17,11 +17,10 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-
 from ...onnxruntime.configuration import AutoQuantizationConfig, ORTConfig
 from ...onnxruntime.quantization import ORTQuantizer
-
 from .. import BaseOptimumCLICommand
+
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser
@@ -66,7 +65,6 @@ def parse_args_onnxruntime_quantize(parser: "ArgumentParser"):
 
 
 class ONNXRuntimmeQuantizeCommand(BaseOptimumCLICommand):
-
     @staticmethod
     def parse_args(parser: "ArgumentParser"):
         return parse_args_onnxruntime_quantize(parser)

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -15,7 +15,7 @@
 
 import importlib
 from pathlib import Path
-from typing import List, Optional, Tuple, Type, Union, Dict
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 from ..utils import logging
 from .base import BaseOptimumCLICommand, CommandInfo, RootOptimumCLICommand
@@ -33,7 +33,9 @@ OPTIMUM_CLI_SUBCOMMANDS = [
 ]
 
 
-def resolve_command_to_command_instance(root: RootOptimumCLICommand, commands: List[Type[BaseOptimumCLICommand]]) -> Dict[Type[BaseOptimumCLICommand], BaseOptimumCLICommand]:
+def resolve_command_to_command_instance(
+    root: RootOptimumCLICommand, commands: List[Type[BaseOptimumCLICommand]]
+) -> Dict[Type[BaseOptimumCLICommand], BaseOptimumCLICommand]:
     to_visit = [root]
     remaining_commands = set(commands)
     command2command_instance = {}
@@ -51,6 +53,7 @@ def resolve_command_to_command_instance(root: RootOptimumCLICommand, commands: L
             f"Could not find an instance of the following commands in the CLI {root}: {', '.join(class_names)}."
         )
     return command2command_instance
+
 
 def dynamic_load_commands_in_register() -> (
     List[Tuple[Union[Type[BaseOptimumCLICommand], CommandInfo], Optional[Type[BaseOptimumCLICommand]]]]
@@ -83,6 +86,7 @@ def dynamic_load_commands_in_register() -> (
             commands_to_register.append((command_or_command_info, parent_command_cls))
     return commands_to_register
 
+
 def register_optimum_cli_subcommand(
     command_or_command_info: Union[Type[BaseOptimumCLICommand], CommandInfo],
     parent_command: BaseOptimumCLICommand,
@@ -108,13 +112,12 @@ def main():
 
     commands_in_register = dynamic_load_commands_in_register()
     command2command_instance = resolve_command_to_command_instance(
-        root, 
-        [parent_command_cls for _, parent_command_cls in commands_in_register if parent_command_cls is not None]
+        root, [parent_command_cls for _, parent_command_cls in commands_in_register if parent_command_cls is not None]
     )
-    
+
     for command_or_command_info, parent_command in commands_in_register:
         if parent_command is None:
-            parent_command_instance  = root
+            parent_command_instance = root
         else:
             parent_command_instance = command2command_instance[parent_command]
         register_optimum_cli_subcommand(command_or_command_info, parent_command=parent_command_instance)

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -40,12 +40,7 @@ def main():
 
     # Register commands
     for subcommand_cls in OPTIMUM_CLI_SUBCOMMANDS:
-        subcommand = subcommand_cls(commands_parser)
-
-
-    ExportCommand.register_subcommand(commands_parser)
-    EnvironmentCommand.register_subcommand(commands_parser)
-    ONNXRuntimeCommand.register_subcommand(commands_parser)
+        subcommand_cls(commands_parser)
 
     args = parser.parse_args()
 

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -85,10 +85,9 @@ def dynamic_load_commands_in_register() -> (
     """
     commands_to_register = []
     register_dir_path = Path(__file__).parent / "register"
-    print(list(register_dir_path.parent.iterdir()))
     for filename in register_dir_path.iterdir():
         if filename.is_dir() or filename.suffix != ".py":
-            if filename.name != "__pycache__":
+            if filename.name not in ["__pycache__", "README.md"]:
                 logger.warning(
                     f"Skipping {filename} because only python files are allowed when registering commands dynamically."
                 )

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -85,6 +85,7 @@ def dynamic_load_commands_in_register() -> (
     """
     commands_to_register = []
     register_dir_path = Path(__file__).parent / "register"
+    print(list(register_dir_path.parent.iterdir()))
     for filename in register_dir_path.iterdir():
         if filename.is_dir() or filename.suffix != ".py":
             if filename.name != "__pycache__":

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -14,10 +14,24 @@
 # limitations under the License.
 
 from argparse import ArgumentParser
+from typing import Type, TypeVar
+
+from optimum.commands.base import BaseOptimumCLICommand
 
 from .env import EnvironmentCommand
 from .export import ExportCommand
 from .onnxruntime import ONNXRuntimeCommand
+
+OPTIMUM_CLI_SUBCOMMANDS = [
+    ExportCommand,
+    EnvironmentCommand,
+    ONNXRuntimeCommand,
+    
+]
+
+
+def register_optimum_cli_subcommand(subcommand_cls: Type[BaseOptimumCLICommand]):
+    OPTIMUM_CLI_SUBCOMMANDS.append(subcommand_cls)
 
 
 def main():
@@ -25,6 +39,10 @@ def main():
     commands_parser = parser.add_subparsers(help="optimum-cli command helpers")
 
     # Register commands
+    for subcommand_cls in OPTIMUM_CLI_SUBCOMMANDS:
+        subcommand = subcommand_cls(commands_parser)
+
+
     ExportCommand.register_subcommand(commands_parser)
     EnvironmentCommand.register_subcommand(commands_parser)
     ONNXRuntimeCommand.register_subcommand(commands_parser)

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from argparse import ArgumentParser
-from typing import Type
+from typing import Type, Optional, Union
 
-from optimum.commands.base import BaseOptimumCLICommand
+from optimum.commands.base import BaseOptimumCLICommand, CommandInfo, RootOptimumCLICommand
 
 from .env import EnvironmentCommand
 from .export import ExportCommand
@@ -29,19 +29,47 @@ OPTIMUM_CLI_SUBCOMMANDS = [
     ONNXRuntimeCommand,
 ]
 
+ROOT = RootOptimumCLICommand("Optimum CLI tool", usage="optimum-cli <command> [<args>]")
 
-def register_optimum_cli_subcommand(subcommand_cls: Type[BaseOptimumCLICommand]):
-    OPTIMUM_CLI_SUBCOMMANDS.append(subcommand_cls)
+
+
+def register_optimum_cli_subcommand(command_or_command_info: Union[Type[BaseOptimumCLICommand], CommandInfo], parent_command_cls: Optional[Type[BaseOptimumCLICommand]] = None):
+    if parent_command_cls is None:
+        parent_command_cls = RootOptimumCLICommand
+    if not isinstance(command_or_command_info, CommandInfo):
+        command_info = CommandInfo(command_or_command_info.COMMAND.name, help=command_or_command_info.COMMAND.help, subcommand_class=command_or_command_info)
+    else:
+        command_info = command_or_command_info
+    command_info.is_subcommand_info_or_raise()
+
+    parent_command = ROOT
+
+    was_registered = False
+    to_visit = [parent_command]
+    while to_visit:
+        subcommand = to_visit.pop(0)
+        if isinstance(subcommand, parent_command_cls):
+            subcommand.register_subcommand(command_info)
+            was_registered = True
+            break
+        to_visit += parent_command.registered_subcommands
+    if not was_registered:
+        raise RuntimeError(
+            f"Could not register the subcommand called {command_info.name} to the parent command {parent_command} "
+            f"because this parent command is not in the Optimum CLI subcommands."
+        )
 
 
 def main():
-    parser = ArgumentParser("Optimum CLI tool", usage="optimum-cli <command> [<args>]")
-    commands_parser = parser.add_subparsers(help="optimum-cli command helpers")
+    # parser = ArgumentParser("Optimum CLI tool", usage="optimum-cli <command> [<args>]")
+    # commands_parser = parser.add_subparsers()
 
     # Register commands
     for subcommand_cls in OPTIMUM_CLI_SUBCOMMANDS:
-        subcommand_cls(commands_parser)
+        # subcommand_cls(commands_parser)
+        register_optimum_cli_subcommand(subcommand_cls)
 
+    parser = ROOT.parser
     args = parser.parse_args()
 
     if not hasattr(args, "func"):

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -48,7 +48,7 @@ def resolve_command_to_command_instance(
             break
         to_visit += current_command_instance.registered_subcommands
     if remaining_commands:
-        class_names = map(lambda x: x.__name__, remaining_commands)
+        class_names = (command.__name__ for command in remaining_commands)
         raise RuntimeError(
             f"Could not find an instance of the following commands in the CLI {root}: {', '.join(class_names)}."
         )

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -36,6 +36,19 @@ OPTIMUM_CLI_SUBCOMMANDS = [
 def resolve_command_to_command_instance(
     root: RootOptimumCLICommand, commands: List[Type[BaseOptimumCLICommand]]
 ) -> Dict[Type[BaseOptimumCLICommand], BaseOptimumCLICommand]:
+    """
+    Retrieves command instances in the root CLI command from a list of command classes.
+
+    Args:
+        root (`RootOptimumCLICommand`):
+            The root CLI command instance.
+        commands (`List[Type[BaseOptimumCLICommand]]`):
+            The list of command classes to retrieve the instances of in root.
+
+    Returns:
+        `Dict[Type[BaseOptimumCLICommand], BaseOptimumCLICommand]`: A dictionary mapping a command class to a command
+        instance in the root CLI.
+    """
     to_visit = [root]
     remaining_commands = set(commands)
     command2command_instance = {}
@@ -58,6 +71,18 @@ def resolve_command_to_command_instance(
 def dynamic_load_commands_in_register() -> (
     List[Tuple[Union[Type[BaseOptimumCLICommand], CommandInfo], Optional[Type[BaseOptimumCLICommand]]]]
 ):
+    """
+    Loads a list of command classes to register to the CLI from the `optimum/commands/register/` directory.
+    It will look in any python file if there is a `REGISTER_COMMANDS` list, and load the commands to register
+    accordingly.
+    At this point, nothing is actually registered in the root CLI.
+
+    Returns:
+        `List[Tuple[Union[Type[BaseOptimumCLICommand], CommandInfo], Optional[Type[BaseOptimumCLICommand]]]]`: A list
+        of tuples with two elements. The first element corresponds to the command to register, it can either be a
+        subclass of `BaseOptimumCLICommand` or a `CommandInfo`. The second element corresponds to the parent command,
+        where `None` means that the parent command is the root CLI command.
+    """
     commands_to_register = []
     register_dir_path = Path(__file__).parent / "register"
     for filename in register_dir_path.iterdir():
@@ -91,6 +116,15 @@ def register_optimum_cli_subcommand(
     command_or_command_info: Union[Type[BaseOptimumCLICommand], CommandInfo],
     parent_command: BaseOptimumCLICommand,
 ):
+    """
+    Registers a command as being a subcommand of `parent_command`.
+
+    Args:
+        command_or_command_info (`Union[Type[BaseOptimumCLICommand], CommandInfo]`):
+            The command to register.
+        parent_command (`BaseOptimumCLICommand`):
+            The instance of the parent command.
+    """
     if not isinstance(command_or_command_info, CommandInfo):
         command_info = CommandInfo(
             command_or_command_info.COMMAND.name,

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -15,14 +15,14 @@
 
 import importlib
 from pathlib import Path
-from typing import Type, Optional, Union, List, Tuple
+from typing import List, Optional, Tuple, Type, Union
 
 from ..utils import logging
-
 from .base import BaseOptimumCLICommand, CommandInfo, RootOptimumCLICommand
 from .env import EnvironmentCommand
 from .export import ExportCommand
 from .onnxruntime import ONNXRuntimeCommand
+
 
 logger = logging.get_logger()
 
@@ -34,14 +34,17 @@ OPTIMUM_CLI_SUBCOMMANDS = [
 ROOT = RootOptimumCLICommand("Optimum CLI tool", usage="optimum-cli <command> [<args>]")
 
 
-def dynamic_load_commands_in_register() -> List[Tuple[Union[Type[BaseOptimumCLICommand], CommandInfo], Optional[Type[BaseOptimumCLICommand]]]]:
+def dynamic_load_commands_in_register() -> (
+    List[Tuple[Union[Type[BaseOptimumCLICommand], CommandInfo], Optional[Type[BaseOptimumCLICommand]]]]
+):
     commands_to_register = []
     register_dir_path = Path(__file__).parent / "register"
     for filename in register_dir_path.iterdir():
         if filename.is_dir() or filename.suffix != ".py":
-            logger.warning(
-                f"Skipping {filename} because only python files are allowed when registering commands dynamically."
-            )
+            if filename.name != "__pycache__":
+                logger.warning(
+                    f"Skipping {filename} because only python files are allowed when registering commands dynamically."
+                )
             continue
         module_name = f".register.{filename.stem}"
         module = importlib.import_module(module_name, package="optimum.commands")
@@ -52,8 +55,9 @@ def dynamic_load_commands_in_register() -> List[Tuple[Union[Type[BaseOptimumCLIC
             else:
                 command_or_command_info = command
                 parent_command_cls = None
-            print(command_or_command_info, parent_command_cls)
-            if not isinstance(command_or_command_info, (BaseOptimumCLICommand, CommandInfo)):
+            if not isinstance(command_or_command_info, CommandInfo) and not issubclass(
+                command_or_command_info, BaseOptimumCLICommand
+            ):
                 raise ValueError(
                     f"The command at index {command_idx} in {filename} is not of the right type: {type(command_or_command_info)}."
                 )
@@ -61,11 +65,18 @@ def dynamic_load_commands_in_register() -> List[Tuple[Union[Type[BaseOptimumCLIC
     return commands_to_register
 
 
-def register_optimum_cli_subcommand(command_or_command_info: Union[Type[BaseOptimumCLICommand], CommandInfo], parent_command_cls: Optional[Type[BaseOptimumCLICommand]] = None):
+def register_optimum_cli_subcommand(
+    command_or_command_info: Union[Type[BaseOptimumCLICommand], CommandInfo],
+    parent_command_cls: Optional[Type[BaseOptimumCLICommand]] = None,
+):
     if parent_command_cls is None:
         parent_command_cls = RootOptimumCLICommand
     if not isinstance(command_or_command_info, CommandInfo):
-        command_info = CommandInfo(command_or_command_info.COMMAND.name, help=command_or_command_info.COMMAND.help, subcommand_class=command_or_command_info)
+        command_info = CommandInfo(
+            command_or_command_info.COMMAND.name,
+            help=command_or_command_info.COMMAND.help,
+            subcommand_class=command_or_command_info,
+        )
     else:
         command_info = command_or_command_info
     command_info.is_subcommand_info_or_raise()
@@ -90,13 +101,11 @@ def register_optimum_cli_subcommand(command_or_command_info: Union[Type[BaseOpti
 def main():
     # Register commands
     for subcommand_cls in OPTIMUM_CLI_SUBCOMMANDS:
-        # subcommand_cls(commands_parser)
         register_optimum_cli_subcommand(subcommand_cls)
 
     commands_in_register = dynamic_load_commands_in_register()
-    for command_or_command_info, parent_command_cls in  commands_in_register:
+    for command_or_command_info, parent_command_cls in commands_in_register:
         register_optimum_cli_subcommand(command_or_command_info, parent_command_cls=parent_command_cls)
-
 
     parser = ROOT.parser
     args = parser.parse_args()

--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from argparse import ArgumentParser
-from typing import Type, TypeVar
+from typing import Type
 
 from optimum.commands.base import BaseOptimumCLICommand
 
@@ -22,11 +22,11 @@ from .env import EnvironmentCommand
 from .export import ExportCommand
 from .onnxruntime import ONNXRuntimeCommand
 
+
 OPTIMUM_CLI_SUBCOMMANDS = [
     ExportCommand,
     EnvironmentCommand,
     ONNXRuntimeCommand,
-    
 ]
 
 

--- a/optimum/commands/register/README.md
+++ b/optimum/commands/register/README.md
@@ -6,7 +6,7 @@ Steps to follow:
 
 1. Create a command as a subclass of `optimum.commands.BaseOptimumCLICommand`.
 2. Create a Python file under `optimum/commands/register/`, and define a `REGISTER_COMMANDS` list variable there.
-3. Fill the `REGISTER_COMMANDS` as folows:
+3. Fill the `REGISTER_COMMANDS` as follows:
 
 ```python
 # CustomCommand1 and CustomCommand2 could also be defined in this file actually.

--- a/optimum/commands/register/README.md
+++ b/optimum/commands/register/README.md
@@ -1,0 +1,22 @@
+# Register commands in the Optimum CLI from a subpackage
+
+It is possible to register a command in the Optimum CLI, either as a command or a subcommand of an already existing command.
+
+Steps to follow:
+
+1. Create a command as a subclass of `optimum.commands.BaseOptimumCLICommand`.
+2. Create a Python file under `optimum/commands/register/`, and define a `REGISTER_COMMANDS` list variable there.
+3. Fill the `REGISTER_COMMANDS` as folows:
+
+```python
+# CustomCommand1 and CustomCommand2 could also be defined in this file actually.
+from ..my_custom_commands import CustomCommand1, CustomCommand2
+from ..export import ExportCommand
+
+REGISTER_COMMANDS = [
+  # CustomCommand1 will be registered as a subcommand of the root Optimum CLI. 
+  CustomCommand1, 
+  # CustomCommand2 will be registered as a subcommand of the `optimum-cli export` command. 
+  (CustomCommand2, ExportCommand) # CustomCommand2 will be registered
+]
+```

--- a/optimum/commands/register/__init__.py
+++ b/optimum/commands/register/__init__.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/cli/cli_with_custom_command.py
+++ b/tests/cli/cli_with_custom_command.py
@@ -13,6 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ONNXRuntimeCommand
-from .optimize import ONNXRuntimmeOptimizeCommand
-from .quantize import ONNXRuntimmeQuantizeCommand
+import os
+
+from optimum.commands import BaseOptimumCLICommand, CommandInfo, ExportCommand
+
+
+class MyCustomCommand(BaseOptimumCLICommand):
+    COMMAND = CommandInfo(name="blablabla", help="Says something thing")
+
+    def run(self):
+        print("If the CI can read this, it means it worked!")
+
+
+parent_command_cls = os.environ.get("TEST_REGISTER_COMMAND_WITH_SUBCOMMAND", None)
+
+if parent_command_cls == "true":
+    REGISTER_COMMANDS = [
+        (MyCustomCommand, ExportCommand),
+    ]
+else:
+    REGISTER_COMMANDS = [
+        MyCustomCommand,
+    ]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import os
 import shutil
 import subprocess
@@ -20,11 +21,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import optimum.commands
+
 
 CLI_WIH_CUSTOM_COMMAND_PATH = Path(__file__).parent / "cli_with_custom_command.py"
-REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH = (
-    Path(__file__).parent.parent.parent / "optimum" / "commands" / "register" / "cli_with_custom_command.py"
-)
+OPTIMUM_COMMANDS_DIR = Path(inspect.getfile(optimum.commands)).parent
+REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH = OPTIMUM_COMMANDS_DIR / "register" / "cli_with_custom_command.py"
 
 
 class TestCLI(unittest.TestCase):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
+import os
 import shutil
 import subprocess
 import tempfile
 import unittest
+from pathlib import Path
 
 
 class TestCLI(unittest.TestCase):
@@ -98,11 +99,14 @@ class TestCLI(unittest.TestCase):
         register_dir = current_dir.parent.parent / "optimum" / "commands" / "register"
         filename = "cli_with_custom_command.py"
 
-        # Registering by providing the command.
         shutil.copy(current_dir / filename, register_dir / filename)
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
-        shutil.rmtree(filename)
+        (register_dir / filename).unlink()
 
-        
-
+        shutil.copy(current_dir / filename, register_dir / filename)
+        os.environ["TEST_REGISTER_COMMAND_WITH_SUBCOMMAND"] = "true"
+        custom_command = "optimum-cli export blablabla"
+        succeeded = self._run_command_and_check_content(custom_command, command_content)
+        self.assertTrue(succeeded, "The command should succeed here since it is registered.")
+        (register_dir / filename).unlink()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,22 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+import shutil
 import subprocess
 import tempfile
 import unittest
-import random
-import string
-
-from optimum.commands import BaseOptimumCLICommand, CommandInfo, register_optimum_cli_subcommand
-
-class MyCustomCommand(BaseOptimumCLICommand):
-    COMMAND = CommandInfo(name="blablabla", help="Says something thing")
-
-    # def _generate_random_string(self, length: int):
-    #     return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
-
-    def run(self):
-        print("If the CI can read this, it means it worked!")
 
 
 class TestCLI(unittest.TestCase):
@@ -95,6 +84,7 @@ class TestCLI(unittest.TestCase):
         proc = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()
         stdout = stdout.decode("utf-8")
+        print(stdout)
         print(stderr)
         return content in stdout
 
@@ -104,10 +94,15 @@ class TestCLI(unittest.TestCase):
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertFalse(succeeded, "The command should fail here since it is not registered yet.")
 
+        current_dir = Path(__file__).parent
+        register_dir = current_dir.parent.parent / "optimum" / "commands" / "register"
+        filename = "cli_with_custom_command.py"
+
         # Registering by providing the command.
-        register_optimum_cli_subcommand(MyCustomCommand)
+        shutil.copy(current_dir / filename, register_dir / filename)
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
+        shutil.rmtree(filename)
 
         
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -21,7 +21,17 @@ import unittest
 from pathlib import Path
 
 
+CLI_WIH_CUSTOM_COMMAND_PATH = Path(__file__).parent / "cli_with_custom_command.py"
+REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH = (
+    Path(__file__).parent.parent.parent / "optimum" / "commands" / "register" / "cli_with_custom_command.py"
+)
+
+
 class TestCLI(unittest.TestCase):
+    def tearDown(self):
+        super().tearDown()
+        REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH.unlink(missing_ok=True)
+
     def test_helps_no_raise(self):
         commands = [
             "optimum-cli --help",
@@ -95,18 +105,14 @@ class TestCLI(unittest.TestCase):
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertFalse(succeeded, "The command should fail here since it is not registered yet.")
 
-        current_dir = Path(__file__).parent
-        register_dir = current_dir.parent.parent / "optimum" / "commands" / "register"
-        filename = "cli_with_custom_command.py"
-
-        shutil.copy(current_dir / filename, register_dir / filename)
+        shutil.copy(CLI_WIH_CUSTOM_COMMAND_PATH, REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH)
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
-        (register_dir / filename).unlink()
+        REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH.unlink()
 
-        shutil.copy(current_dir / filename, register_dir / filename)
+        shutil.copy(CLI_WIH_CUSTOM_COMMAND_PATH, REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH)
         os.environ["TEST_REGISTER_COMMAND_WITH_SUBCOMMAND"] = "true"
         custom_command = "optimum-cli export blablabla"
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
-        (register_dir / filename).unlink()
+        REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH.unlink()


### PR DESCRIPTION
# What does this PR do?

This PR both refactors how the Optimum CLI was implemented and provides a way to register commands to the Optimum CLI for subpackages.

## Copy-pasting `optimum/commands/register/README.md` to explain how it works:

It is possible to register a command in the Optimum CLI, either as a command or a subcommand of an already existing command.

Steps to follow:

1. Create a command as a subclass of `optimum.commands.BaseOptimumCLICommand`.
2. Create a Python file under `optimum/commands/register/`, and define a `REGISTER_COMMANDS` list variable there.
3. Fill the `REGISTER_COMMANDS` as folows:

```python
# CustomCommand1 and CustomCommand2 could also be defined in this file actually.
from ..my_custom_commands import CustomCommand1, CustomCommand2
from ..export import ExportCommand
REGISTER_COMMANDS = [
  # CustomCommand1 will be registered as a subcommand of the root Optimum CLI. 
  CustomCommand1, 
  # CustomCommand2 will be registered as a subcommand of the `optimum-cli export` command. 
  (CustomCommand2, ExportCommand) # CustomCommand2 will be registered
]