### PR TITLE
remove torchvision requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ REQUIRED_PKGS = [
     "sympy",
     "transformers[sentencepiece]>=4.26.0",
     "torch>=1.9",
-    "torchvision",
     "packaging",
     "numpy",
     "huggingface_hub>=0.8.0",
@@ -31,6 +30,7 @@ TESTS_REQUIRE = [
     "pytest-xdist",
     "Pillow",
     "sacremoses",
+    "torchvision",
     "diffusers",
     "torchaudio",
 ]


### PR DESCRIPTION
# What does this PR do?

As discussed [here](https://github.com/huggingface/optimum/issues/1046#issuecomment-1545663717) the torchvision is not always needed. As such it can be removed from the requirements although it does need to be available for the tests, so it is now included in `TESTS_REQUIRE`.

Fixes https://github.com/huggingface/optimum/issues/1046#issuecomment-1545663717


