### PR TITLE
Add ControlNet ONNX export

### DIFF
--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -198,7 +198,8 @@ class ONNXExportCommand(BaseOptimumCLICommand):
         # Get the shapes to be used to generate dummy inputs
         input_shapes = {}
         for input_name in DEFAULT_DUMMY_SHAPES.keys():
-            input_shapes[input_name] = getattr(self.args, input_name)
+            if hasattr(self.args, input_name):
+                input_shapes[input_name] = getattr(self.args, input_name)
 
         main_export(
             model_name_or_path=self.args.model,

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -151,6 +151,7 @@ class OnnxConfig(ExportConfig, ABC):
             }
         ),
         "semantic-segmentation": OrderedDict({"logits": {0: "batch_size", 1: "num_labels", 2: "height", 3: "width"}}),
+        "stable-diffusion-control": OrderedDict(),
         "text2text-generation": OrderedDict({"logits": {0: "batch_size", 1: "decoder_sequence_length"}}),
         "text-classification": OrderedDict({"logits": {0: "batch_size"}}),
         "token-classification": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -48,6 +48,7 @@ from .input_generators import (
     DummySeq2SeqPastKeyValuesGenerator,
     DummyTextInputGenerator,
     DummyTimestepInputGenerator,
+    DummyUnetEncoderHiddenStatesInputGenerator,
     DummyVisionInputGenerator,
 )
 from .modeling_utils import recurse_getattr, recurse_setattr


### PR DESCRIPTION
Fixes https://github.com/huggingface/optimum/issues/961

I'm not so sure about this one, we may rather want to export ControlNet + UNet together. But the issue is that quite a few repos on the Hub have ControlNet alone, but then the unet inputs depend on whether controlnet is used or not, making the export of the unet tricky.