### PR TITLE
add position_ids

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -539,7 +539,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
                     if (
                         self.use_past is True
                         and self.use_cache_branch is not False
-                        and input_name in ["decoder_input_ids", "input_ids"]
+                        and input_name in ["decoder_input_ids", "input_ids", "position_ids"]
                     ):
                         sequence_length = dummy_input_gen.sequence_length
                         if "sequence_length" in kwargs and kwargs["sequence_length"] != 1:

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -180,6 +180,21 @@ class GPT2OnnxConfig(TextDecoderOnnxConfig):
             return {**super_values_override, **pad_value_override}
         return pad_value_override
 
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self.use_past_in_inputs:
+            common_inputs = {"input_ids": {0: "batch_size"}}
+            self.add_past_key_values(common_inputs, direction="inputs")
+            common_inputs["attention_mask"] = {0: "batch_size", 1: "past_sequence_length + 1"}
+            common_inputs["position_ids"] = {0: "batch_size"}
+        else:
+            common_inputs = {
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+                "position_ids": {0: "batch_size", 1: "sequence_length"},
+            }
+        return common_inputs
+
 
 class GPTJOnnxConfig(GPT2OnnxConfig):
     pass
@@ -211,6 +226,21 @@ class OPTOnnxConfig(TextDecoderOnnxConfig):
 class LlamaOnnxConfig(TextDecoderOnnxConfig):
     DEFAULT_ONNX_OPSET = 13
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self.use_past_in_inputs:
+            common_inputs = {"input_ids": {0: "batch_size"}}
+            self.add_past_key_values(common_inputs, direction="inputs")
+            common_inputs["attention_mask"] = {0: "batch_size", 1: "past_sequence_length + 1"}
+            common_inputs["position_ids"] = {0: "batch_size"}
+        else:
+            common_inputs = {
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+                "position_ids": {0: "batch_size", 1: "sequence_length"},
+            }
+        return common_inputs
 
 
 class BloomDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -209,6 +209,7 @@ class GPTJOnnxConfig(GPT2OnnxConfig):
                 "attention_mask": {0: "batch_size", 1: "sequence_length"},
             }
         return common_inputs
