### PR TITLE
Fix HF Push to hub

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -164,8 +164,7 @@ class OptimizedModel(ABC):
 
         api.create_repo(
             token=huggingface_token,
-            name=repository_id,
-            organization=user["name"],
+            repo_id=repository_id,
             exist_ok=True,
             private=private,
         )
@@ -177,7 +176,7 @@ class OptimizedModel(ABC):
                 try:
                     api.upload_file(
                         token=huggingface_token,
-                        repo_id=f"{user['name']}/{repository_id}",
+                        repo_id=f"{repository_id}",
                         path_or_fileobj=os.path.join(os.getcwd(), local_file_path),
                         path_in_repo=hub_file_path,
                     )


### PR DESCRIPTION
# What does this PR do?

Push to hub is failing due to recent API change in huggingface_hub:

```
E       TypeError: create_repo() got an unexpected keyword argument 'name'
```

cf. https://huggingface.co/docs/huggingface_hub/package_reference/hf_api#huggingface_hub.HfApi.create_repo.repo_id