### PR TITLE
Adamlouly/fix unwrap model eval

### DIFF
--- a/docs/source/onnxruntime/package_reference/modeling_ort.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_ort.mdx
@@ -48,13 +48,13 @@ The following ORT classes are available for the following natural language proce
 
 [[autodoc]] onnxruntime.ORTModelForMultipleChoice
 
-## Computer vision
-
-The following ORT classes are available for the following computer vision tasks.
-
 ### ORTModelForQuestionAnswering
 
 [[autodoc]] onnxruntime.ORTModelForQuestionAnswering
+
+## Computer vision
+
+The following ORT classes are available for the following computer vision tasks.
 
 ### ORTModelForImageClassification
 

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -907,7 +907,8 @@ class ORTTrainer(Trainer):
         """
         # memory metrics - must set up as early as possible
         # TODO: We need to enable evaluation using ORT backend.
-        self.model = self.model._original_model
+        if self.args.use_module_with_loss:
+            self.model = self.model._original_model
         self._memory_tracker.start()
 
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
@@ -1000,7 +1001,8 @@ class ORTTrainer(Trainer):
               labels).
         """
         # TODO: We need to enable evaluation using ORT backend.
-        self.model = self.model._original_model
+        if self.args.use_module_with_loss:
+            self.model = self.model._original_model
 
         # memory metrics - must set up as early as possible
         self._memory_tracker.start()

--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -907,7 +907,7 @@ class ORTTrainer(Trainer):
         """
         # memory metrics - must set up as early as possible
         # TODO: We need to enable evaluation using ORT backend.
-        self.model = unwrap_model(self.model)
+        self.model = self.model._original_model
         self._memory_tracker.start()
 
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
@@ -1000,7 +1000,7 @@ class ORTTrainer(Trainer):
               labels).
         """
         # TODO: We need to enable evaluation using ORT backend.
-        self.model = unwrap_model(self.model)
+        self.model = self.model._original_model
 
         # memory metrics - must set up as early as possible
         self._memory_tracker.start()


### PR DESCRIPTION
# Fixing unwrap model when using ModuleWithLoss.

When using the --module_with_loss flag, if we run training and then evaluation right after it in t5-base, it will fail with this error:
```
AttributeError: 'ModuleWithLoss' object has no attribute 'main_input_name'
```
The error occurs because it tries to execute the following part:
```
packages/optimum/onnxruntime/trainer_seq2seq.py", line 675, in prediction_step
    generation_inputs = inputs[self.model.main_input_name]
 ```
The failure indicates that the model hasn't switched back from the ModuleWithLoss class to Module, which causes the failure.

The reason is that we used _unwrap_model, thinking it would convert ModuleWithLoss back to Module, but that's not the case. The unwrap_model function is intended to recursively unwrap a model from potential containers that might be used during distributed training.

Therefore, in this case, we need to use:
```
model = model._original_model
```
to fix this issue.
