### PR TITLE
Fix transformers version 

### DIFF
--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -45,7 +45,7 @@ if is_diffusers_available():
     TMP_DIFFUSERS_MAX_VERSION = "0.17.0"
     if check_if_diffusers_greater(TMP_DIFFUSERS_MAX_VERSION):
         logger.warning(
-            f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be < {TMP_DIFFUSERS_MAX_VERSION}."
+            f"We found an newer version of diffusers {_diffusers_version} but we require diffusers to be < {TMP_DIFFUSERS_MAX_VERSION}."
         )
 
     from diffusers.models.cross_attention import CrossAttnProcessor

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -42,8 +42,8 @@ if is_diffusers_available():
             f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be >= {DIFFUSERS_MINIMUM_VERSION}. "
             "Please update diffusers by running `pip install --upgrade diffusers`"
         )
-        TMP_DIFFUSERS_MAX_VERSION = "0.17.0"
-        if not check_if_diffusers_greater(TMP_DIFFUSERS_MAX_VERSION):
+    TMP_DIFFUSERS_MAX_VERSION = "0.17.0"
+    if check_if_diffusers_greater(TMP_DIFFUSERS_MAX_VERSION):
         logger.warning(
             f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be < {TMP_DIFFUSERS_MAX_VERSION}."
         )

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -26,10 +26,14 @@ from ...utils import (
     ORT_QUANTIZE_MINIMUM_VERSION,
     check_if_diffusers_greater,
     is_diffusers_available,
+    logging,
 )
 from ...utils.import_utils import _diffusers_version
 from ..tasks import TasksManager
 from .constants import ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, ONNX_ENCODER_NAME
+
+
+logger = logging.get_logger()
 
 
 if is_diffusers_available():
@@ -37,6 +41,11 @@ if is_diffusers_available():
         raise ImportError(
             f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be >= {DIFFUSERS_MINIMUM_VERSION}. "
             "Please update diffusers by running `pip install --upgrade diffusers`"
+        )
+        TMP_DIFFUSERS_MAX_VERSION = "0.17.0"
+        if not check_if_diffusers_greater(TMP_DIFFUSERS_MAX_VERSION):
+        logger.warning(
+            f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be < {TMP_DIFFUSERS_MAX_VERSION}."
         )
 
     from diffusers.models.cross_attention import CrossAttnProcessor

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.26.0",
+    "transformers[sentencepiece]>=4.26.0,<4.30.0",
     "torch>=1.9",
     "packaging",
     "numpy",
@@ -31,7 +31,7 @@ TESTS_REQUIRE = [
     "Pillow",
     "sacremoses",
     "torchvision",
-    "diffusers",
+    "diffusers<0.17.0",
     "torchaudio",
 ]
 


### PR DESCRIPTION
Limit `transformers` version to avoind incompatibility issues and add warning log for `diffusers>=0.17.0` (as some subpackage like openvino) 
