### PR TITLE
`optimum-cli` print the help of subcommands

### DIFF
--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -138,7 +138,7 @@ def register_optimum_cli_subcommand(
 
 
 def main():
-    root = RootOptimumCLICommand("Optimum CLI tool", usage="optimum-cli <command> [<args>]")
+    root = RootOptimumCLICommand("Optimum CLI tool", usage="optimum-cli")
     parser = root.parser
 
     for subcommand_cls in OPTIMUM_CLI_SUBCOMMANDS:

--- a/tests/cli/cli_with_custom_command.py
+++ b/tests/cli/cli_with_custom_command.py
@@ -19,7 +19,7 @@ from optimum.commands import BaseOptimumCLICommand, CommandInfo, ExportCommand
 
 
 class MyCustomCommand(BaseOptimumCLICommand):
-    COMMAND = CommandInfo(name="blablabla", help="Says something thing")
+    COMMAND = CommandInfo(name="blablabla", help="Says something.")
 
     def run(self):
         print("If the CI can read this, it means it worked!")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -102,19 +102,34 @@ class TestCLI(unittest.TestCase):
         return content in stdout
 
     def test_register_command(self):
+        # Nothing was registered, it should fail.
         custom_command = "optimum-cli blablabla"
         command_content = "If the CI can read this, it means it worked!"
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertFalse(succeeded, "The command should fail here since it is not registered yet.")
 
+        # As a "base" command in `optimum-cli`.
         shutil.copy(CLI_WIH_CUSTOM_COMMAND_PATH, REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH)
+
+        # We check that the print_help method prints the registered command.
+        succeeded = self._run_command_and_check_content("optimum-cli", "blablabla")
+        self.assertTrue(succeeded, "The command name should appear in the help.")
+
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
+
         REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH.unlink()
 
+        # As a subcommand of an existing command, `optimum-cli export` here.
         shutil.copy(CLI_WIH_CUSTOM_COMMAND_PATH, REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH)
         os.environ["TEST_REGISTER_COMMAND_WITH_SUBCOMMAND"] = "true"
+
+        # We check that the print_help method prints the registered command.
+        succeeded = self._run_command_and_check_content("optimum-cli export", "blablabla")
+        self.assertTrue(succeeded, "The command name should appear in the help.")
+
         custom_command = "optimum-cli export blablabla"
         succeeded = self._run_command_and_check_content(custom_command, command_content)
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
+
         REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH.unlink()


### PR DESCRIPTION
# What does this PR do?

The Optimum CLI was not printing the proper help message for subcommands.

## Example command:

```plain
optimum-cli export
```

### Before #928

Before adding the register mechanism to the CLI, the above command would give:

```plain
usage: optimum-cli <command> [<args>]

positional arguments:
  {export,env,onnxruntime}
                        optimum-cli command helpers
    export              Export PyTorch and TensorFlow models to several format (currently supported: onnx).
    env                 Get information about the environment used.
    onnxruntime         ONNX Runtime optimize and quantize utilities.

options:
  -h, --help            show this help message and exit
```

### After #928 

Now, after adding the register mechanism, it gives:

```plain
Traceback (most recent call last):
  File "/home/michael/micromamba/envs/optimum/bin/optimum-cli", line 8, in <module>
    sys.exit(main())
  File "/home/michael/projects/optimum/optimum/commands/optimum_cli.py", line 167, in main
    service.run()
  File "/home/michael/projects/optimum/optimum/commands/base.py", line 131, in run
    raise NotImplementedError()
NotImplementedError
```

### With this PR

With this PR, it gives:

```plain
usage: optimum-cli export [-h] {onnx,tflite} ...

positional arguments:
  {onnx,tflite}
    onnx         Export PyTorch and TensorFlow to ONNX.
    tflite       Export TensorFlow to TensorFlow Lite.

options:
  -h, --help     show this help message and exit
```

