### PR TITLE
Update onnxruntime/trainer.py with recent huggingface change

### DIFF
--- a/optimum/onnxruntime/training_args.py
+++ b/optimum/onnxruntime/training_args.py
@@ -73,7 +73,7 @@ class ORTTrainingArguments(TrainingArguments):
         },
     )
 
-    # This method will not need to be overriden after the deprecation of `--adafactor` in version 5 of 🤗 Transformers.
+    # TODO This method will not need to be overriden after the deprecation of `--adafactor` in version 5 of 🤗 Transformers.
     def __post_init__(self):
         # Handle --use_env option in torch.distributed.launch (local_rank not passed as an arg then).
         # This needs to happen before any call to self.device or self.n_gpu.


### PR DESCRIPTION
# What does this PR do?
This PR updates trainer.py and trainer_args.py to keep up with changes around deepspeed usage in transformers/trainer.
This starts to break since https://github.com/huggingface/transformers/commit/a73b1d59a34ca8e30098b3e32a977a7928663559#diff-ed55888e6665791fe92cc8fc0c499da54f4ace6738551cd9a2591881cda076de

Fixes #1133 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

