### PR TITLE
Fix past key value generator used for ONNX export validation for t5/mt5

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -296,6 +296,7 @@ class T5OnnxConfig(TextSeq2SeqOnnxConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = TextSeq2SeqOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[:-1] + (
         T5DummySeq2SeqPastKeyValuesGenerator,
     )
+    DUMMY_PKV_GENERATOR_CLASS = T5DummySeq2SeqPastKeyValuesGenerator
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
         hidden_size="d_model",
         num_attention_heads="num_heads",


### PR DESCRIPTION
Fixes https://github.com/huggingface/optimum/issues/1004