### PR TITLE
Fix ONNX export of stable diffusion models

### DIFF
--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -42,7 +42,6 @@ if is_diffusers_available():
             f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be >= {DIFFUSERS_MINIMUM_VERSION}. "
             "Please update diffusers by running `pip install --upgrade diffusers`"
         )
-    from diffusers.models.cross_attention import CrossAttnProcessor
 
 if TYPE_CHECKING:
     from .base import OnnxConfig

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -28,7 +28,7 @@ from ...utils import (
     is_diffusers_available,
     logging,
 )
-from ...utils.import_utils import _diffusers_version
+from ...utils.import_utils import _diffusers_version, check_if_torch_greater
 from ..tasks import TasksManager
 from .constants import ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, ONNX_ENCODER_NAME
 
@@ -42,12 +42,6 @@ if is_diffusers_available():
             f"We found an older version of diffusers {_diffusers_version} but we require diffusers to be >= {DIFFUSERS_MINIMUM_VERSION}. "
             "Please update diffusers by running `pip install --upgrade diffusers`"
         )
-    TMP_DIFFUSERS_MAX_VERSION = "0.17.0"
-    if check_if_diffusers_greater(TMP_DIFFUSERS_MAX_VERSION):
-        logger.warning(
-            f"We found an newer version of diffusers {_diffusers_version} but we require diffusers to be < {TMP_DIFFUSERS_MAX_VERSION}."
-        )
-
     from diffusers.models.cross_attention import CrossAttnProcessor
 
 if TYPE_CHECKING:
