### PR TITLE
Fix some pipeline tags usage in TasksManager

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -145,6 +145,7 @@ class TasksManager:
         # In case the same task (pipeline tag) may map to several loading classes, we use a tuple and the
         # auto-class _model_mapping to determine the right one.
         _TASKS_TO_AUTOMODELS = {
+            "conversational": ("AutoModelForCausalLM", "AutoModelForSeq2SeqLM"),
             "feature-extraction": "AutoModel",
             "fill-mask": "AutoModelForMaskedLM",
             "text-generation": "AutoModelForCausalLM",
@@ -169,6 +170,7 @@ class TasksManager:
         }
     if is_tf_available():
         _TASKS_TO_TF_AUTOMODELS = {
+            "conversational": ("TFAutoModelForCausalLM", "TFAutoModelForSeq2SeqLM"),
             "feature-extraction": "TFAutoModel",
             "fill-mask": "TFAutoModelForMaskedLM",
             "text-generation": "TFAutoModelForCausalLM",
@@ -206,6 +208,7 @@ class TasksManager:
         "audio-ctc": "automatic-speech-recognition",
         "translation": "text2text-generation",
         "summarization": "text2text-generation",
+        "zero-shot-classification": "text-classification",
     }
 
     # Reverse dictionaries str -> str, where several automodels may map to the same task
@@ -218,6 +221,7 @@ class TasksManager:
     }
 
     _TASKS_TO_LIBRARY = {
+        "conversational": "transformers",
         "feature-extraction": "transformers",
         "fill-mask": "transformers",
         "text-generation": "transformers",
@@ -239,6 +243,7 @@ class TasksManager:
         "image-to-text": "transformers",
         "stable-diffusion": "diffusers",
         "summarization": "transformers",
+        "zero-shot-classification": "transformers",
         "zero-shot-image-classification": "transformers",
         "zero-shot-object-detection": "transformers",
     }
@@ -1034,16 +1039,16 @@ class TasksManager:
             else:
                 tasks_to_automodel = TasksManager._TASKS_TO_TF_AUTOMODELS
 
-            if task not in tasks_to_automodel:
-                raise KeyError(
-                    f"Unknown task: {task}. Possible values are: "
-                    + ", ".join([f"`{key}` for {tasks_to_automodel[key]}" for key in tasks_to_automodel])
-                )
-
             library = TasksManager._TASKS_TO_LIBRARY[task]
             loaded_library = importlib.import_module(library)
 
             if model_class_name is None:
+                if task not in tasks_to_automodel:
+                    raise KeyError(
+                        f"Unknown task: {task}. Possible values are: "
+                        + ", ".join([f"`{key}` for {tasks_to_automodel[key]}" for key in tasks_to_automodel])
+                    )
+
                 if isinstance(tasks_to_automodel[task], str):
                     model_class_name = tasks_to_automodel[task]
                 else:
@@ -1227,7 +1232,10 @@ class TasksManager:
                 if "stable-diffusion" in model_info.tags:
                     inferred_task_name = "stable-diffusion"
             else:
-                if getattr(model_info, "pipeline_tag", None) is not None:
+                pipeline_tag = getattr(model_info, "pipeline_tag", None)
+                # conversational is not a supported task per se, just an alias that may map to
+                # text-generaton or text2text-generation
+                if pipeline_tag is not None and pipeline_tag != "conversational":
                     inferred_task_name = model_info.pipeline_tag
                 else:
                     transformers_info = model_info.transformersInfo

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -204,6 +204,8 @@ class TasksManager:
         "default": "feature-extraction",
         "default-with-past": "feature-extraction-with-past",
         "audio-ctc": "automatic-speech-recognition",
+        "translation": "text2text-generation",
+        "summarization": "text2text-generation",
     }
 
     # Reverse dictionaries str -> str, where several automodels may map to the same task
@@ -222,6 +224,7 @@ class TasksManager:
         "text2text-generation": "transformers",
         "text-classification": "transformers",
         "token-classification": "transformers",
+        "translation": "transformers",
         "multiple-choice": "transformers",
         "object-detection": "transformers",
         "question-answering": "transformers",
@@ -235,6 +238,7 @@ class TasksManager:
         "audio-xvector": "transformers",
         "image-to-text": "transformers",
         "stable-diffusion": "diffusers",
+        "summarization": "transformers",
         "zero-shot-image-classification": "transformers",
         "zero-shot-object-detection": "transformers",
     }

--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -310,3 +310,21 @@ class OnnxCLIExportTestCase(unittest.TestCase):
         else:
             with TemporaryDirectory() as tmpdir:
                 main_export(model_name_or_path=model_name, output=tmpdir, task=task)
+
+    @slow
+    def test_complex_synonyms(self):
+        # conversational
+        with TemporaryDirectory() as tmpdir:
+            main_export(model_name_or_path="facebook/blenderbot-400M-distill", output=tmpdir)
+
+        # summarization
+        with TemporaryDirectory() as tmpdir:
+            main_export(model_name_or_path="facebook/bart-large-cnn", output=tmpdir)
+
+        # zero-shot-classification
+        with TemporaryDirectory() as tmpdir:
+            main_export(model_name_or_path="facebook/bart-large-mnli", output=tmpdir)
+
+        # translation
+        with TemporaryDirectory() as tmpdir:
+            main_export(model_name_or_path="t5-small", output=tmpdir)

--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -20,7 +20,7 @@ from typing import Dict, Optional
 
 import pytest
 from parameterized import parameterized
-from transformers import is_torch_available
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, is_torch_available
 from transformers.testing_utils import require_torch, require_torch_gpu, require_vision, slow
 
 from optimum.exporters.onnx.__main__ import main_export
@@ -332,3 +332,13 @@ class OnnxCLIExportTestCase(unittest.TestCase):
         # translation
         with TemporaryDirectory() as tmpdir:
             main_export(model_name_or_path="t5-small", output=tmpdir)
+
+        # from local
+        with TemporaryDirectory() as tmpdir_in, TemporaryDirectory() as tmpdir_out:
+            tokenizer = AutoTokenizer.from_pretrained("facebook/bart-large-mnli")
+            model = AutoModelForSequenceClassification.from_pretrained("facebook/bart-large-mnli")
+
+            tokenizer.save_pretrained(tmpdir_in)
+            model.save_pretrained(tmpdir_in)
+
+            main_export(model_name_or_path=tmpdir_in, output=tmpdir_out, task="text-classification")

--- a/tests/exporters/onnx/test_exporters_onnx_cli.py
+++ b/tests/exporters/onnx/test_exporters_onnx_cli.py
@@ -313,9 +313,13 @@ class OnnxCLIExportTestCase(unittest.TestCase):
 
     @slow
     def test_complex_synonyms(self):
-        # conversational
+        # conversational (text2text-generation)
         with TemporaryDirectory() as tmpdir:
             main_export(model_name_or_path="facebook/blenderbot-400M-distill", output=tmpdir)
+
+        # conversational (text-generation)
+        with TemporaryDirectory() as tmpdir:
+            main_export(model_name_or_path="microsoft/DialoGPT-small", output=tmpdir)
 
         # summarization
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fixes conversational, summarization, zero-shot-classification, translation.

I believe they are the only "exotic" pipeline tags.