### PR TITLE
added ORTModelForSpeechSeq2Seq support to optimizer

### DIFF
--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -31,7 +31,7 @@ from ..utils.save_utils import maybe_save_preprocessors
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_decoder import ORTModelForCausalLM
 from .modeling_ort import ORTModel
-from .modeling_seq2seq import ORTModelForSeq2SeqLM
+from .modeling_seq2seq import ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq
 from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
 
 
@@ -89,7 +89,7 @@ class ORTOptimizer:
         config = None
         if isinstance(model_or_path, ORTModel):
             from_ortmodel = True
-            if isinstance(model_or_path, ORTModelForSeq2SeqLM):
+            if isinstance(model_or_path, (ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq)):
                 onnx_model_path += [
                     model_or_path.encoder_model_path,
                     model_or_path.decoder_model_path,

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -31,7 +31,7 @@ from ..utils.save_utils import maybe_save_preprocessors
 from .configuration import OptimizationConfig, ORTConfig
 from .modeling_decoder import ORTModelForCausalLM
 from .modeling_ort import ORTModel
-from .modeling_seq2seq import ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq
+from .modeling_seq2seq import ORTModelForConditionalGeneration
 from .utils import ONNX_WEIGHTS_NAME, ORTConfigManager
 
 
@@ -89,7 +89,7 @@ class ORTOptimizer:
         config = None
         if isinstance(model_or_path, ORTModel):
             from_ortmodel = True
-            if isinstance(model_or_path, (ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq)):
+            if isinstance(model_or_path, ORTModelForConditionalGeneration):
                 onnx_model_path += [
                     model_or_path.encoder_model_path,
                     model_or_path.decoder_model_path,

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -356,8 +356,10 @@ class ORTOptimizerForSpeechSeq2SeqIntegrationTest(ORTOptimizerTestMixin):
 
         if provider == "CUDAExecutionProvider":
             for_gpu = True
+            device = "cuda"
         else:
             for_gpu = False
+            device = "cpu"
 
         ort_model = ORTModelForSpeechSeq2Seq.from_pretrained(
             self.onnx_model_dirs[export_name], use_cache=use_cache, provider=provider, use_io_binding=use_io_binding
@@ -384,7 +386,7 @@ class ORTOptimizerForSpeechSeq2SeqIntegrationTest(ORTOptimizerTestMixin):
 
             data = self._generate_random_audio_data()
             processor = get_preprocessor(model_id)
-            features = processor.feature_extractor(data, return_tensors="pt")
+            features = processor.feature_extractor(data, return_tensors="pt").to(device)
 
             model_outputs = ort_model.generate(features["input_features"])
 

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -418,26 +418,24 @@ class ORTOptimizerForSpeechSeq2SeqIntegrationTest(ORTOptimizerTestMixin):
             {
                 "model_arch": SUPPORTED_ARCHITECTURES,
                 "use_cache": [True],
+                "use_io_binding": [False, True],
                 "optimization_level": ["O1", "O2", "O3", "O4"],
             }
         )
     )
     @require_torch_gpu
     @pytest.mark.gpu_test
-    def test_optimization_levels_gpu(self, test_name: str, model_arch: str, use_cache: bool, optimization_level: str):
-        for use_io_binding in [False, True]:
-            # TODO: investigate why marian with IO Binding fails
-            if model_arch == "marian" and use_io_binding is True:
-                continue
-
-            self._test_optimization_levels(
-                test_name=test_name,
-                model_arch=model_arch,
-                use_cache=use_cache,
-                optimization_level=optimization_level,
-                provider="CUDAExecutionProvider",
-                use_io_binding=use_io_binding,
-            )
+    def test_optimization_levels_gpu(
+        self, test_name: str, model_arch: str, use_cache: bool, use_io_binding: bool, optimization_level: str
+    ):
+        self._test_optimization_levels(
+            test_name=test_name,
+            model_arch=model_arch,
+            use_cache=use_cache,
+            optimization_level=optimization_level,
+            provider="CUDAExecutionProvider",
+            use_io_binding=use_io_binding,
+        )
 
 
 class ORTOptimizerForCausalLMIntegrationTest(ORTOptimizerTestMixin):

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -328,9 +328,7 @@ class ORTOptimizerForSpeechSeq2SeqIntegrationTest(ORTOptimizerTestMixin):
     TASK = "automatic-speech-recognition"
     ORTMODEL_CLASS = ORTModelForSpeechSeq2Seq
 
-    SUPPORTED_ARCHITECTURES = [
-        "whisper"
-    ]
+    SUPPORTED_ARCHITECTURES = ["whisper"]
 
     FULL_GRID = {
         "model_arch": SUPPORTED_ARCHITECTURES,

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -20,11 +20,13 @@ import unittest
 from pathlib import Path
 from typing import Dict, Optional
 
+import numpy as np
 import onnx
 import pytest
 import torch
 from parameterized import parameterized
 from transformers import AutoTokenizer
+from transformers.onnx.utils import get_preprocessor
 from transformers.testing_utils import require_torch_gpu
 from utils_onnxruntime_tests import MODEL_NAMES
 
@@ -32,7 +34,7 @@ from optimum.exporters import TasksManager
 from optimum.onnxruntime import AutoOptimizationConfig, ORTConfig, ORTModelForSequenceClassification, ORTOptimizer
 from optimum.onnxruntime.configuration import OptimizationConfig
 from optimum.onnxruntime.modeling_decoder import ORTModelForCausalLM
-from optimum.onnxruntime.modeling_seq2seq import ORTModelForSeq2SeqLM
+from optimum.onnxruntime.modeling_seq2seq import ORTModelForSeq2SeqLM, ORTModelForSpeechSeq2Seq
 from optimum.utils.testing_utils import grid_parameters
 
 
@@ -273,6 +275,122 @@ class ORTOptimizerForSeq2SeqLMIntegrationTest(ORTOptimizerTestMixin):
             tokens = tokenizer("This is a sample input", return_tensors="pt").to(device)
             model_outputs = ort_model.generate(**tokens)
             optimized_model_outputs = optimized_model.generate(**tokens)
+
+            self.assertTrue(torch.equal(model_outputs, optimized_model_outputs))
+            gc.collect()
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_arch": SUPPORTED_ARCHITECTURES,
+                "use_cache": [False, True],
+                "optimization_level": ["O1", "O2", "O3"],
+            }
+        )
+    )
+    def test_optimization_levels_cpu(self, test_name: str, model_arch: str, use_cache: bool, optimization_level: str):
+        self._test_optimization_levels(
+            test_name=test_name,
+            model_arch=model_arch,
+            use_cache=use_cache,
+            optimization_level=optimization_level,
+            provider="CPUExecutionProvider",
+        )
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_arch": SUPPORTED_ARCHITECTURES,
+                "use_cache": [True],
+                "optimization_level": ["O1", "O2", "O3", "O4"],
+            }
+        )
+    )
+    @require_torch_gpu
+    @pytest.mark.gpu_test
+    def test_optimization_levels_gpu(self, test_name: str, model_arch: str, use_cache: bool, optimization_level: str):
+        for use_io_binding in [False, True]:
+            # TODO: investigate why marian with IO Binding fails
+            if model_arch == "marian" and use_io_binding is True:
+                continue
+
+            self._test_optimization_levels(
+                test_name=test_name,
+                model_arch=model_arch,
+                use_cache=use_cache,
+                optimization_level=optimization_level,
+                provider="CUDAExecutionProvider",
+                use_io_binding=use_io_binding,
+            )
+
+
+class ORTOptimizerForSpeechSeq2SeqIntegrationTest(ORTOptimizerTestMixin):
+    TASK = "automatic-speech-recognition"
+    ORTMODEL_CLASS = ORTModelForSpeechSeq2Seq
+
+    SUPPORTED_ARCHITECTURES = [
+        "whisper"
+    ]
+
+    FULL_GRID = {
+        "model_arch": SUPPORTED_ARCHITECTURES,
+    }
+
+    def _generate_random_audio_data(self):
+        np.random.seed(10)
+        t = np.linspace(0, 5.0, int(5.0 * 22050), endpoint=False)
+        # generate pure sine wave at 220 Hz
+        audio_data = 0.5 * np.sin(2 * np.pi * 220 * t)
+        return audio_data
+
+    def _test_optimization_levels(
+        self,
+        test_name: str,
+        model_arch: str,
+        use_cache: bool,
+        optimization_level: str,
+        provider: str,
+        use_io_binding: Optional[bool] = None,
+    ):
+        export_name = test_name[:-3]  # remove `_OX` that is irrelevant as the export
+        model_args = {"test_name": export_name, "model_arch": model_arch, "use_cache": use_cache}
+        self._setup(model_args)
+
+        if provider == "CUDAExecutionProvider":
+            for_gpu = True
+        else:
+            for_gpu = False
+
+        ort_model = ORTModelForSpeechSeq2Seq.from_pretrained(
+            self.onnx_model_dirs[export_name], use_cache=use_cache, provider=provider, use_io_binding=use_io_binding
+        )
+
+        optimizer = ORTOptimizer.from_pretrained(ort_model)
+
+        optimization_config = AutoOptimizationConfig.with_optimization_level(optimization_level, for_gpu=for_gpu)
+        optimization_config.disable_shape_inference = True
+        model_id = MODEL_NAMES[model_arch]
+
+        with tempfile.TemporaryDirectory(suffix="_optimized") as tmp_dir:
+            optimizer.optimize(save_dir=tmp_dir, optimization_config=optimization_config)
+
+            optimized_model = ORTModelForSpeechSeq2Seq.from_pretrained(
+                tmp_dir, use_cache=use_cache, provider=provider, use_io_binding=use_io_binding
+            )
+
+            expected_ort_config = ORTConfig(optimization=optimization_config)
+            ort_config = ORTConfig.from_pretrained(tmp_dir)
+
+            # Verify the ORTConfig was correctly created and saved
+            self.assertEqual(ort_config.to_dict(), expected_ort_config.to_dict())
+
+            data = self._generate_random_audio_data()
+            processor = get_preprocessor(model_id)
+            features = processor.feature_extractor(data, return_tensors="pt")
+
+            model_outputs = ort_model.generate(features["input_features"])
+
+            optimized_model_outputs = optimized_model.generate(features["input_features"])
 
             self.assertTrue(torch.equal(model_outputs, optimized_model_outputs))
             gc.collect()


### PR DESCRIPTION
# What does this PR do?

ORT optimization support for `whisper` was added here #986 but `ORTOptimizer` didn't support `ORTModelForSpeechSeq2Seq`.

@regisss I can add tests if necessary.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

