### PR TITLE
Detect model type for all transformers models in TasksManager

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1379,13 +1379,13 @@ class TasksManager:
         model_type = None
         model_class_name = None
         if TasksManager._TASKS_TO_LIBRARY[task.replace("-with-past", "")] == "transformers":
+            config = AutoConfig.from_pretrained(model_name_or_path)
+            model_type = config.model_type.replace("_", "-")
             # TODO: if automatic-speech-recognition is passed as task, it may map to several
             # different auto class (AutoModelForSpeechSeq2Seq or AutoModelForCTC),
             # depending on the model type
             # if original_task in ["auto", "automatic-speech-recognition"]:
             if original_task == "automatic-speech-recognition" or task == "automatic-speech-recognition":
-                config = AutoConfig.from_pretrained(model_name_or_path)
-                model_type = config.model_type.replace("_", "-")
                 if original_task == "auto" and config.architectures is not None:
                     model_class_name = config.architectures[0]
 

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1378,8 +1378,10 @@ class TasksManager:
 
         model_type = None
         model_class_name = None
+        kwargs = {"subfolder": subfolder, "revision": revision, "cache_dir": cache_dir, **model_kwargs}
+
         if TasksManager._TASKS_TO_LIBRARY[task.replace("-with-past", "")] == "transformers":
-            config = AutoConfig.from_pretrained(model_name_or_path)
+            config = AutoConfig.from_pretrained(model_name_or_path, **kwargs)
             model_type = config.model_type.replace("_", "-")
             # TODO: if automatic-speech-recognition is passed as task, it may map to several
             # different auto class (AutoModelForSpeechSeq2Seq or AutoModelForCTC),
@@ -1393,7 +1395,6 @@ class TasksManager:
             task, framework, model_type=model_type, model_class_name=model_class_name
         )
 
-        kwargs = {"subfolder": subfolder, "revision": revision, "cache_dir": cache_dir, **model_kwargs}
         try:
             if framework == "pt":
                 kwargs["torch_dtype"] = torch_dtype

--- a/tests/exporters/common/test_tasks_manager.py
+++ b/tests/exporters/common/test_tasks_manager.py
@@ -18,7 +18,7 @@ from typing import Optional, Set
 from unittest import TestCase
 
 import pytest
-from transformers import BertConfig, VisualBertForQuestionAnswering
+from transformers import BertConfig, Pix2StructForConditionalGeneration, VisualBertForQuestionAnswering
 from transformers.testing_utils import slow
 
 from optimum.exporters import TasksManager
@@ -162,6 +162,9 @@ class TasksManagerTestCase(TestCase):
     def test_custom_class(self):
         task = TasksManager.infer_task_from_model("google/pix2struct-base")
         self.assertEqual(task, "image-to-text")
+
+        model = TasksManager.get_model_from_task("image-to-text", "google/pix2struct-base")
+        self.assertTrue(isinstance(model, Pix2StructForConditionalGeneration))
 
         model = TasksManager.get_model_from_task("question-answering", "uclanlp/visualbert-vqa")
         self.assertTrue(isinstance(model, VisualBertForQuestionAnswering))


### PR DESCRIPTION
This fixes likely a bug in https://github.com/huggingface/optimum/pull/967, where transformers model type would not be filled in general.

As some model types as visualbert and pix2struct need a special class to be loaded (not autoclass), we need the model type on top of the task to retrieve the right class to load from the [`_CUSTOM_CLASSES` dict](https://github.com/huggingface/optimum/blob/4c2389a9be027220475e7ca74ef43c1e86ca5ef8/optimum/exporters/tasks.py#L225-L228).

`RUN_SLOW=1 pytest tests/exporters/common/test_tasks_manager.py -k "test_custom_class" -s` was not passing, now it does.