### PR TITLE
Remove from_transformers references from the documentation

### DIFF
--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -176,7 +176,7 @@ As you can see, converting a model to ONNX does not mean leaving the Hugging Fac
 It is also possible to export the model to ONNX directly from the `ORTModelForQuestionAnswering` class by doing the following:
 
 ```python
->>> model = ORTModelForQuestionAnswering.from_pretrained("distilbert-base-uncased-distilled-squad", from_transformers=True)
+>>> model = ORTModelForQuestionAnswering.from_pretrained("distilbert-base-uncased-distilled-squad", export=True)
 ```
 
 For more information, check the `optimum.onnxruntime` documentation [page on this topic](/onnxruntime/overview).

--- a/docs/source/onnxruntime/quickstart.mdx
+++ b/docs/source/onnxruntime/quickstart.mdx
@@ -23,7 +23,7 @@ Before applying quantization or optimization, we first need to export our model 
 >>> model_checkpoint = "distilbert-base-uncased-finetuned-sst-2-english"
 >>> save_directory = "tmp/onnx/"
 >>> # Load a model from transformers and export it to ONNX
->>> ort_model = ORTModelForSequenceClassification.from_pretrained(model_checkpoint, from_transformers=True)
+>>> ort_model = ORTModelForSequenceClassification.from_pretrained(model_checkpoint, export=True)
 >>> tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
 >>> # Save the onnx model and tokenizer
 >>> ort_model.save_pretrained(save_directory)

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -35,7 +35,7 @@ Before going further, run the following sample code to check whether the install
 
 >>> ort_model = ORTModelForSequenceClassification.from_pretrained(
 ...   "philschmid/tiny-bert-sst2-distilled",
-...   from_transformers=True,
+...   export=True,
 ...   provider="CUDAExecutionProvider",
 ... )
 
@@ -63,7 +63,7 @@ For non-quantized models, the use is straightforward. Simply specify the `provid
 
 >>> ort_model = ORTModelForSequenceClassification.from_pretrained(
 ...   "distilbert-base-uncased-finetuned-sst-2-english",
-...   from_transformers=True,
+...   export=True,
 ...   provider="CUDAExecutionProvider",
 ... )
 ```
@@ -93,7 +93,7 @@ Additionally, you can pass the session option `log_severity_level = 0` (verbose)
 
 >>> ort_model = ORTModelForSequenceClassification.from_pretrained(
 ...     "distilbert-base-uncased-finetuned-sst-2-english",
-...     from_transformers=True,
+...     export=True,
 ...     provider="CUDAExecutionProvider",
 ...     session_options=session_options
 ... )
@@ -134,7 +134,7 @@ And if you want to turn off IOBinding:
 >>> from optimum.onnxruntime import ORTModelForSeq2SeqLM
 
 # Load the model from the hub and export it to the ONNX format
->>> model = ORTModelForSeq2SeqLM.from_pretrained("t5-small", from_transformers=True, use_io_binding=False)
+>>> model = ORTModelForSeq2SeqLM.from_pretrained("t5-small", export=True, use_io_binding=False)
 >>> tokenizer = AutoTokenizer.from_pretrained("t5-small")
 
 # Create a pipeline
@@ -247,7 +247,7 @@ Before going further, run the following sample code to check whether the install
 
 >>> ort_model = ORTModelForSequenceClassification.from_pretrained(
 ...     "philschmid/tiny-bert-sst2-distilled",
-...     from_transformers=True,
+...     export=True,
 ...     provider="TensorrtExecutionProvider",
 ... )
 
@@ -379,7 +379,7 @@ For non-quantized models, the use is straightforward, by simply using the `provi
 
 >>> ort_model = ORTModelForSequenceClassification.from_pretrained(
 ...     "distilbert-base-uncased-finetuned-sst-2-english",
-...     from_transformers=True,
+...     export=True,
 ...     provider="TensorrtExecutionProvider",
 ... )
 ```

--- a/docs/source/onnxruntime/usage_guides/models.mdx
+++ b/docs/source/onnxruntime/usage_guides/models.mdx
@@ -30,7 +30,7 @@ pred = onnx_qa(question, context)
 ### Loading a vanilla Transformers model
 
 Because the model you want to work with might not be already converted to ONNX,  [`~optimum.onnxruntime.ORTModel`]
