### PR TITLE
Hash tensor data during deduplication

### DIFF
--- a/optimum/onnx/transformations_utils.py
+++ b/optimum/onnx/transformations_utils.py
@@ -12,9 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import hashlib
 from collections import defaultdict
 from typing import DefaultDict, Dict, List, Set, Tuple
-import hashlib
 
 import numpy as np
 
@@ -41,15 +41,12 @@ def _find_duplicate_initializers(
         for initializer in models[i].graph.initializer:
             tensor_dims = tuple(getattr(initializer, "dims"))
             if len(tensor_dims) > 1 or (len(tensor_dims) == 1 and initializer.data_type not in [6, 7]):
-                for data_attr in ["raw_data", "int32_data", "int64_data", "uint64_data", "float_data", "double_data"]:
-                    tensor_data = getattr(initializer, data_attr)
-                    if tensor_data:
-                        tensor_data = tuple(tensor_data)
-                        break
+                # Extract tensor data as numpy array
+                tensor_data = numpy_helper.to_array(initializer)
 
                 # Hash tensor data to avoid storing large amounts of data in memory
                 hashed = hashlib.sha512()
-                hashed.update(str(tensor_data).encode("utf-8"))
+                hashed.update(tensor_data)
                 tensor_digest = hashed.hexdigest()
 
                 duplicates[(initializer.data_type, tensor_digest, tensor_dims)].add((initializer.name, i))


### PR DESCRIPTION
# What does this PR do?

When exporting a causal lm model to onnx, the past key version and regular version are merged.  The merge loops through each tensor in the graph and stores the values as dict keys.  This requires massive memory (>100GB for an 11GB model), and prevents merging from happening.

This is due to the `tensor_data` in `_find_duplicate_initializers` being converted from `bytes` to a `tuple`.  I assume there is a good reason to convert it to a tuple (maybe for comparison across dtypes).

As such, this PR doesn't remove that conversion, but instead converts the tuple to a string and hashes it.  It uses SHA-512 to reduce the probability of a hash collision.  This uses very little memory to do the deduplication.

You could also:
-  just convert to `str` to remove the possibility of collisions - this will take more memory than hashing
- remove the initial `tuple` conversion entirely - also more memory than hashing
- Trade off memory for compute - loop through each pair of tensors to compare them - much slower than hashing

I have done some basic manual testing, and this method seems to work.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

