### PR TITLE
Add mpt model_type to NormalizedTextConfig

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -129,7 +129,7 @@ T5LikeNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="num_heads",
     hidden_size="d_model",
 )
-MptLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
+MPTNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="n_heads", hidden_size="d_model", num_layers="n_layers"
 )
 

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -129,6 +129,10 @@ T5LikeNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="num_heads",
     hidden_size="d_model",
 )
+MptLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
+    num_attention_heads="n_heads", hidden_size="d_model", num_layers="n_layers"
+)
+
 WhisperLikeNormalizedTextConfig = NormalizedTextConfig.with_args(
     hidden_size="d_model",
 )
@@ -226,6 +230,7 @@ class NormalizedConfigManager:
         "vit": NormalizedVisionConfig,
         "xlm-roberta": NormalizedTextConfig,
         "yolos": NormalizedVisionConfig,
+        "mpt": MptLikeNormalizedTextConfig,
     }
 
     @classmethod

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -230,7 +230,7 @@ class NormalizedConfigManager:
         "vit": NormalizedVisionConfig,
         "xlm-roberta": NormalizedTextConfig,
         "yolos": NormalizedVisionConfig,
-        "mpt": MptLikeNormalizedTextConfig,
+        "mpt": MPTNormalizedTextConfig,
     }
 
     @classmethod


### PR DESCRIPTION
# What does this PR do?
 I want to use TSModelForCausalLM class loading mpt model, but the model_type "mpt" missed. so I create `MptLikeNormalizedTextConfig` to normalize the config.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