+
     pass
 
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -197,6 +197,18 @@ class GPT2OnnxConfig(TextDecoderOnnxConfig):
 
 
 class GPTJOnnxConfig(GPT2OnnxConfig):
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self.use_past_in_inputs:
+            common_inputs = {"input_ids": {0: "batch_size"}}
+            self.add_past_key_values(common_inputs, direction="inputs")
+            common_inputs["attention_mask"] = {0: "batch_size", 1: "past_sequence_length + 1"}
+        else:
+            common_inputs = {
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+            }
+        return common_inputs
     pass
 
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -235,24 +235,8 @@ class OPTOnnxConfig(TextDecoderOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
 
 
-class LlamaOnnxConfig(TextDecoderOnnxConfig):
-    DEFAULT_ONNX_OPSET = 13
+class LlamaOnnxConfig(GPT2OnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
-
-    @property
-    def inputs(self) -> Dict[str, Dict[int, str]]:
-        if self.use_past_in_inputs:
-            common_inputs = {"input_ids": {0: "batch_size"}}
-            self.add_past_key_values(common_inputs, direction="inputs")
-            common_inputs["attention_mask"] = {0: "batch_size", 1: "past_sequence_length + 1"}
-            common_inputs["position_ids"] = {0: "batch_size"}
-        else:
-            common_inputs = {
-                "input_ids": {0: "batch_size", 1: "sequence_length"},
-                "attention_mask": {0: "batch_size", 1: "sequence_length"},
-                "position_ids": {0: "batch_size", 1: "sequence_length"},
-            }
-        return common_inputs
 
 
 class BloomDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -293,6 +293,7 @@ class ORTDecoder(ORTModelPart):
         input_ids: torch.LongTensor,
         attention_mask: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache_branch: None = None,
     ) -> CausalLMOutputWithCrossAttentions:
@@ -325,6 +326,9 @@ class ORTDecoder(ORTModelPart):
 
             if past_key_values is not None:
                 model_inputs += past_key_values
+
+            if "position_ids" in self.input_names:
+                model_inputs.append(position_ids)
 
             if use_cache_branch_tensor is not None:
                 model_inputs.append(use_cache_branch_tensor)
@@ -373,6 +377,9 @@ class ORTDecoder(ORTModelPart):
                     for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
                         onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
 
+                if "position_ids" in self.input_names:
+                    onnx_inputs["position_ids"] = position_ids.cpu().detach().numpy()
+
                 if "labels" in self.input_names:
                     onnx_inputs["labels"] = labels.cpu().detach().numpy()
             else:
@@ -388,6 +395,9 @@ class ORTDecoder(ORTModelPart):
                     # Add the past_key_values to the decoder inputs
                     for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
                         onnx_inputs[input_name] = past_key_value
+
+                if "position_ids" in self.input_names:
+                    onnx_inputs["position_ids"] = position_ids
 
                 if "labels" in self.input_names:
                     onnx_inputs["labels"] = labels

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -641,6 +641,7 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
         input_ids: torch.LongTensor = None,
         attention_mask: Optional[torch.FloatTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> CausalLMOutputWithCrossAttentions:
@@ -649,6 +650,7 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
+                position_ids=position_ids,
                 labels=labels,
             )
         elif self.use_merged is True:
@@ -656,12 +658,14 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
                 input_ids=input_ids[:, -1:],
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
+                position_ids=position_ids,
             )
         else:
             outputs = self.decoder_with_past(
                 input_ids=input_ids[:, -1:],
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
+                position_ids=position_ids,
                 labels=labels,
             )
 
@@ -675,12 +679,13 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
 
         attention_mask = kwargs.get("attention_mask", None)  # input_ids.new_ones(input_ids.shape)
         use_cache = kwargs.get("use_cache", None)
+        position_ids = kwargs.get("position_ids", None)
 
         return {
             "input_ids": input_ids,
             "past_key_values": past_key_values,
             "use_cache": use_cache,
-            "position_ids": None,
+            "position_ids": position_ids,
             "attention_mask": attention_mask,
         }
 

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -266,12 +266,7 @@ class DummyTextInputGenerator(DummyInputGenerator):
     Generates dummy encoder text inputs.
     """
 
-    SUPPORTED_INPUT_NAMES = (
-        "input_ids",
-        "attention_mask",
-        "token_type_ids",
-        "position_ids"
-    )
+    SUPPORTED_INPUT_NAMES = ("input_ids", "attention_mask", "token_type_ids", "position_ids")
 
     def __init__(
         self,

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -270,6 +270,7 @@ class DummyTextInputGenerator(DummyInputGenerator):
         "input_ids",
         "attention_mask",
         "token_type_ids",
+        "position_ids"
     )
 
     def __init__(

--- a/tests/exporters/onnx/test_onnx_config_loss.py
+++ b/tests/exporters/onnx/test_onnx_config_loss.py
@@ -155,6 +155,7 @@ class TestOnnxConfigWithLoss(unittest.TestCase):
             inputs = {
                 "input_ids": torch.ones((batch, seq_length), dtype=torch.long),
                 "attention_mask": torch.ones((batch, seq_length), dtype=torch.long),
+                "position_ids": torch.ones((batch, seq_length), dtype=torch.long),
                 "labels": torch.zeros(batch, dtype=torch.long),
             }
             input_names = [ort_input.name for ort_input in ort_sess._inputs_meta]


### PR DESCRIPTION
Some models like gpt2 and llama have "position_ids" in their generation inputs. We can add "position_ids" in the model's config to fix it.

@echarlaix @fxmarty Would you please help to review it? Thanks!