### PR TITLE
Add sam ONNX export

### DIFF
--- a/docs/source/exporters/onnx/overview.mdx
+++ b/docs/source/exporters/onnx/overview.mdx
@@ -71,6 +71,7 @@ Supported architectures:
 - ResNet
 - Roberta
 - Roformer
+- SAM
 - Segformer
 - SEW
 - SEW-D

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -198,7 +198,8 @@ class ONNXExportCommand(BaseOptimumCLICommand):
         # Get the shapes to be used to generate dummy inputs
         input_shapes = {}
         for input_name in DEFAULT_DUMMY_SHAPES.keys():
-            input_shapes[input_name] = getattr(self.args, input_name)
+            if hasattr(self.args, input_name):
+                input_shapes[input_name] = getattr(self.args, input_name)
 
         main_export(
             model_name_or_path=self.args.model,

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -124,8 +124,8 @@ class OnnxConfig(ExportConfig, ABC):
         "audio-frame-classification": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "automatic-speech-recognition": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "audio-xvector": OrderedDict({"logits": {0: "batch_size"}, "embeddings": {0: "batch_size"}}),
-        "text-generation": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "feature-extraction": OrderedDict({"last_hidden_state": {0: "batch_size", 1: "sequence_length"}}),
+        "fill-mask": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "image-classification": OrderedDict({"logits": {0: "batch_size"}}),
         # TODO: Is this the same thing as semantic-segmentation?
         "image-segmentation": OrderedDict(
@@ -135,8 +135,9 @@ class OnnxConfig(ExportConfig, ABC):
                 "pred_masks": {0: "batch_size", 1: "num_queries"},
             }
         ),
+        "image-to-text": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
+        "mask-generation": OrderedDict({"logits": {0: "batch_size"}}),
         "masked-im": OrderedDict({"logits": {0: "batch_size"}}),
-        "fill-mask": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "multiple-choice": OrderedDict({"logits": {0: "batch_size", 1: "num_choices"}}),
         "object-detection": OrderedDict(
             {
@@ -153,8 +154,8 @@ class OnnxConfig(ExportConfig, ABC):
         "semantic-segmentation": OrderedDict({"logits": {0: "batch_size", 1: "num_labels", 2: "height", 3: "width"}}),
         "text2text-generation": OrderedDict({"logits": {0: "batch_size", 1: "decoder_sequence_length"}}),
         "text-classification": OrderedDict({"logits": {0: "batch_size"}}),
+        "text-generation": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "token-classification": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
-        "image-to-text": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "zero-shot-image-classification": OrderedDict(
             {
                 "logits_per_image": {0: "image_batch_size", 1: "text_batch_size"},
@@ -273,6 +274,7 @@ class OnnxConfig(ExportConfig, ABC):
                     onnx_inputs.update(dict(value.items()))
                 else:
                     onnx_inputs[name] = value
+
             for name, value in onnx_inputs.items():
                 if value.dtype == np.float32 and dtype == "fp16":
                     onnx_inputs[name] = onnx_inputs[name].astype(np.float16)

--- a/optimum/utils/__init__.py
+++ b/optimum/utils/__init__.py
@@ -44,6 +44,7 @@ from .input_generators import (
     DummyInputGenerator,
     DummyLabelsGenerator,
     DummyPastKeyValuesGenerator,
+    DummyPointsGenerator,
     DummySeq2SeqDecoderTextInputGenerator,
     DummySeq2SeqPastKeyValuesGenerator,
     DummyTextInputGenerator,

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -54,6 +54,8 @@ DEFAULT_DUMMY_SHAPES = {
     "width": 64,
     "height": 64,
     "num_channels": 3,
+    "point_batch_size": 3,
+    "nb_points_per_image": 2,
     # audio
     "feature_size": 80,
     "nb_max_frames": 3000,
@@ -661,3 +663,30 @@ class DummyLabelsGenerator(DummyInputGenerator):
             shape = [self.batch_size, self.sequence_length]
 
         return self.random_int_tensor(shape, max_value=max_value, framework=framework)
+
+
+class DummyPointsGenerator(DummyInputGenerator):
+    """
+    Generates dummy time step inputs.
+    """
+
+    SUPPORTED_INPUT_NAMES = ("input_points",)
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        point_batch_size: int = DEFAULT_DUMMY_SHAPES["point_batch_size"],
+        nb_points_per_image: int = DEFAULT_DUMMY_SHAPES["nb_points_per_image"],
+        **kwargs,
+    ):
+        self.task = task
+
+        self.batch_size = batch_size
+        self.point_batch_size = point_batch_size
+        self.nb_points_per_image = nb_points_per_image
+
+    def generate(self, input_name: str, framework: str = "pt"):
+        shape = [self.batch_size, self.point_batch_size, self.nb_points_per_image, 2]
+        return self.random_int_tensor(shape, max_value=50, framework=framework)

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -15,9 +15,11 @@
 
 VALIDATE_EXPORT_ON_SHAPES_SLOW = {
     "batch_size": [1, 3, 5],
-    "sequence_length": [8, 19, 33, 64, 96, 154],
+    "sequence_length": [8, 33, 96, 154],
     "num_choices": [2, 4],
     "audio_sequence_length": [1000, 2000],
+    "point_batch_size": [1, 5],
+    "nb_points_per_image": [1, 3],
 }
 
 VALIDATE_EXPORT_ON_SHAPES_FAST = {
@@ -89,6 +91,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "resnet": "hf-internal-testing/tiny-random-resnet",
     "roberta": "hf-internal-testing/tiny-random-RobertaModel",
     "roformer": "hf-internal-testing/tiny-random-RoFormerModel",
+    "sam": "fxmarty/sam-vit-tiny-random",
     "segformer": "hf-internal-testing/tiny-random-SegformerModel",
     "splinter": "hf-internal-testing/tiny-random-SplinterModel",
     "squeezebert": "hf-internal-testing/tiny-random-SqueezeBertModel",


### PR DESCRIPTION
As per title. For now only support `input_points` as an input, will the rest really be useful @younesbelkada ?

We will need an other PR to be merged in transformers https://github.com/huggingface/transformers/pull/22915, and we will need to wait for transformers to release.

Yon can try with: `optimum-cli export onnx --model fxmarty/sam-vit-tiny-random sam_onnx`

Validation on various shapes pass: `RUN_SLOW=1 pytest tests/bettertransformer/test_encoder.py -k "test_accelerate_compatibility_cpu_gpu" -s -vvvvv`

Fixes https://github.com/huggingface/optimum/issues/990