### PR TITLE
Use ORT symbolic shape inference instead of ONNX shape inference by default

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -323,7 +323,6 @@ def main_export(
 
         optimization_config = AutoOptimizationConfig.with_optimization_level(optimization_level=optimize)
 
-        optimization_config.disable_shape_inference = True
         optimizer.optimize(save_dir=output, optimization_config=optimization_config, file_suffix="")
 
     # Optionally post process the obtained ONNX file(s), for example to merge the decoder / decoder with past if any


### PR DESCRIPTION
Fixes https://github.com/huggingface/optimum/issues/901

Should make sure ORT optimizer GPU tests pass first.

Still many failing cases when using symbolic shape inference:

```
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_01_bart_True_O2 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmp7kg2x5gt_optimized/decoder_model_optimized.onn...
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_02_bart_True_O3 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmpdynitmty_optimized/decoder_model_optimized.onn...
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_03_bart_True_O4 - RuntimeError: Graph is not a DAG: len(sorted_node_set)=135, len(graph.node)=139, failed at node graph_output_cast6
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_13_m2m_100_True_O2 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmp5l6mz68l_optimized/decoder_model_optimized.onn...
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_14_m2m_100_True_O3 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmpneq0mqy8_optimized/decoder_model_optimized.onn...
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_15_m2m_100_True_O4 - RuntimeError: Graph is not a DAG: len(sorted_node_set)=146, len(graph.node)=150, failed at node graph_output_cast6
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_21_mbart_True_O2 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmpwl_ishyf_optimized/decoder_model_optimized.onn...
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_22_mbart_True_O3 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmphrns6zc8_optimized/decoder_model_optimized.onn...
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForSeq2SeqLMIntegrationTest::test_optimization_levels_gpu_23_mbart_True_O4 - RuntimeError: Graph is not a DAG: len(sorted_node_set)=185, len(graph.node)=187, failed at node graph_output_cast6
FAILED tests/onnxruntime/test_optimization.py::ORTOptimizerForCausalLMIntegrationTest::test_optimization_levels_gpu_47_gptj_False_True_O4 - onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/tmp8ukb8ius_optimized/decoder_model_optimized.onn...
```