### PR TITLE
Use mask for seq2seq ONNX decoder models 

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -287,6 +287,7 @@ class OnnxConfig(ExportConfig, ABC):
             for name, value in onnx_inputs.items():
                 if value.dtype == np.float32 and dtype == "fp16":
                     onnx_inputs[name] = onnx_inputs[name].astype(np.float16)
+
             outputs = session.run(None, onnx_inputs)
             del session
 
@@ -843,6 +844,9 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         if self._behavior is ConfigBehavior.DECODER:
             if "decoder_input_ids" in reference_model_inputs:
                 reference_model_inputs["input_ids"] = reference_model_inputs.pop("decoder_input_ids")
+
+            if "attention_mask" in reference_model_inputs:
+                reference_model_inputs["encoder_attention_mask"] = reference_model_inputs.pop("attention_mask")
 
             if "encoder_outputs" in reference_model_inputs:
                 if self.use_past_in_inputs is False or self.is_merged:

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -163,19 +163,13 @@ class TextSeq2SeqOnnxConfig(OnnxSeq2SeqConfigWithPast):
         common_inputs["attention_mask"] = {0: "batch_size", 1: "encoder_sequence_length"}
 
         if self._behavior is not ConfigBehavior.ENCODER:
-            # TODO: it is likely this pop() is unwanted as we then always hit
-            # https://github.com/huggingface/transformers/blob/v4.26.0/src/transformers/models/t5/modeling_t5.py#L965-L969
-            common_inputs.pop("attention_mask")
-
             if self.use_past_in_inputs:
                 # TODO: validate the axis name for attention_mask
                 # common_inputs["attention_mask"][1] = "past_encoder_sequence_length + sequence_length"
                 common_inputs["decoder_input_ids"] = {0: "batch_size"}
+                self.add_past_key_values(common_inputs, direction="inputs")
             else:
                 common_inputs["decoder_input_ids"] = {0: "batch_size", 1: "decoder_sequence_length"}
-
-            if self.use_past_in_inputs:
-                self.add_past_key_values(common_inputs, direction="inputs")
 
         if self._behavior is ConfigBehavior.DECODER:
             common_inputs["encoder_outputs"] = {0: "batch_size", 1: "encoder_sequence_length"}


### PR DESCRIPTION
As per title. I am not sure why the encoder attention mask for seq2seq models was not used up to now. The bug may have been introduced in https://github.com/huggingface/optimum/pull/698.

Fixes https://github.com/huggingface/optimum/issues/775