### PR TITLE
fix: ValueError offload_dir

### DIFF
--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 from copy import deepcopy
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import torch
 from packaging.version import parse
@@ -171,7 +172,11 @@ class BetterTransformer(object):
         "Please upgrade PyTorch following https://pytorch.org/get-started/locally/ in order to use BetterTransformer.",
     )
     def transform(
-        model: torch.nn.Module, keep_original_model: bool = False, max_memory: Optional[Dict] = None, **kwargs
+        model: torch.nn.Module,
+        keep_original_model: bool = False,
+        max_memory: Optional[Dict] = None,
+        offload_dir: Optional[Union[str, os.PathLike]] = None,
+        **kwargs,
     ) -> torch.nn.Module:
         r"""
         Conversion script from `transformers` model to its BetterTransformers version
@@ -265,12 +270,12 @@ class BetterTransformer(object):
             else:
                 bt_device_map = hf_device_map
 
-            model_fast = dispatch_model(model_fast, bt_device_map)
+            model_fast = dispatch_model(model_fast, bt_device_map, offload_dir=offload_dir)
 
             # It is not recommended to have `keep_original_model=True` with a model
             # that is loaded with accelerate but just in case
             if keep_original_model:
-                model = dispatch_model(model, hf_device_map)
+                model = dispatch_model(model, hf_device_map, offload_dir=offload_dir)
 
         # See: https://github.com/pytorch/pytorch/issues/96099
         if BetterTransformerManager.requires_torch_20(model_fast.config.model_type):

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -14,7 +14,6 @@
 import logging
 import os
 import types
-
 from copy import deepcopy
 from typing import TYPE_CHECKING, Dict, Optional, Union
 


### PR DESCRIPTION
Fixes the following error when model as weights offloaded to disk by providing an optional `offload_dir` argument that can be used with `BetterTransformer.transform`:

 `ValueError: We need an 'offload_dir' to dispatch this model according to this 'device_map', the following submodules need to be offloaded...`

Example:

`model = BetterTransformer.transform(model_hf, keep_original_model=True, offload_dir="OFFLOAD-DIR")`

Let me know if you have any suggestions!

P.S. I don't think any of the below options applies
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

