### PR TITLE
remove encoder_sequence_length in seq2seq config so users can pass it

### DIFF
--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -194,7 +194,6 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
         dummy_seq2seq_past_key_values_generator = self.DUMMY_INPUT_GENERATOR_CLASSES[2](
             self.task,
             self._normalized_config,
-            encoder_sequence_length=dummy_text_input_generator.sequence_length,
             **kwargs,
         )
         dummy_inputs_generators = [


### PR DESCRIPTION
Hi, @fxmarty @echarlaix . The param of `encoder_sequence_length` does not need to be specified here. First, the parameter will be set to `sequence_length` if it is None, see [DummySeq2SeqPastKeyValuesGenerator](https://github.com/huggingface/optimum/blob/main/optimum/utils/input_generators.py#L449). Second, users can specify the `encoder_sequence_length` by themselves if we remove this code. Would you please help to review it? Thanks!

