### PR TITLE
Lower GPU memory requirements at ONNX export

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -44,23 +44,6 @@ from typing import Optional, Union
 logger = logging.get_logger()
 logger.setLevel(logging.INFO)
 
-import subprocess
-
-import psutil
-
-
-def print_memory(prefix):
-    cpu_ram_mb = (psutil.virtual_memory().total - psutil.virtual_memory().available) / 1000**2
-
-    command = "nvidia-smi --query-gpu=memory.used --format=csv --id=0"
-    gpu_mem_info = subprocess.check_output(command.split()).decode("ascii").split("\n")[:-1][1:]
-
-    gpu_mem_mb = [int(x.split()[0]) for i, x in enumerate(gpu_mem_info)][0] * 1.048576
-
-    print("-----------------", prefix)
-    print(f"RAM: {cpu_ram_mb:.2f} MB")
-    print(f"GPU mem: {gpu_mem_mb:.2f} MB")
-
 
 def main_export(
     model_name_or_path: str,
@@ -323,7 +306,6 @@ def main_export(
         else:
             models_and_onnx_configs = {"model": (model, onnx_config)}
 
-    print_memory("After loading models_and_onnx_configs, before export")
     _, onnx_outputs = export_models(
         models_and_onnx_configs=models_and_onnx_configs,
         opset=opset,
@@ -333,8 +315,6 @@ def main_export(
         device=device,
         dtype="fp16" if fp16 is True else None,
     )
-
-    print_memory("After export, before post-process")
 
     if optimize == "O4" and device != "cuda":
         raise ValueError(
@@ -367,8 +347,6 @@ def main_export(
                 f"The post-processing of the ONNX export failed. The export can still be performed by passing the option --no-post-process. Detailed error: {e}"
             )
 
-    print_memory("After post-process")
-
     if do_validation is True:
         try:
             validate_models_outputs(
@@ -396,8 +374,6 @@ def main_export(
             raise Exception(
                 f"An error occured during validation, but the model was saved nonetheless at {output.as_posix()}. Detailed error: {e}."
             )
-
-    print_memory("After validation")
 
 
 def main():

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -27,6 +27,7 @@ from ...utils.save_utils import maybe_save_preprocessors
 from ..error_utils import AtolError, OutputMatchError, ShapeError
 from ..tasks import TasksManager
 from .base import OnnxConfigWithPast
+from .constants import UNPICKABLE_ARCHS
 from .convert import export_models, validate_models_outputs
 from .utils import (
     get_decoder_models_for_export,
@@ -353,22 +354,10 @@ def main_export(
         use_subprocess = (
             False  # TODO: fix Can't pickle local object 'get_stable_diffusion_models_for_export.<locals>.<lambda>'
         )
-    else:
+    elif model.config.model_type in UNPICKABLE_ARCHS:
         # Pickling is bugged for nn.utils.weight_norm: https://github.com/pytorch/pytorch/issues/102983
         # TODO: fix "Cowardly refusing to serialize non-leaf tensor" error for wav2vec2-conformer
-        if model.config.model_type in [
-            "encodec",
-            "hubert",
-            "sew",
-            "sew-d",
-            "speecht5",
-            "unispeech",
-            "unispeech-sat",
-            "wav2vec2",
-            "wav2vec2-conformer",
-            "wavlm",
-        ]:
-            use_subprocess = False
+        use_subprocess = False
 
     if do_validation is True:
         try:

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -44,6 +44,23 @@ from typing import Optional, Union
 logger = logging.get_logger()
 logger.setLevel(logging.INFO)
 
+import subprocess
+
+import psutil
+
+
+def print_memory(prefix):
+    cpu_ram_mb = (psutil.virtual_memory().total - psutil.virtual_memory().available) / 1000**2
+
+    command = "nvidia-smi --query-gpu=memory.used --format=csv --id=0"
+    gpu_mem_info = subprocess.check_output(command.split()).decode("ascii").split("\n")[:-1][1:]
+
+    gpu_mem_mb = [int(x.split()[0]) for i, x in enumerate(gpu_mem_info)][0] * 1.048576
+
+    print("-----------------", prefix)
+    print(f"RAM: {cpu_ram_mb:.2f} MB")
+    print(f"GPU mem: {gpu_mem_mb:.2f} MB")
+
 
 def main_export(
     model_name_or_path: str,
@@ -306,6 +323,7 @@ def main_export(
         else:
             models_and_onnx_configs = {"model": (model, onnx_config)}
 
+    print_memory("After loading models_and_onnx_configs, before export")
     _, onnx_outputs = export_models(
         models_and_onnx_configs=models_and_onnx_configs,
         opset=opset,
@@ -315,6 +333,8 @@ def main_export(
         device=device,
         dtype="fp16" if fp16 is True else None,
     )
+
+    print_memory("After export, before post-process")
 
     if optimize == "O4" and device != "cuda":
         raise ValueError(
@@ -347,6 +367,8 @@ def main_export(
                 f"The post-processing of the ONNX export failed. The export can still be performed by passing the option --no-post-process. Detailed error: {e}"
             )
 
+    print_memory("After post-process")
+
     if do_validation is True:
         try:
             validate_models_outputs(
@@ -374,6 +396,8 @@ def main_export(
             raise Exception(
                 f"An error occured during validation, but the model was saved nonetheless at {output.as_posix()}. Detailed error: {e}."
             )
+
+    print_memory("After validation")
 
 
 def main():

--- a/optimum/exporters/onnx/constants.py
+++ b/optimum/exporters/onnx/constants.py
@@ -20,3 +20,16 @@ ONNX_ENCODER_NAME = "encoder_model"
 ONNX_DECODER_NAME = "decoder_model"
 ONNX_DECODER_WITH_PAST_NAME = "decoder_with_past_model"
 ONNX_DECODER_MERGED_NAME = "decoder_model_merged"
+
+UNPICKABLE_ARCHS = [
+    "encodec",
+    "hubert",
+    "sew",
+    "sew-d",
+    "speecht5",
+    "unispeech",
+    "unispeech-sat",
+    "wav2vec2",
+    "wav2vec2-conformer",
+    "wavlm",
+]

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -167,6 +167,7 @@ def validate_models_outputs(
         raise exceptions[-1]
 
 
+# Copied from https://github.com/microsoft/onnxruntime/issues/7846#issuecomment-850217402
 class PickableInferenceSession:  # This is a wrapper to make the current InferenceSession class pickable.
     def __init__(self, model_path, sess_options, providers):
         import onnxruntime as ort

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -97,6 +97,7 @@ def validate_models_outputs(
     input_shapes: Optional[Dict] = None,
     device: str = "cpu",
     dtype: Optional["torch.dtype"] = None,
+    use_subprocess: Optional[bool] = True,
 ):
     """
     Validates the export of several models, by checking that the outputs from both the reference and the exported model match.
@@ -120,6 +121,8 @@ def validate_models_outputs(
             The device on which the ONNX models will be validated. Either `cpu` or `cuda`. Validation on a CUDA device is supported only for PyTorch.
         dtype (`Optional[torch.dtype]`, defaults to `None`):
             Data type of the inputs to perform validation on. Validation on float16 is supported only for PyTorch.
+        use_subprocess (`Optional[bool]`, defaults to `True`):
+            Launch validation of each exported model in a subprocess.
 
     Raises:
         ValueError: If the outputs shapes or values do not match between the reference and the exported model.
@@ -134,6 +137,8 @@ def validate_models_outputs(
             f"Provided custom names {onnx_files_subpaths} for the validation of {len(models_and_onnx_configs)} models. Please provide the same number of ONNX file names as models to export."
         )
 
+    if use_subprocess:
+        logger.info("Validating models in subprocesses...")
     exceptions = []  # run all validations before raising
     onnx_paths = []
     for i, model_name in enumerate(models_and_onnx_configs.keys()):
@@ -157,6 +162,7 @@ def validate_models_outputs(
                 input_shapes=input_shapes,
                 device=device,
                 dtype=dtype,
+                use_subprocess=use_subprocess,
             )
         except Exception as e:
             exceptions.append(e)
@@ -176,6 +182,7 @@ def validate_model_outputs(
     input_shapes: Optional[Dict] = None,
     device: str = "cpu",
     dtype: Optional["torch.dtype"] = None,
+    use_subprocess: Optional[bool] = True,
 ):
     """
     Validates the export by checking that the outputs from both the reference and the exported model match.
@@ -194,25 +201,219 @@ def validate_model_outputs(
             If specified, allows to use specific shapes to validate the ONNX model on.
         device (`str`, defaults to `"cpu"`):
             The device on which the ONNX model will be validated. Either `cpu` or `cuda`. Validation on a CUDA device is supported only for PyTorch.
+        use_subprocess (`Optional[bool]`, defaults to `True`):
+            Launch validation of each exported model in a subprocess.
     Raises:
         ValueError: If the outputs shapes or values do not match between the reference and the exported model.
     """
-    io_process = ValidationProcess(
-        config,
-        reference_model,
-        onnx_model,
-        onnx_named_outputs,
-        atol,
-        input_shapes,
-        device,
-        dtype,
-    )
-    io_process.start()
-    io_process.join()
+    if use_subprocess:
+        io_process = ValidationProcess(
+            config,
+            reference_model,
+            onnx_model,
+            onnx_named_outputs,
+            atol,
+            input_shapes,
+            device,
+            dtype,
+        )
+        io_process.start()
+        io_process.join()
 
-    if io_process.exception:
-        error, traceback = io_process.exception
-        raise error
+        if io_process.exception:
+            error, traceback = io_process.exception
+            raise error
+    else:
+        _run_validation(config, reference_model, onnx_model, onnx_named_outputs, atol, input_shapes, device, dtype)
+
+
+def _run_validation(
+    config: OnnxConfig,
+    reference_model: Union["PreTrainedModel", "TFPreTrainedModel", "ModelMixin"],
+    onnx_model: Path,
+    onnx_named_outputs: List[str],
+    atol: Optional[float] = None,
+    input_shapes: Optional[Dict] = None,
+    device: str = "cpu",
+    dtype: Optional["torch.dtype"] = None,
+):
+    from onnxruntime import GraphOptimizationLevel, SessionOptions
+
+    logger.info(f"Validating ONNX model {onnx_model.as_posix()}...")
+
+    if atol is None:
+        atol = config.ATOL_FOR_VALIDATION
+
+    if "diffusers" in str(reference_model.__class__) and not is_diffusers_available():
+        raise ImportError("The pip package `diffusers` is required to validate stable diffusion ONNX models.")
+
+    framework = "pt" if is_torch_available() and isinstance(reference_model, nn.Module) else "tf"
+
+    if input_shapes is None:
+        input_shapes = {}  # will use the defaults from DEFAULT_DUMMY_SHAPES
+    reference_model_inputs = config.generate_dummy_inputs(framework=framework, **input_shapes)
+
+    # Create ONNX Runtime session
+    session_options = SessionOptions()
+    # We could well set ORT_DISABLE_ALL here, but it makes CUDA export with O4 of gpt_neo fail
+    session_options.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_BASIC
+
+    if device.startswith("cuda"):
+        provider = "CUDAExecutionProvider"
+    else:
+        provider = "CPUExecutionProvider"
+
+    session = PickableInferenceSession(onnx_model.as_posix(), sess_options=session_options, providers=[provider])
+
+    # Sometimes the exported model can have more outputs than what is specified in the ONNX config because the original
+    # PyTorch model has more outputs that were forgotten in the config, so we check for that.
+    all_onnx_outputs = {output.name for output in session.get_outputs()}
+    config_outputs = set(config.outputs)
+    if all_onnx_outputs != config_outputs:
+        if len(all_onnx_outputs) > len(config_outputs):
+            diff = all_onnx_outputs - config_outputs
+        else:
+            diff = config_outputs - all_onnx_outputs
+
+        raise OutputMatchError(
+            "The exported ONNX model does not have the exact same outputs as what is provided in "
+            f"{config.__class__.__name__}. Difference: {', '.join(diff)}"
+        )
+
+    # Sometimes the exported model can have axes that are inferred as dynamic axes but were not specified as such in
+    # the ONNX Config: it was either an error on the config side, or an error on the ONNX side inferring a dynamic axis
+    # that is actually static.
+    # The `OnnxConfig.fix_dynamic_axes` method should fix that at export time, but it is still worth checking here.
+    all_config_dynamic_axes_names = set()
+    for input_ in config.inputs.values():
+        all_config_dynamic_axes_names |= set(input_.values())
+    for output in config.outputs.values():
+        all_config_dynamic_axes_names |= set(output.values())
+
+    for node in session.get_outputs():
+        for idx, axis in enumerate(node.shape):
+            if isinstance(axis, str) and axis not in all_config_dynamic_axes_names:
+                raise DynamicAxisNameError(
+                    f"The axis {idx} of input / output node called {node.name} has an unknown name: {axis}"
+                )
+
+    # Compute outputs from the reference model
+    if is_torch_available() and isinstance(reference_model, nn.Module):
+        reference_model.to(device)
+
+        for key, value in reference_model_inputs.items():
+            reference_model_inputs[key] = recursive_to_device(value=value, device=device)
+            reference_model_inputs[key] = recursive_to_dtype(
+                value=reference_model_inputs[key], dtype=dtype, start_dtype=torch.float32
+            )
+
+    if is_torch_available() and isinstance(reference_model, nn.Module):
+        with torch.inference_mode():
+            ref_outputs = reference_model(**reference_model_inputs)
+    else:
+        ref_outputs = reference_model(**reference_model_inputs)
+    ref_outputs_dict = {}
+
+    # We flatten potential collection of outputs (i.e. past_keys) to a flat structure
+    for name, value in ref_outputs.items():
+        # Overwriting the output name as "present" since it is the name used for the ONNX outputs
+        # ("past_key_values" being taken for the ONNX inputs)
+        if name == "past_key_values":
+            name = "present"
+        if isinstance(value, (list, tuple)):
+            value = config.flatten_output_collection_property(name, value)
+            ref_outputs_dict.update(value)
+        else:
+            ref_outputs_dict[name] = value
+
+    onnx_input_names = [inp.name for inp in session.get_inputs()]
+
+    # Possibly edit the input for the onnxruntime.InferenceSession, this is for example the case for merged
+    # models where the input `use_cache_branch` is added
+    reference_ort_inputs = config.generate_dummy_inputs_for_validation(
+        reference_model_inputs, onnx_input_names=onnx_input_names
+    )
+
+    # generate_dummy_inputs_for_validation may add inputs (e.g. past_key_values) that are by
+    # default on torch.float32 dtype. Thus, to run validation of fp16 model, these inputs need
+    # to be casted as well.
+    if is_torch_available() and isinstance(reference_model, nn.Module):
+        for key, value in reference_ort_inputs.items():
+            reference_ort_inputs[key] = recursive_to_dtype(
+                value=reference_ort_inputs[key], dtype=dtype, start_dtype=torch.float32
+            )
+
+    # We flatten potential collection of inputs (i.e. past_keys)
+    onnx_inputs = {}
+    for name, value in reference_ort_inputs.items():
+        if isinstance(value, (list, tuple)):
+            value = config.flatten_output_collection_property(name, value)
+            onnx_inputs.update({tensor_name: pt_tensor.cpu().numpy() for tensor_name, pt_tensor in value.items()})
+        else:
+            onnx_inputs[name] = value.cpu().numpy()
+
+    # Compute outputs from the ONNX model
+    onnx_outputs = session.run(onnx_named_outputs, onnx_inputs)
+
+    # Modify the ONNX output names to match the reference model output names
+    onnx_to_torch = {v: k for k, v in config.torch_to_onnx_output_map.items()}
+    onnx_named_outputs = [onnx_to_torch.get(k, k) for k in onnx_named_outputs]
+
+    # Check we have a subset of the keys into onnx_outputs against ref_outputs
+    ref_outputs_set, onnx_outputs_set = set(ref_outputs_dict.keys()), set(onnx_named_outputs)
+    if not onnx_outputs_set.issubset(ref_outputs_set):
+        raise OutputMatchError(
+            "ONNX model output names do not match reference model output names.\n"
+            f"Reference model output names: {ref_outputs_set}\n"
+            f"ONNX model output names: {onnx_outputs_set}"
+            f"Difference: {onnx_outputs_set.difference(ref_outputs_set)}"
+        )
+    else:
+        onnx_output_names = ", ".join(onnx_outputs_set)
+        logger.info(f"\t-[✓] ONNX model output names match reference model ({onnx_output_names})")
+
+    if "diffusers" in str(reference_model.__class__) and not is_diffusers_available():
+        raise ImportError("The pip package `diffusers` is required to validate stable diffusion ONNX models.")
+
+    # Check the shape and values match
+    shape_failures = []
+    value_failures = []
+    for name, ort_value in zip(onnx_named_outputs, onnx_outputs):
+        if is_torch_available() and isinstance(reference_model, nn.Module):
+            ref_value = ref_outputs_dict[name].detach().cpu().numpy()
+        else:
+            ref_value = ref_outputs_dict[name].cpu().numpy()
+        logger.info(f'\t- Validating ONNX Model output "{name}":')
+
+        # Shape
+        if not ort_value.shape == ref_value.shape:
+            logger.error(f"\t\t-[x] shape {ort_value.shape} doesn't match {ref_value.shape}")
+            shape_failures.append((name, ref_value.shape, ort_value.shape))
+        else:
+            logger.info(f"\t\t-[✓] {ort_value.shape} matches {ref_value.shape}")
+
+        # Values
+        try:
+            if not np.allclose(ref_value, ort_value, atol=atol):
+                max_diff = np.amax(np.abs(ref_value - ort_value))
+                logger.error(f"\t\t-[x] values not close enough, max diff: {max_diff} (atol: {atol})")
+                value_failures.append((name, max_diff))
+            else:
+                logger.info(f"\t\t-[✓] all values close (atol: {atol})")
+        except Exception:
+            # If shapes do not match, it is possible that the np.allclose call fails, since we raise the proper issue
+            # right after, we do not do anything here.
+            pass
+
+    if shape_failures:
+        msg = "\n".join(f"- {t[0]}: got {t[1]} (reference) and {t[2]} (ONNX)" for t in shape_failures)
+        raise ShapeError(f"Output shapes do not match between reference model and ONNX exported model:\n{msg}")
+
+    if value_failures:
+        msg = "\n".join(f"- {t[0]}: max diff = {t[1]}" for t in value_failures)
+        raise AtolError(
+            f"The maximum absolute difference between the output of the reference model and the ONNX exported model is not within the set tolerance {atol}:\n{msg}"
+        )
 
 
 class ValidationProcess(mp.Process):
@@ -241,187 +442,16 @@ class ValidationProcess(mp.Process):
 
     def run(self):
         try:
-            from onnxruntime import GraphOptimizationLevel, SessionOptions
-
-            logger.info(f"Validating ONNX model {self.onnx_model.as_posix()}...")
-
-            if self.atol is None:
-                self.atol = self.config.ATOL_FOR_VALIDATION
-
-            if "diffusers" in str(self.reference_model.__class__) and not is_diffusers_available():
-                raise ImportError("The pip package `diffusers` is required to validate stable diffusion ONNX models.")
-
-            framework = "pt" if is_torch_available() and isinstance(self.reference_model, nn.Module) else "tf"
-
-            if self.input_shapes is None:
-                self.input_shapes = {}  # will use the defaults from DEFAULT_DUMMY_SHAPES
-            reference_model_inputs = self.config.generate_dummy_inputs(framework=framework, **self.input_shapes)
-
-            # Create ONNX Runtime session
-            session_options = SessionOptions()
-            # We could well set ORT_DISABLE_ALL here, but it makes CUDA export with O4 of gpt_neo fail
-            session_options.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_BASIC
-
-            if self.device.startswith("cuda"):
-                provider = "CUDAExecutionProvider"
-            else:
-                provider = "CPUExecutionProvider"
-
-            session = PickableInferenceSession(
-                self.onnx_model.as_posix(), sess_options=session_options, providers=[provider]
+            _run_validation(
+                config=self.config,
+                reference_model=self.reference_model,
+                onnx_model=self.onnx_model,
+                onnx_named_outputs=self.onnx_named_outputs,
+                atol=self.atol,
+                input_shapes=self.input_shapes,
+                device=self.device,
+                dtype=self.dtype,
             )
-
-            # Sometimes the exported model can have more outputs than what is specified in the ONNX config because the original
-            # PyTorch model has more outputs that were forgotten in the config, so we check for that.
-            all_onnx_outputs = {output.name for output in session.get_outputs()}
-            config_outputs = set(self.config.outputs)
-            if all_onnx_outputs != config_outputs:
-                if len(all_onnx_outputs) > len(config_outputs):
-                    diff = all_onnx_outputs - config_outputs
-                else:
-                    diff = config_outputs - all_onnx_outputs
-
-                raise OutputMatchError(
-                    "The exported ONNX model does not have the exact same outputs as what is provided in "
-                    f"{self.config.__class__.__name__}. Difference: {', '.join(diff)}"
-                )
-
-            # Sometimes the exported model can have axes that are inferred as dynamic axes but were not specified as such in
-            # the ONNX Config: it was either an error on the config side, or an error on the ONNX side inferring a dynamic axis
-            # that is actually static.
-            # The `OnnxConfig.fix_dynamic_axes` method should fix that at export time, but it is still worth checking here.
-            all_config_dynamic_axes_names = set()
-            for input_ in self.config.inputs.values():
-                all_config_dynamic_axes_names |= set(input_.values())
-            for output in self.config.outputs.values():
-                all_config_dynamic_axes_names |= set(output.values())
-
-            for node in session.get_outputs():
-                for idx, axis in enumerate(node.shape):
-                    if isinstance(axis, str) and axis not in all_config_dynamic_axes_names:
-                        raise DynamicAxisNameError(
-                            f"The axis {idx} of input / output node called {node.name} has an unknown name: {axis}"
-                        )
-
-            # Compute outputs from the reference model
-            if is_torch_available() and isinstance(self.reference_model, nn.Module):
-                self.reference_model.to(self.device)
-
-                for key, value in reference_model_inputs.items():
-                    reference_model_inputs[key] = recursive_to_device(value=value, device=self.device)
-                    reference_model_inputs[key] = recursive_to_dtype(
-                        value=reference_model_inputs[key], dtype=self.dtype, start_dtype=torch.float32
-                    )
-
-            if is_torch_available() and isinstance(self.reference_model, nn.Module):
-                with torch.inference_mode():
-                    ref_outputs = self.reference_model(**reference_model_inputs)
-            else:
-                ref_outputs = self.reference_model(**reference_model_inputs)
-            ref_outputs_dict = {}
-
-            # We flatten potential collection of outputs (i.e. past_keys) to a flat structure
-            for name, value in ref_outputs.items():
-                # Overwriting the output name as "present" since it is the name used for the ONNX outputs
-                # ("past_key_values" being taken for the ONNX inputs)
-                if name == "past_key_values":
-                    name = "present"
-                if isinstance(value, (list, tuple)):
-                    value = self.config.flatten_output_collection_property(name, value)
-                    ref_outputs_dict.update(value)
-                else:
-                    ref_outputs_dict[name] = value
-
-            onnx_input_names = [inp.name for inp in session.get_inputs()]
-
-            # Possibly edit the input for the onnxruntime.InferenceSession, this is for example the case for merged
-            # models where the input `use_cache_branch` is added
-            reference_ort_inputs = self.config.generate_dummy_inputs_for_validation(
-                reference_model_inputs, onnx_input_names=onnx_input_names
-            )
-
-            # generate_dummy_inputs_for_validation may add inputs (e.g. past_key_values) that are by
-            # default on torch.float32 dtype. Thus, to run validation of fp16 model, these inputs need
-            # to be casted as well.
-            if is_torch_available() and isinstance(self.reference_model, nn.Module):
-                for key, value in reference_ort_inputs.items():
-                    reference_ort_inputs[key] = recursive_to_dtype(
-                        value=reference_ort_inputs[key], dtype=self.dtype, start_dtype=torch.float32
-                    )
-
-            # We flatten potential collection of inputs (i.e. past_keys)
-            onnx_inputs = {}
-            for name, value in reference_ort_inputs.items():
-                if isinstance(value, (list, tuple)):
-                    value = self.config.flatten_output_collection_property(name, value)
-                    onnx_inputs.update(
-                        {tensor_name: pt_tensor.cpu().numpy() for tensor_name, pt_tensor in value.items()}
-                    )
-                else:
-                    onnx_inputs[name] = value.cpu().numpy()
-
-            # Compute outputs from the ONNX model
-            onnx_outputs = session.run(self.onnx_named_outputs, onnx_inputs)
-
-            # Modify the ONNX output names to match the reference model output names
-            onnx_to_torch = {v: k for k, v in self.config.torch_to_onnx_output_map.items()}
-            self.onnx_named_outputs = [onnx_to_torch.get(k, k) for k in self.onnx_named_outputs]
-
-            # Check we have a subset of the keys into onnx_outputs against ref_outputs
-            ref_outputs_set, onnx_outputs_set = set(ref_outputs_dict.keys()), set(self.onnx_named_outputs)
-            if not onnx_outputs_set.issubset(ref_outputs_set):
-                raise OutputMatchError(
-                    "ONNX model output names do not match reference model output names.\n"
-                    f"Reference model output names: {ref_outputs_set}\n"
-                    f"ONNX model output names: {onnx_outputs_set}"
-                    f"Difference: {onnx_outputs_set.difference(ref_outputs_set)}"
-                )
-            else:
-                onnx_output_names = ", ".join(onnx_outputs_set)
-                logger.info(f"\t-[✓] ONNX model output names match reference model ({onnx_output_names})")
-
-            if "diffusers" in str(self.reference_model.__class__) and not is_diffusers_available():
-                raise ImportError("The pip package `diffusers` is required to validate stable diffusion ONNX models.")
-
-            # Check the shape and values match
-            shape_failures = []
-            value_failures = []
-            for name, ort_value in zip(self.onnx_named_outputs, onnx_outputs):
-                if is_torch_available() and isinstance(self.reference_model, nn.Module):
-                    ref_value = ref_outputs_dict[name].detach().cpu().numpy()
-                else:
-                    ref_value = ref_outputs_dict[name].cpu().numpy()
-                logger.info(f'\t- Validating ONNX Model output "{name}":')
-
-                # Shape
-                if not ort_value.shape == ref_value.shape:
-                    logger.error(f"\t\t-[x] shape {ort_value.shape} doesn't match {ref_value.shape}")
-                    shape_failures.append((name, ref_value.shape, ort_value.shape))
-                else:
-                    logger.info(f"\t\t-[✓] {ort_value.shape} matches {ref_value.shape}")
-
-                # Values
-                try:
-                    if not np.allclose(ref_value, ort_value, atol=self.atol):
-                        max_diff = np.amax(np.abs(ref_value - ort_value))
-                        logger.error(f"\t\t-[x] values not close enough, max diff: {max_diff} (atol: {self.atol})")
-                        value_failures.append((name, max_diff))
-                    else:
-                        logger.info(f"\t\t-[✓] all values close (atol: {self.atol})")
-                except Exception:
-                    # If shapes do not match, it is possible that the np.allclose call fails, since we raise the proper issue
-                    # right after, we do not do anything here.
-                    pass
-
-            if shape_failures:
-                msg = "\n".join(f"- {t[0]}: got {t[1]} (reference) and {t[2]} (ONNX)" for t in shape_failures)
-                raise ShapeError(f"Output shapes do not match between reference model and ONNX exported model:\n{msg}")
-
-            if value_failures:
-                msg = "\n".join(f"- {t[0]}: max diff = {t[1]}" for t in value_failures)
-                raise AtolError(
-                    f"The maximum absolute difference between the output of the reference model and the ONNX exported model is not within the set tolerance {self.atol}:\n{msg}"
-                )
         except Exception as e:
             tb = traceback.format_exc()
             self._cconn.send((e, tb))

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -151,7 +151,7 @@ def validate_models_outputs(
         onnx_paths.append(onnx_model_path)
         try:
             # Model validation is done in subprocesses, as ONNX Runtime has the bad habit of
-            # not release memory once an InferenceSession is initialized.
+            # not releasing memory once an InferenceSession is initialized.
             # Reference: https://github.com/huggingface/optimum/pull/1115
             validate_model_outputs(
                 config=sub_onnx_config,

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -252,3 +252,29 @@ def recursive_to_dtype(
             value = value.to(dtype=dtype)
 
     return value
+
+
+# Copied from https://github.com/microsoft/onnxruntime/issues/7846#issuecomment-850217402
+class PickableInferenceSession:  # This is a wrapper to make the current InferenceSession class pickable.
+    def __init__(self, model_path, sess_options, providers):
+        import onnxruntime as ort
+
+        self.model_path = model_path
+        self.sess_options = sess_options
+        self.providers = providers
+        self.sess = ort.InferenceSession(self.model_path, sess_options=sess_options, providers=providers)
+
+    def run(self, *args):
+        return self.sess.run(*args)
+
+    def get_outputs(self):
+        return self.sess.get_outputs()
+
+    def __getstate__(self):
+        return {"model_path": self.model_path}
+
+    def __setstate__(self, values):
+        import onnxruntime as ort
+
+        self.model_path = values["model_path"]
+        self.sess = ort.InferenceSession(self.model_path, sess_options=self.sess_options, providers=self.providers)

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -270,6 +270,9 @@ class PickableInferenceSession:  # This is a wrapper to make the current Inferen
     def get_outputs(self):
         return self.sess.get_outputs()
 
+    def get_inputs(self):
+        return self.sess.get_inputs()
+
     def __getstate__(self):
         return {"model_path": self.model_path}
 

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -44,6 +44,9 @@ class NormalizedConfig:
         return functools.partial(cls, allow_new=allow_new, **kwargs)
 
     def __getattr__(self, attr_name):
+        if attr_name == "config":
+            return super().__getattr__(attr_name)
+
         try:
             attr_name = super().__getattribute__(attr_name.upper())
         except AttributeError:  # e.g. in the NormalizedTextAndVisionConfig case

--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -409,4 +409,5 @@ class OnnxExportTestCase(TestCase):
                 output_dir=Path(tmpdirname),
                 atol=1e-3,
                 onnx_files_subpaths=output_names,
+                use_subprocess=False,
             )


### PR DESCRIPTION
Post-processing (merging of decoders) still uses x2 the model size **in RAM, not GPU memory**.

May partially fix https://github.com/huggingface/optimum/issues/1069 https://github.com/huggingface/optimum/issues/1060 https://github.com/huggingface/optimum/issues/1055

Fixes as well a bug where ORT inputs generated in `generate_dummy_inputs_for_validation` were always of type fp32, even if the export is in fp16.

ONNX Runtime has the bad habit of not releasing GPU memory (see https://github.com/microsoft/onnxruntime/issues/7463 & https://github.com/microsoft/onnxruntime/issues/11362 & the script below) when doing

```python
del session
gc.collect()
```

or when simply exiting a function that initialized an InferenceSession.

Thus, in the ONNX export validation, as we initialize several `InferenceSession` (e.g. encoder, decoder), if the export is done on GPU, memory keeps accumulating which may result in OOM.

This PR allows to launch the validation in subprocesses, that are effectively killed after each validation and allow to indeed release memory. See the logs below to compare the memory usage (exporting llama-7b on fp16 on cuda device, on pytorch 2.1.0.dev20230615+cu118).

<details>
  <summary>Currently</summary>
  
```
----------------- Start main_export
RAM: 39519.16 MB
GPU mem: 0.00 MB
----------------- before from_pretrained call
RAM: 39519.74 MB
GPU mem: 0.00 MB
----------------- after from_pretrained call
RAM: 41075.89 MB
GPU mem: 14547.94 MB
----------------- After loading model
RAM: 41071.94 MB
GPU mem: 14547.94 MB
----------------- After loading models_and_onnx_configs, before export
RAM: 41084.33 MB
GPU mem: 14547.94 MB
----------------- Just before onnx_export call
RAM: 41083.15 MB
GPU mem: 14547.94 MB
----------------- Just after onnx_export call
RAM: 43764.74 MB
GPU mem: 15351.15 MB
----------------- Just after save external data call
RAM: 43752.37 MB
GPU mem: 15351.15 MB
----------------- Just before onnx_export call
RAM: 44119.20 MB
GPU mem: 15761.15 MB
----------------- Just after onnx_export call
RAM: 45858.22 MB
GPU mem: 15782.12 MB
----------------- Just after save external data call
RAM: 45847.20 MB
GPU mem: 15782.12 MB
----------------- After export, before post-process
RAM: 45856.85 MB
GPU mem: 15782.12 MB
----------------- After post-process
RAM: 47516.82 MB
GPU mem: 15782.12 MB
----------------- Before nth validation
RAM: 47515.49 MB
GPU mem: 15782.12 MB
----------------- Start of nth model validation
RAM: 47527.54 MB
GPU mem: 15782.12 MB
----------------- Before InferenceSession init
RAM: 47526.32 MB
GPU mem: 15782.12 MB
----------------- After InferenceSession init
RAM: 48015.36 MB
GPU mem: 33012.32 MB
----------------- Before nth validation
RAM: 48057.54 MB
GPU mem: 35233.20 MB
----------------- Start of nth model validation
RAM: 48059.34 MB
GPU mem: 35233.20 MB
----------------- Before InferenceSession init
RAM: 48084.92 MB
GPU mem: 35233.20 MB
----------------- After InferenceSession init
RAM: 48694.38 MB
GPU mem: 52501.15 MB
----------------- After validation
RAM: 48799.00 MB
GPU mem: 55058.63 MB
```
  
</details>

<details>
  <summary>After this PR</summary>

```
----------------- Start main_export
RAM: 32096.99 MB
GPU mem: 0.00 MB
----------------- before from_pretrained call
RAM: 32109.21 MB
GPU mem: 0.00 MB
----------------- after from_pretrained call
RAM: 35730.13 MB
GPU mem: 14545.85 MB
----------------- After loading model
RAM: 35739.60 MB
GPU mem: 14545.85 MB
----------------- After loading models_and_onnx_configs, before export
RAM: 35787.28 MB
GPU mem: 14545.85 MB
----------------- Just before onnx_export call
RAM: 35795.46 MB
GPU mem: 14545.85 MB
----------------- Just before onnx_export call
RAM: 38835.44 MB
GPU mem: 15761.15 MB
----------------- Just after onnx_export call
RAM: 40598.87 MB
GPU mem: 15782.12 MB
----------------- Just after save external data call
RAM: 40578.62 MB
GPU mem: 15782.12 MB
----------------- After export, before post-process
RAM: 40570.54 MB
GPU mem: 15782.12 MB
----------------- After post-process
RAM: 42374.24 MB
GPU mem: 15782.12 MB
----------------- before ValidationProcess init
RAM: 42377.47 MB
GPU mem: 15782.12 MB
----------------- end of ValidationProcess init
RAM: 42377.54 MB
GPU mem: 15782.12 MB
----------------- start of ValidationProcess run
RAM: 42686.26 MB
GPU mem: 16213.08 MB
----------------- after ValidationProcess join
RAM: 42385.13 MB
GPU mem: 15782.12 MB
----------------- before ValidationProcess init
RAM: 42396.16 MB
GPU mem: 15782.12 MB
----------------- end of ValidationProcess init
RAM: 42395.87 MB
GPU mem: 15782.12 MB
----------------- start of ValidationProcess run
RAM: 42802.97 MB
GPU mem: 16213.08 MB
----------------- after ValidationProcess join
RAM: 42466.02 MB
GPU mem: 15782.12 MB
----------------- After validation
RAM: 42464.28 MB
GPU mem: 15782.12 MB
```
  
</details>

<details>
  <summary>ORT not releasing memory bug reproduction</summary>

```python
import onnxruntime as ort
import gc
import psutil
import subprocess
import torch
import os

def print_memory(prefix):
    cpu_ram_mb = (psutil.virtual_memory().total - psutil.virtual_memory().available) / 1000**2

    command = "nvidia-smi --query-gpu=memory.used --format=csv --id=0"
    gpu_mem_info = subprocess.check_output(command.split()).decode("ascii").split("\n")[:-1][1:]

    gpu_mem_mb = [int(x.split()[0]) for i, x in enumerate(gpu_mem_info)][0] * 1.048576

    print("-----------------", prefix, flush=True)
    print(f"RAM: {cpu_ram_mb:.2f} MB", flush=True)
    print(f"GPU mem: {gpu_mem_mb:.2f} MB", flush=True)

print_memory("Before session load")

session = ort.InferenceSession("/path/to/decoder_model.onnx", providers=["CUDAExecutionProvider"])

"""
onnx_inputs = {
    "input_ids": torch.randint(0, 10, (2, 20)).numpy(),
    "attention_mask": torch.ones(2, 20, dtype=torch.int64).numpy()
}

onnx_outputs = session.run(None, onnx_inputs)
"""
del session
gc.collect()

print_memory("after collect")
```

printing

```
----------------- Before session load
RAM: 6784.98 MB
GPU mem: 5.24 MB
----------------- after collect
RAM: 8804.13 MB
GPU mem: 921.70 MB
```

</details>