@@ -175,6 +169,9 @@ def get_stable_diffusion_models_for_export(
         onnx configs for the different components of the model.
     """
     models_for_export = {}
+    # To be applied for torch v2.0.0 > x > v2.0.2
+    if check_if_torch_greater("2.0.0") and not check_if_torch_greater("2.0.2"):
+        register_custom_scaled_dot_product_attention_export()
 
     # Text encoder
     text_encoder_config_constructor = TasksManager.get_exporter_config_constructor(
@@ -190,13 +187,10 @@ def get_stable_diffusion_models_for_export(
     unet_onnx_config = onnx_config_constructor(pipeline.unet.config)
 
     # PyTorch does not support the ONNX export of torch.nn.functional.scaled_dot_product_attention
-    pipeline.unet.set_attn_processor(CrossAttnProcessor())
     models_for_export["unet"] = (pipeline.unet, unet_onnx_config)
 
     # VAE Encoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L565
     vae_encoder = copy.deepcopy(pipeline.vae)
-    if hasattr(vae_encoder.encoder.mid_block.attentions[0], "_use_2_0_attn"):
-        vae_encoder.encoder.mid_block.attentions[0]._use_2_0_attn = False
     vae_encoder.forward = lambda sample: {"latent_sample": vae_encoder.encode(x=sample)["latent_dist"].sample()}
     vae_config_constructor = TasksManager.get_exporter_config_constructor(
         model=vae_encoder, exporter="onnx", task="semantic-segmentation", model_type="vae-encoder"
@@ -252,3 +246,123 @@ def recursive_to_dtype(
             value = value.to(dtype=dtype)
 
     return value
+
+
+def register_custom_scaled_dot_product_attention_export():
+    @torch.onnx.symbolic_helper.parse_args("v", "v", "v", "v", "f", "b", "v")
+    def scaled_dot_product_attention(
+        g: torch.onnx._internal.jit_utils.GraphContext,
+        query: torch._C.Value,
+        key: torch._C.Value,
+        value: torch._C.Value,
+        attn_mask: Optional[torch._C.Value] = None,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+        scale: Optional[torch._C.Value] = None,
+    ):
+        assert (not is_causal) or (
+            is_causal and torch.onnx.symbolic_helper._is_none(attn_mask)
+        ), "is_causal and attn_mask cannot be set at the same time"
+
+        scale = torch.onnx.symbolic_helper._maybe_get_const(scale, "f")
+        if scale is None:
+            scale = _attention_scale(g, query)
+
+        if is_causal:
+            attn_mask = _causal_attention_mask(g, query, key)
+        key_shape_builtin = torch.onnx.symbolic_helper._get_tensor_rank(key)
+        key_transposed_axes = list(range(key_shape_builtin))
+        key_transposed_axes[-1], key_transposed_axes[-2] = (
+            key_transposed_axes[-2],
+            key_transposed_axes[-1],
+        )
+        key_transposed = g.op("Transpose", key, perm_i=key_transposed_axes)
+        query_scaled = g.op("Mul", query, g.op("Sqrt", scale))
+        key_transposed_scaled = g.op("Mul", key_transposed, g.op("Sqrt", scale))
+        mul_qk = g.op("MatMul", query_scaled, key_transposed_scaled)
+        if attn_mask is None or torch.onnx.symbolic_helper._is_none(attn_mask):
+            mul_qk_add = mul_qk
+        elif torch.onnx._type_utils.JitScalarType.from_value(attn_mask) == torch.onnx._type_utils.JitScalarType.BOOL:
+            # Turn the Boolean mask to float: attn_mask.masked_fill(not attn_mask, -float('inf'))
+            const_zero = g.op("Constant", value_t=torch.tensor([0.0]))
+            const_neg_inf = g.op("Constant", value_t=torch.tensor([-float("inf")]))
+            attn_mask = g.op("Where", attn_mask, const_zero, const_neg_inf)
+            mul_qk_add = g.op("Add", mul_qk, attn_mask)
+        elif torch.onnx._type_utils.JitScalarType.from_value(attn_mask) == torch.onnx._type_utils.JitScalarType.FLOAT:
+            mul_qk_add = g.op("Add", mul_qk, attn_mask)
+        else:
+            raise ValueError(
+                f"Unsupported type for attn_mask: {torch.onnx._type_utils.JitScalarType.from_value(attn_mask)}"
+            )
+
+        attn_weight = g.op("Softmax", mul_qk_add, axis_i=-1)
+
+        if dropout_p != 0:
+            attn_weight = g.op(
+                "Dropout",
+                attn_weight,
+                g.op("Constant", value_t=torch.tensor(dropout_p, dtype=torch.float)),
+            )
+
+        return g.op("MatMul", attn_weight, value)
+
+    def _attention_scale(g: torch.onnx._internal.jit_utils.GraphContext, query: torch._C.Value) -> torch._C.Value:
+        """Calculate the scale factor for the attention result.
+        Args:
+            query: Tensor of shape [..., L, E]
+        Returns:
+            Scalar scale factor := 1 / math.sqrt(query.size(-1))
+        """
+        query_shape = g.op("Shape", query)
+        query_shape_last = g.op(
+            "Slice",
+            query_shape,
+            g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)),
+            g.op("Constant", value_t=torch.tensor([torch.onnx._constants.INT64_MAX], dtype=torch.int64)),
+        )
+        embedding_size = g.op(
+            "Cast",
+            query_shape_last,
+            to_i=torch.onnx._type_utils.JitScalarType.from_value(query).onnx_type(),
+        )
+        const_one = g.op("Constant", value_t=torch.tensor([1.0], dtype=torch.float))
+        scale = g.op("Div", const_one, g.op("Sqrt", embedding_size))
+        return scale
+
+    def _causal_attention_mask(
+        g: torch.onnx._internal.jit_utils.GraphContext, query: torch._C.Value, key: torch._C.Value
+    ) -> torch._C.Value:
+        """Create a causal mask for the given query and key tensors.
+        Equivalent to::
+            mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+            attn_mask = torch.zeros(L, S, dtype=torch.float)
+            attn_mask = attn_mask.masked_fill(not mask, -float('inf'))
+        Args:
+            query: Tensor of shape [..., L, E]
+            key: Tensor of shape [..., S, E]
+        Returns:
+            Tensor of shape [L, S]
+        """
+
+        query_shape = g.op("Shape", query)
+        key_shape = g.op("Shape", key)
+
+        last_idx = g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
+        second_last_idx = g.op("Constant", value_t=torch.tensor([-2], dtype=torch.int64))
+        target_length = g.op("Slice", query_shape, second_last_idx, last_idx)
+        source_length = g.op("Slice", key_shape, second_last_idx, last_idx)
+        # attn_mask = torch.ones(L, S) := {
+        size = g.op("Concat", target_length, source_length, axis_i=0)
+        const_one = g.op("Constant", value_t=torch.tensor([1.0]))
+        attn_mask = g.op("Expand", const_one, size)
+        # }
+        attn_mask = g.op("Trilu", attn_mask, upper_i=0)
+        # The causal mask has 0s in the lower triangle and -inf in the upper triangle.
+        const_zero = g.op("Constant", value_t=torch.tensor([0.0]))
+        const_neg_inf = g.op("Constant", value_t=torch.tensor([-float("inf")]))
+        attn_mask = g.op("Where", g.op("Equal", attn_mask, const_zero), const_neg_inf, const_zero)
+        return attn_mask
+
+    torch.onnx.register_custom_op_symbolic(
+        "aten::scaled_dot_product_attention", scaled_dot_product_attention, opset_version=14
+    )

--- a/optimum/utils/import_utils.py
+++ b/optimum/utils/import_utils.py
@@ -117,6 +117,24 @@ def check_if_pytorch_greater(target_version: str, message: str):
         pass
 
 
+def check_if_torch_greater(target_version: Union[str, packaging.version.Version]) -> bool:
+    """
+    Checks whether the current install of torch is greater than or equal to the target version.
+
+    Args:
+        target_version (`Union[str, packaging.version.Version]`): version used as the reference for comparison.
+
+    Returns:
+        bool: whether the check is True or not.
+    """
+    import torch
+
+    if isinstance(target_version, str):
+        target_version = packaging.version.parse(target_version)
+
+    return packaging.version.parse(torch.__version__) >= target_version
+
+
 def check_if_transformers_greater(target_version: Union[str, packaging.version.Version]) -> bool:
     """
     Checks whether the current install of transformers is greater than or equal to the target version.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ TESTS_REQUIRE = [
     "Pillow",
     "sacremoses",
     "torchvision",
-    "diffusers<0.17.0",
+    "diffusers",
     "torchaudio",
 ]
 


### PR DESCRIPTION
Solution integrated by @eaidova in https://github.com/huggingface/optimum-intel/pull/342 to fix the ONNX export of stable diffusion models as the `aten::scaled_dot_product_attention` is not registered for export.  Beforehand the scaled dot-product attention was disabled by default even for torch > v2.0 before exporting the model. See https://github.com/huggingface/diffusers/pull/3273, disabled in https://github.com/huggingface/diffusers/pull/3387 