### PR TITLE
Ensure backward compatibility of ORTModel

### DIFF
--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -588,7 +588,7 @@ class ORTDecoderForSeq2Seq(ORTDecoder):
                     out_past_key_values[i : i + self.num_pkv] for i in range(0, len(out_past_key_values), self.num_pkv)
                 )
             else:
-                # grab the cross attention key/values from the inputs
+                # Grab the cross attention key/values from the inputs
                 out_past_key_values = tuple(
                     out_past_key_values[i : i + self.num_pkv] + past_key_values[2 * i + 2 : 2 * i + 2 + self.num_pkv]
                     for i in range(0, len(out_past_key_values), self.num_pkv)

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -22,7 +22,11 @@ from transformers.modeling_outputs import BaseModelOutput, CausalLMOutputWithCro
 from onnxruntime import InferenceSession
 
 from ..utils import NormalizedConfigManager
-from .utils import get_ordered_input_names
+from ..utils.logging import warn_once
+from .utils import get_ordered_input_names, logging
+
+
+logger = logging.get_logger(__name__)
 
 
 if TYPE_CHECKING:
@@ -402,6 +406,10 @@ class ORTDecoderForSeq2Seq(ORTDecoder):
         else:
             self.num_pkv = 4
 
+        self.legacy_outputs = any(
+            "encoder" in output_name and "present" in output_name for output_name in self.output_names
+        )
+
     def compute_past_key_values_output_shapes(
         self, input_ids, encoder_hidden_states, past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     ) -> Dict[str, int]:
@@ -569,10 +577,21 @@ class ORTDecoderForSeq2Seq(ORTDecoder):
                 out_past_key_values[i : i + self.num_pkv] for i in range(0, len(out_past_key_values), self.num_pkv)
             )
         else:
-            # grab the cross attention key/values from the inputs
-            out_past_key_values = tuple(
-                out_past_key_values[i : i + self.num_pkv] + past_key_values[2 * i + 2 : 2 * i + 2 + self.num_pkv]
-                for i in range(0, len(out_past_key_values), self.num_pkv)
-            )
+            if self.legacy_outputs is True:
+                msg = (
+                    "For the decoder with past, using ONNX models outputting cross attention past key values"
+                    " is deprecated and the support will be removed in optimum 2.0. We recommend exporting again the model"
+                    " with optimum>=1.7.3."
+                )
+                warn_once(logger, msg=msg)
+                out_past_key_values = tuple(
+                    out_past_key_values[i : i + self.num_pkv] for i in range(0, len(out_past_key_values), self.num_pkv)
+                )
+            else:
+                # grab the cross attention key/values from the inputs
+                out_past_key_values = tuple(
+                    out_past_key_values[i : i + self.num_pkv] + past_key_values[2 * i + 2 : 2 * i + 2 + self.num_pkv]
+                    for i in range(0, len(out_past_key_values), self.num_pkv)
+                )
 
         return Seq2SeqLMOutput(loss=loss, logits=logits, past_key_values=out_past_key_values)

--- a/optimum/utils/logging.py
+++ b/optimum/utils/logging.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 import threading
+from functools import lru_cache
 from logging import (
     CRITICAL,  # NOQA
     DEBUG,  # NOQA
@@ -29,7 +30,11 @@ from logging import (
     WARN,  # NOQA
     WARNING,  # NOQA
 )
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+
+if TYPE_CHECKING:
+    from logging import Logger
 
 
 _lock = threading.Lock()
@@ -262,3 +267,8 @@ def reset_format() -> None:
 
     for handler in handlers:
         handler.setFormatter(None)
+
+
+@lru_cache(None)
+def warn_once(logger: "Logger", msg: str):
+    logger.warning(msg)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1983,6 +1983,15 @@ class ORTModelForCausalLMIntegrationTest(ORTModelTestMixin):
     GENERATION_LENGTH = 100
     SPEEDUP_CACHE = 1.1
 
+    def test_inference_old_onnx_model(self):
+        model = ORTModelForCausalLM.from_pretrained("optimum/gpt2")
+
+        tokenizer = get_preprocessor("optimum/gpt2")
+        text = "This is a sample output"
+        tokens = tokenizer(text, return_tensors="pt")
+
+        model.generate(**tokens)
+
     def test_load_model_from_hub_onnx(self):
         model = ORTModelForCausalLM.from_pretrained("fxmarty/onnx-tiny-random-gpt2-without-merge")
 
@@ -3063,6 +3072,15 @@ class ORTModelForSeq2SeqLMIntegrationTest(ORTModelTestMixin):
 
     GENERATION_LENGTH = 100
     SPEEDUP_CACHE = 1.1
+
+    def test_inference_old_onnx_model(self):
+        model = ORTModelForSeq2SeqLM.from_pretrained("optimum/t5-small")
+
+        tokenizer = get_preprocessor("optimum/t5-small")
+        text = "This is a sample output"
+        tokens = tokenizer(text, return_tensors="pt")
+
+        model.generate(**tokens)
 
     def test_load_vanilla_transformers_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
Following https://github.com/huggingface/optimum/pull/872, we make sure we have no breaking change for the existing exported models.

Thank you @echarlaix for pointing it out!