-includes a method to convert vanilla Transformers models to ONNX ones. Simply pass `from_transformers=True` to the
+includes a method to convert vanilla Transformers models to ONNX ones. Simply pass `export=True` to the
 [`~optimum.onnxruntime.ORTModel.from_pretrained`] method, and your model will be loaded and converted to ONNX on-the-fly:
 
 ```python
@@ -38,7 +38,7 @@ includes a method to convert vanilla Transformers models to ONNX ones. Simply pa
 
 >>> # Load the model from the hub and export it to the ONNX format
 >>> model = ORTModelForSequenceClassification.from_pretrained(
-...     "distilbert-base-uncased-finetuned-sst-2-english", from_transformers=True
+...     "distilbert-base-uncased-finetuned-sst-2-english", export=True
 ... )
 ```
 
@@ -52,7 +52,7 @@ It is also possible, just as with regular [`~transformers.PreTrainedModel`]s, to
 
 >>> # Load the model from the hub and export it to the ONNX format
 >>> model = ORTModelForSequenceClassification.from_pretrained(
-...     "distilbert-base-uncased-finetuned-sst-2-english", from_transformers=True
+...     "distilbert-base-uncased-finetuned-sst-2-english", export=True
 ... )
 
 >>> # Save the converted model
@@ -82,7 +82,7 @@ Here is an example of how you can load a T5 model to the ONNX format and run inf
 
 # Load the model from the hub and export it to the ONNX format
 >>> model_name = "t5-small"
->>> model = ORTModelForSeq2SeqLM.from_pretrained(model_name, from_transformers=True)
+>>> model = ORTModelForSeq2SeqLM.from_pretrained(model_name, export=True)
 >>> tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 # Create a pipeline

--- a/docs/source/onnxruntime/usage_guides/optimization.mdx
+++ b/docs/source/onnxruntime/usage_guides/optimization.mdx
@@ -113,7 +113,7 @@ Below you will find an easy end-to-end example on how to optimize [distilbert-ba
 >>> save_dir = "distilbert_optimized"
 
 >>> # Load a PyTorch model and export it to the ONNX format
->>> model = ORTModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
+>>> model = ORTModelForSequenceClassification.from_pretrained(model_id, export=True)
 
 >>> # Create the optimizer
 >>> optimizer = ORTOptimizer.from_pretrained(model)
@@ -136,7 +136,7 @@ Below you will find an easy end-to-end example on how to optimize a Seq2Seq mode
 >>> save_dir = "distilbart_optimized"
 
 >>> # Load a PyTorch model and export it to the ONNX format
->>> model = ORTModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True)
+>>> model = ORTModelForSeq2SeqLM.from_pretrained(model_id, export=True)
 
 >>> # Create the optimizer
 >>> optimizer = ORTOptimizer.from_pretrained(model)

