### PR TITLE
Add check that dynamic ONNX axis do not use different length

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -25,7 +25,7 @@ from ...utils.save_utils import maybe_save_preprocessors
 from ..error_utils import AtolError, OutputMatchError, ShapeError
 from ..tasks import TasksManager
 from .base import OnnxConfigWithPast
-from .convert import export_models, validate_models_outputs
+from .convert import DynamicAxisNameError, export_models, validate_models_outputs
 from .utils import (
     get_decoder_models_for_export,
     get_encoder_decoder_models_for_export,
@@ -499,6 +499,8 @@ def main_export(
             )
             logger.info(f"The ONNX export succeeded and the exported model was saved at: {output.as_posix()}")
         except ShapeError as e:
+            raise e
+        except DynamicAxisNameError as e:
             raise e
         except AtolError as e:
             logger.warning(

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -622,6 +622,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         elif self.is_merged is True and self.use_cache_branch is False:
             reference_model_inputs["use_cache_branch"] = DummyInputGenerator.constant_tensor(shape=[1], value=False)
 
+            # Beware: in ORT implem, batch size is zero, hence we need to have it have a different axis name?
             # We don't support optional inputs for now, so even though the non-cache branch is used,
             # dummy past key values are necessary
             batch_size = reference_model_inputs["input_ids"].shape[0]

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -622,7 +622,6 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
         elif self.is_merged is True and self.use_cache_branch is False:
             reference_model_inputs["use_cache_branch"] = DummyInputGenerator.constant_tensor(shape=[1], value=False)
 
-            # Beware: in ORT implem, batch size is zero, hence we need to have it have a different axis name?
             # We don't support optional inputs for now, so even though the non-cache branch is used,
             # dummy past key values are necessary
             batch_size = reference_model_inputs["input_ids"].shape[0]

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -318,10 +318,8 @@ def validate_model_outputs(
     ort_inputs = {inp.name: inp for inp in session.get_inputs()}
     ort_outputs = {output.name: output for output in session.get_outputs()}
 
-    print("------")
     for input_name, input_value in onnx_inputs.items():
         for i, axis in enumerate(ort_inputs[input_name].shape):
-            print(input_name, axis, input_value.shape[i])
             if isinstance(axis, str):
                 if axis not in length_per_dynamic_axis:
                     length_per_dynamic_axis[axis] = {input_value.shape[i]}
@@ -330,14 +328,12 @@ def validate_model_outputs(
 
     for output_name, output_value in zip(onnx_named_outputs, onnx_outputs):
         for i, axis in enumerate(ort_outputs[output_name].shape):
-            print(output_name, axis, output_value.shape[i])
             if isinstance(axis, str):
                 if axis not in length_per_dynamic_axis:
                     length_per_dynamic_axis[axis] = {output_value.shape[i]}
                 else:
                     length_per_dynamic_axis[axis].add(output_value.shape[i])
 
-    print("length_per_dynamic_axis", length_per_dynamic_axis)
     wrong_axis = [axis_name for axis_name, axis_lengths in length_per_dynamic_axis.items() if len(axis_lengths) > 1]
     if len(wrong_axis) > 0:
         raise DynamicAxisNameError(


### PR DESCRIPTION
This is a huge issue, especially with IO Binding and TensoRT, where buffers may tentatively be reused, which fails in case we hinted same shapes although it is not the case.

Current issues:
* The `batch_size` may be zero with the fake pkv introduced in seq2seq models (should rather leave the real value, and out zero in the sequence length).
* The `encoder_sequence_length_out` is repeated in the input/output of seq2seq models, with different shapes (`1` and encoder length).

Fixes https://github.com/huggingface/optimum/issues/870