--- a/docs/source/onnxruntime/usage_guides/pipelines.mdx
+++ b/docs/source/onnxruntime/usage_guides/pipelines.mdx
@@ -76,7 +76,7 @@ Once you have picked an appropriate model, you can create the [`~pipelines.pipel
 >>> pred = onnx_qa(question=question, context=context)
 ```
 
-It is also possible to load it with the `from_pretrained(model_name_or_path, from_transformers=True)`
+It is also possible to load it with the `from_pretrained(model_name_or_path, export=True)`
 method associated with the `ORTModelForXXX` class.
 
 For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnswering`] class for question answering:
@@ -89,10 +89,10 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 >>> tokenizer = AutoTokenizer.from_pretrained("deepset/roberta-base-squad2")
 
 >>> # Loading the PyTorch checkpoint and converting to the ONNX format by providing
->>> # from_transformers=True
+>>> # export=True
 >>> model = ORTModelForQuestionAnswering.from_pretrained(
 ...     "deepset/roberta-base-squad2",
-...     from_transformers=True
+...     export=True
 ... )
 
 >>> onnx_qa = pipeline("question-answering", model=model, tokenizer=tokenizer, accelerator="ort")
@@ -162,7 +162,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 >>> save_dir = "distilbert_quantized"
 
->>> model = ORTModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
+>>> model = ORTModelForSequenceClassification.from_pretrained(model_id, export=True)
 
 >>> # Load the quantization configuration detailing the quantization we wish to apply
 >>> qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=True)
@@ -203,7 +203,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 >>> save_dir = "distilbert_optimized"
 
 >>> tokenizer = AutoTokenizer.from_pretrained(model_id)
->>> model = ORTModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
+>>> model = ORTModelForSequenceClassification.from_pretrained(model_id, export=True)
 
 >>> # Load the optimization configuration detailing the optimization we wish to apply
 >>> optimization_config = AutoOptimizationConfig.O3()

--- a/docs/source/onnxruntime/usage_guides/quantization.mdx
+++ b/docs/source/onnxruntime/usage_guides/quantization.mdx
@@ -105,7 +105,7 @@ find an easy end-to-end example on how to quantize dynamically
 >>> from optimum.onnxruntime.configuration import AutoQuantizationConfig
 
 # Load PyTorch model and convert to ONNX
->>> onnx_model = ORTModelForSequenceClassification.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english", from_transformers=True)
+>>> onnx_model = ORTModelForSequenceClassification.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english", export=True)
 
 # Create quantizer
 >>> quantizer = ORTQuantizer.from_pretrained(onnx_model)
@@ -135,7 +135,7 @@ an easy end-to-end example on how to quantize statically
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 
 # Load PyTorch model and convert to ONNX and create Quantizer and setup config
->>> onnx_model = ORTModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
+>>> onnx_model = ORTModelForSequenceClassification.from_pretrained(model_id, export=True)
 >>> tokenizer = AutoTokenizer.from_pretrained(model_id)
 >>> quantizer = ORTQuantizer.from_pretrained(onnx_model)
 >>> qconfig = AutoQuantizationConfig.arm64(is_static=True, per_channel=False)

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -20,7 +20,7 @@ This quick tour is intended for developers who are ready to dive into the code a
 
 To accelerate inference with ONNX Runtime, 🤗 Optimum uses _configuration objects_ to define parameters for graph optimization and quantization. These objects are then used to instantiate dedicated _optimizers_ and _quantizers_.
 
-Before applying quantization or optimization, first we need to load our model. To load a model and run inference with ONNX Runtime, you can just replace the canonical Transformers [`AutoModelForXxx`](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoModel) class with the corresponding [`ORTModelForXxx`](https://huggingface.co/docs/optimum/onnxruntime/package_reference/modeling_ort#optimum.onnxruntime.ORTModel) class. If you want to load from a PyTorch checkpoint, set `from_transformers=True` to export your model to the ONNX format.
+Before applying quantization or optimization, first we need to load our model. To load a model and run inference with ONNX Runtime, you can just replace the canonical Transformers [`AutoModelForXxx`](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoModel) class with the corresponding [`ORTModelForXxx`](https://huggingface.co/docs/optimum/onnxruntime/package_reference/modeling_ort#optimum.onnxruntime.ORTModel) class. If you want to load from a PyTorch checkpoint, set `export=True` to export your model to the ONNX format.
 
 ```python
 >>> from optimum.onnxruntime import ORTModelForSequenceClassification
@@ -31,7 +31,7 @@ Before applying quantization or optimization, first we need to load our model. T
 
 >>> # Load a model from transformers and export it to ONNX
 >>> tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
->>> ort_model = ORTModelForSequenceClassification.from_pretrained(model_checkpoint, from_transformers=True)
+>>> ort_model = ORTModelForSequenceClassification.from_pretrained(model_checkpoint, export=True)
 
 >>> # Save the ONNX model and tokenizer
 >>> ort_model.save_pretrained(save_directory)
@@ -70,7 +70,7 @@ You can find more examples in the [documentation](https://huggingface.co/docs/op
 #### Intel
 
 To load a model and run inference with OpenVINO Runtime, you can just replace your `AutoModelForXxx` class with the corresponding `OVModelForXxx` class.
-If you want to load a PyTorch checkpoint, set `from_transformers=True` to convert your model to the OpenVINO IR (Intermediate Representation).
+If you want to load a PyTorch checkpoint, set `export=True` to convert your model to the OpenVINO IR (Intermediate Representation).
 
 ```diff
 - from transformers import AutoModelForSequenceClassification
@@ -81,7 +81,7 @@ If you want to load a PyTorch checkpoint, set `from_transformers=True` to conver
   tokenizer = AutoTokenizer.from_pretrained(model_id)
   model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 - model = AutoModelForSequenceClassification.from_pretrained(model_id)
-+ model = OVModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
++ model = OVModelForSequenceClassification.from_pretrained(model_id, export=True)
 
   # Run inference!
   classifier = pipeline("text-classification", model=model, tokenizer=tokenizer)


### PR DESCRIPTION
cc @echarlaix , as we are deprecating this argument in favor of `export`.
