### PR TITLE
[ONNX export] Ability to pass arbitrary kwargs, custom ONNX configs

### DIFF
--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -239,3 +239,73 @@ For each model architecture, you can find the list of supported tasks via the [`
 ```
 
 You can then pass one of these tasks to the `--task` argument in the `optimum-cli export onnx` command, as mentioned above.
+
+## Custom export of Transformers models
+
+Optimum allows for advanced users a finer-grained control over the configuration for the ONNX export. This is especially useful if you would like to export models with different keyword arguments, for example using `output_attentions=True` or `output_hidden_states=True`.
+
+To support these use cases, [~exporters.__main__.main_export] supports two arguments: `model_kwargs` and `custom_onnx_configs`, which are used in the following fashion:
+
+* `model_kwargs` allows to override some of the default arguments to the models `forward`, in practice as `model(**reference_model_inputs, **model_kwargs)`.
+* `custom_onnx_configs` should be a `Dict[str, OnnxConfig]`, mapping from the submodel name (usually `model`, `encoder_model`, `decoder_model`, or `decoder_model_with_past` - [reference](https://github.com/huggingface/optimum/blob/main/optimum/exporters/onnx/constants.py)) to a custom ONNX configuration for the given submodel.
+
+A complete example is given below, allowing to export models with `output_attentions=True`.
+
+```python
+from optimum.exporters.onnx.__main__ import main_export
+from optimum.exporters.onnx.model_configs import WhisperOnnxConfig
+from transformers import AutoConfig
+
+from optimum.exporters.onnx.base import ConfigBehavior
+from typing import Dict
+
+class CustomWhisperOnnxConfig(WhisperOnnxConfig):
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        common_outputs = super().outputs
+
+        if self._behavior is ConfigBehavior.ENCODER:
+            for i in range(self._config.encoder_layers):
+                common_outputs[f"encoder_attentions.{i}"] = {0: "batch_size"}
+        elif self._behavior is ConfigBehavior.DECODER:
+            for i in range(self._config.decoder_layers):
+                common_outputs[f"decoder_attentions.{i}"] = {0: "batch_size", 3: "decoder_sequence_length"}
+            for i in range(self._config.decoder_layers):
+                common_outputs[f"cross_attentions.{i}"] = {0: "batch_size", 3: "cross_attention_length"}
+
+        return common_outputs
+
+    @property
+    def torch_to_onnx_output_map(self):
+        if self._behavior is ConfigBehavior.ENCODER:
+            # The encoder export uses WhisperEncoder that returns the key "attentions"
+            return {"attentions": "encoder_attentions"}
+        else:
+            return {}
+
+model_id = "openai/whisper-tiny.en"
+config = AutoConfig.from_pretrained(model_id)
+
+custom_whisper_onnx_config = CustomWhisperOnnxConfig(
+        config=config,
+        task="automatic-speech-recognition",
+)
+
+encoder_config = custom_whisper_onnx_config.with_behavior("encoder")
+decoder_config = custom_whisper_onnx_config.with_behavior("decoder", use_past=False)
+decoder_with_past_config = custom_whisper_onnx_config.with_behavior("decoder", use_past=True)
+
+custom_onnx_configs={
+    "encoder_model": encoder_config,
+    "decoder_model": decoder_config,
+    "decoder_with_past_model": decoder_with_past_config,
+}
+
+main_export(
+    model_id,
+    output="custom_whisper_onnx",
+    no_post_process=True,
+    model_kwargs={"output_attentions": True},
+    custom_onnx_configs=custom_onnx_configs
+)
+```

--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -269,9 +269,17 @@ class CustomWhisperOnnxConfig(WhisperOnnxConfig):
                 common_outputs[f"encoder_attentions.{i}"] = {0: "batch_size"}
         elif self._behavior is ConfigBehavior.DECODER:
             for i in range(self._config.decoder_layers):
-                common_outputs[f"decoder_attentions.{i}"] = {0: "batch_size", 3: "decoder_sequence_length"}
+                common_outputs[f"decoder_attentions.{i}"] = {
+                    0: "batch_size",
+                    2: "decoder_sequence_length",
+                    3: "past_decoder_sequence_length + 1"
+                }
             for i in range(self._config.decoder_layers):
-                common_outputs[f"cross_attentions.{i}"] = {0: "batch_size", 3: "cross_attention_length"}
+                common_outputs[f"cross_attentions.{i}"] = {
+                    0: "batch_size",
+                    2: "decoder_sequence_length",
+                    3: "encoder_sequence_length_out"
+                }
 
         return common_outputs
 

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -232,5 +232,6 @@ class ONNXExportCommand(BaseOptimumCLICommand):
             trust_remote_code=self.args.trust_remote_code,
             pad_token_id=self.args.pad_token_id,
             for_ort=self.args.for_ort,
+            use_subprocess=True,
             **input_shapes,
         )

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -72,7 +72,7 @@ def main_export(
     for_ort: bool = False,
     do_validation: bool = True,
     model_kwargs: Optional[Dict[str, Any]] = None,
-    custom_onnx_configs: Optional["OnnxConfig"] = None,
+    custom_onnx_configs: Optional[Dict[str, "OnnxConfig"]] = None,
     use_subprocess: bool = False,
     **kwargs_shapes,
 ):

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -139,7 +139,7 @@ def main_export(
             in case, for example, the model inputs/outputs are changed (for example, if
             `model_kwargs={"output_attentions": True}` is passed).
         custom_onnx_configs (`Optional[Dict[str, OnnxConfig]]`, defaults to `None`):
-            Experimental usage: override the default ONNX config used for the given model. This argument may be useful for advanced users that desire a finer-grained control on the export. An example is available [here](TODO: link).
+            Experimental usage: override the default ONNX config used for the given model. This argument may be useful for advanced users that desire a finer-grained control on the export. An example is available [here](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model).
         use_subprocess (`bool`):
             Do the ONNX exported model validation in subprocesses. This is especially useful when
             exporting on CUDA device, where ORT does not release memory at inference session

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -39,8 +39,11 @@ from .utils import (
 if is_torch_available():
     import torch
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
+
+if TYPE_CHECKING:
+    from .base import OnnxConfig
 
 logger = logging.get_logger()
 logger.setLevel(logging.INFO)
@@ -68,6 +71,9 @@ def main_export(
     use_auth_token: Optional[Union[bool, str]] = None,
     for_ort: bool = False,
     do_validation: bool = True,
+    model_kwargs: Optional[Dict[str, Any]] = None,
+    custom_onnx_configs: Optional["OnnxConfig"] = None,
+    use_subprocess: bool = False,
     **kwargs_shapes,
 ):
     """
@@ -127,6 +133,18 @@ def main_export(
         use_auth_token (`Optional[str]`, defaults to `None`):
             The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
             when running `transformers-cli login` (stored in `~/.huggingface`).
+        model_kwargs (`Optional[Dict[str, Any]]`, defaults to `None`):
+            Experimental usage: keyword arguments to pass to the model during
+            the export. This argument should be used along the `custom_onnx_configs` argument
+            in case, for example, the model inputs/outputs are changed (for example, if
+            `model_kwargs={"output_attentions": True}` is passed).
+        custom_onnx_configs (`Optional[Dict[str, OnnxConfig]]`, defaults to `None`):
+            Experimental usage: override the default ONNX config used for the given model. This argument may be useful for advanced users that desire a finer-grained control on the export. An example is available [here](TODO: link).
+        use_subprocess (`bool`):
+            Do the ONNX exported model validation in subprocesses. This is especially useful when
+            exporting on CUDA device, where ORT does not release memory at inference session
+            destruction. When set to `True`, the `main_export` call should be guarded in
+            `if __name__ == "__main__":` block.
         **kwargs_shapes (`Dict`):
             Shapes to use during inference. This argument allows to override the default shapes used during the ONNX export.
 
@@ -308,6 +326,10 @@ def main_export(
         else:
             models_and_onnx_configs = {"model": (model, onnx_config)}
 
+    if custom_onnx_configs is not None:
+        for key, custom_onnx_config in custom_onnx_configs.items():
+            models_and_onnx_configs[key] = (models_and_onnx_configs[key][0], custom_onnx_config)
+
     _, onnx_outputs = export_models(
         models_and_onnx_configs=models_and_onnx_configs,
         opset=opset,
@@ -316,6 +338,7 @@ def main_export(
         input_shapes=input_shapes,
         device=device,
         dtype="fp16" if fp16 is True else None,
+        model_kwargs=model_kwargs,
     )
 
     if optimize == "O4" and device != "cuda":
@@ -349,7 +372,6 @@ def main_export(
                 f"The post-processing of the ONNX export failed. The export can still be performed by passing the option --no-post-process. Detailed error: {e}"
             )
 
-    use_subprocess = True
     if task == "stable-diffusion":
         use_subprocess = (
             False  # TODO: fix Can't pickle local object 'get_stable_diffusion_models_for_export.<locals>.<lambda>'
@@ -371,6 +393,7 @@ def main_export(
                 device=device,
                 dtype=torch_dtype,
                 use_subprocess=use_subprocess,
+                model_kwargs=model_kwargs,
             )
             logger.info(f"The ONNX export succeeded and the exported model was saved at: {output.as_posix()}")
         except ShapeError as e:

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -305,8 +305,10 @@ class OnnxConfig(ExportConfig, ABC):
             del onnx_model
             gc.collect()
 
-    def patch_model_for_export(self, model: Union["PreTrainedModel", "TFPreTrainedModel"]) -> ModelPatcher:
-        return ModelPatcher(self, model)
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+    ) -> ModelPatcher:
+        return ModelPatcher(self, model, model_kwargs=model_kwargs)
 
     @property
     def values_override(self) -> Optional[Dict[str, Any]]:
@@ -435,7 +437,10 @@ class OnnxConfig(ExportConfig, ABC):
             `Dict[str, Any]`: Outputs with flattened structure and key mapping this new structure.
 
         """
-        return {f"{name}.{idx}": item for idx, item in enumerate(itertools.chain.from_iterable(field))}
+        if isinstance(field[0], list) or isinstance(field[0], tuple):
+            return {f"{name}.{idx}": item for idx, item in enumerate(itertools.chain.from_iterable(field))}
+        else:
+            return {f"{name}.{idx}": item for idx, item in enumerate(field)}
 
     def generate_dummy_inputs_for_validation(
         self, reference_model_inputs: Dict[str, Any], onnx_input_names: Optional[List[str]] = None
@@ -807,8 +812,10 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         flattened_output[f"{name}.{idx}.encoder.key"] = t[2]
         flattened_output[f"{name}.{idx}.encoder.value"] = t[3]
 
-    def patch_model_for_export(self, model: Union["PreTrainedModel", "TFPreTrainedModel"]) -> ModelPatcher:
-        return Seq2SeqModelPatcher(self, model)
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+    ) -> ModelPatcher:
+        return Seq2SeqModelPatcher(self, model, model_kwargs=model_kwargs)
 
     def post_process_exported_models(
         self,

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -306,7 +306,7 @@ class OnnxConfig(ExportConfig, ABC):
             gc.collect()
 
     def patch_model_for_export(
-        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> ModelPatcher:
         return ModelPatcher(self, model, model_kwargs=model_kwargs)
 
@@ -813,7 +813,7 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         flattened_output[f"{name}.{idx}.encoder.value"] = t[3]
 
     def patch_model_for_export(
-        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> ModelPatcher:
         return Seq2SeqModelPatcher(self, model, model_kwargs=model_kwargs)
 

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -437,7 +437,7 @@ class OnnxConfig(ExportConfig, ABC):
             `Dict[str, Any]`: Outputs with flattened structure and key mapping this new structure.
 
         """
-        if isinstance(field[0], list) or isinstance(field[0], tuple):
+        if isinstance(field[0], (list, tuple)):
             return {f"{name}.{idx}": item for idx, item in enumerate(itertools.chain.from_iterable(field))}
         else:
             return {f"{name}.{idx}": item for idx, item in enumerate(field)}

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -951,8 +951,10 @@ class WavLMOnnxConfig(HubertOnnxConfig):
     # we need to set output_attentions=True in the model input to avoid calling
     # torch.nn.functional.scaled_dot_product_attention that is not supported by the ONNX export
     # due to the op torch.nn.functional.multi_head_attention_forward used for WavLM
-    def patch_model_for_export(self, model: Union["PreTrainedModel", "TFPreTrainedModel"]) -> "ModelPatcher":
-        return WavLMModelPatcher(self, model)
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+    ) -> "ModelPatcher":
+        return WavLMModelPatcher(self, model, model_kwargs=model_kwargs)
 
 
 class ASTDummyAudioInputGenerator(DummyAudioInputGenerator):

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -952,7 +952,7 @@ class WavLMOnnxConfig(HubertOnnxConfig):
     # torch.nn.functional.scaled_dot_product_attention that is not supported by the ONNX export
     # due to the op torch.nn.functional.multi_head_attention_forward used for WavLM
     def patch_model_for_export(
-        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> "ModelPatcher":
         return WavLMModelPatcher(self, model, model_kwargs=model_kwargs)
 

--- a/optimum/exporters/onnx/model_patcher.py
+++ b/optimum/exporters/onnx/model_patcher.py
@@ -31,8 +31,8 @@ logger = logging.get_logger(__name__)
 def overwride_arguments(args, kwargs, forward_signature, model_kwargs):
     args = list(args)
 
-    for argument in model_kwargs.keys():
-        if argument in forward_signature.parameters.keys():
+    for argument in model_kwargs:
+        if argument in forward_signature.parameters:
             argument_index = list(forward_signature.parameters.keys()).index(argument)
 
             args[argument_index] = model_kwargs[argument]

--- a/optimum/exporters/onnx/model_patcher.py
+++ b/optimum/exporters/onnx/model_patcher.py
@@ -15,7 +15,7 @@
 import dataclasses
 import functools
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 from ...utils import logging
 
@@ -26,6 +26,20 @@ if TYPE_CHECKING:
     from .base import OnnxConfig
 
 logger = logging.get_logger(__name__)
+
+
+def overwride_arguments(args, kwargs, forward_signature, model_kwargs):
+    args = list(args)
+
+    for argument in model_kwargs.keys():
+        if argument in forward_signature.parameters.keys():
+            argument_index = list(forward_signature.parameters.keys()).index(argument)
+
+            args[argument_index] = model_kwargs[argument]
+        else:
+            kwargs[argument] = model_kwargs[argument]
+
+    return args, kwargs
 
 
 @dataclasses.dataclass
@@ -50,7 +64,12 @@ class PatchingSpec:
 
 
 class ModelPatcher:
-    def __init__(self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"]):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: Union["PreTrainedModel", "TFPreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]],
+    ):
         self._model = model
 
         patching_specs = config.PATCHING_SPECS
@@ -64,6 +83,8 @@ class ModelPatcher:
         self.orig_forward_name = "forward" if hasattr(self._model, "forward") else "call"
         self.orig_forward = getattr(self._model, self.orig_forward_name)
 
+        self.model_kwargs = model_kwargs if model_kwargs is not None else {}
+
         # TODO: remove that once we got rid of OnnxConfigWithLoss or we implemented it better.
         if config.__class__.__name__ == "OnnxConfigWithLoss":
             self.real_config = config._onnx_config
@@ -75,14 +96,20 @@ class ModelPatcher:
 
         @functools.wraps(self.orig_forward)
         def patched_forward(*args, **kwargs):
+            signature = inspect.signature(self.orig_forward)
+            args, kwargs = overwride_arguments(args, kwargs, signature, model_kwargs=self.model_kwargs)
+
             outputs = self.orig_forward(*args, **kwargs)
 
             filterd_outputs = {}
-            for k, v in outputs.items():
-                if config.torch_to_onnx_output_map.get(k, k) in config.outputs or (
-                    allow_past_in_outputs and k.startswith("past_key_values")
+            for name, value in outputs.items():
+                onnx_output_name = config.torch_to_onnx_output_map.get(name, name)
+                if (
+                    onnx_output_name in config.outputs
+                    or (allow_past_in_outputs and name.startswith("past_key_values"))
+                    or any(key.startswith(onnx_output_name) for key in config.outputs.keys())
                 ):
-                    filterd_outputs[k] = v
+                    filterd_outputs[name] = value
             return filterd_outputs
 
         self.patched_forward = patched_forward
@@ -112,8 +139,10 @@ class ModelPatcher:
 
 
 class Seq2SeqModelPatcher(ModelPatcher):
-    def __init__(self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"]):
-        super().__init__(config, model)
+    def __init__(
+        self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+    ):
+        super().__init__(config, model, model_kwargs)
 
         allow_past_in_outputs = (
             hasattr(self.real_config, "use_present_in_outputs") and self.real_config.use_present_in_outputs
@@ -126,13 +155,19 @@ class Seq2SeqModelPatcher(ModelPatcher):
 
         @functools.wraps(self.orig_forward)
         def patched_forward(*args, **kwargs):
+            signature = inspect.signature(self.orig_forward)
+            args, kwargs = overwride_arguments(args, kwargs, signature, model_kwargs=self.model_kwargs)
+
             outputs = self.orig_forward(*args, **kwargs)
 
             # Filter out cross attention past key values
             filterd_outputs = {}
             for name, value in outputs.items():
-                if config.torch_to_onnx_output_map.get(name, name) in config.outputs or (
-                    allow_past_in_outputs and name.startswith("past_key_values")
+                onnx_output_name = config.torch_to_onnx_output_map.get(name, name)
+                if (
+                    onnx_output_name in config.outputs
+                    or (allow_past_in_outputs and name.startswith("past_key_values"))
+                    or any(key.startswith(onnx_output_name) for key in config.outputs.keys())
                 ):
                     if name != "past_key_values":
                         if self.real_config._behavior == "decoder" and name == "encoder_last_hidden_state":
@@ -147,14 +182,17 @@ class Seq2SeqModelPatcher(ModelPatcher):
                             filterd_outputs[name] = value
                         elif self.real_config._behavior == "decoder" and self.real_config.use_past is True:
                             filterd_outputs[name] = tuple([v[:2] for v in value])
+
             return filterd_outputs
 
         self.patched_forward = patched_forward
 
 
 class WavLMModelPatcher(ModelPatcher):
-    def __init__(self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"]):
-        super().__init__(config, model)
+    def __init__(
+        self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+    ):
+        super().__init__(config, model, model_kwargs)
 
         allow_past_in_outputs = (
             hasattr(self.real_config, "use_present_in_outputs") and self.real_config.use_present_in_outputs
@@ -162,23 +200,25 @@ class WavLMModelPatcher(ModelPatcher):
 
         @functools.wraps(self.orig_forward)
         def patched_forward(*args, **kwargs):
-            args = list(args)
-
-            signature = inspect.signature(self.orig_forward)
-            output_attentions_index = list(signature.parameters.keys()).index("output_attentions")
-
+            model_kwargs = self.model_kwargs
             # setting output_attentions=True in the model input to avoid calling torch.nn.functional.scaled_dot_product_attention
             # in https://github.com/huggingface/transformers/blob/v4.27.1/src/transformers/models/wavlm/modeling_wavlm.py#L496
             # that calls https://github.com/pytorch/pytorch/blob/v2.0.0/torch/nn/functional.py#L5334
-            args[output_attentions_index] = True
+            model_kwargs["output_attentions"] = True
+            signature = inspect.signature(self.orig_forward)
+            args, kwargs = overwride_arguments(args, kwargs, signature, model_kwargs=model_kwargs)
+
             outputs = self.orig_forward(*args, **kwargs)
 
             filterd_outputs = {}
-            for k, v in outputs.items():
-                if config.torch_to_onnx_output_map.get(k, k) in config.outputs or (
-                    allow_past_in_outputs and k.startswith("past_key_values")
+            for name, value in outputs.items():
+                onnx_output_name = config.torch_to_onnx_output_map.get(name, name)
+                if (
+                    onnx_output_name in config.outputs
+                    or (allow_past_in_outputs and name.startswith("past_key_values"))
+                    or any(key.startswith(onnx_output_name) for key in config.outputs.keys())
                 ):
-                    filterd_outputs[k] = v
+                    filterd_outputs[name] = value
             return filterd_outputs
 
         self.patched_forward = patched_forward

--- a/optimum/exporters/onnx/model_patcher.py
+++ b/optimum/exporters/onnx/model_patcher.py
@@ -68,7 +68,7 @@ class ModelPatcher:
         self,
         config: "OnnxConfig",
         model: Union["PreTrainedModel", "TFPreTrainedModel"],
-        model_kwargs: Optional[Dict[str, Any]],
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self._model = model
 
@@ -140,7 +140,10 @@ class ModelPatcher:
 
 class Seq2SeqModelPatcher(ModelPatcher):
     def __init__(
-        self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+        self,
+        config: "OnnxConfig",
+        model: Union["PreTrainedModel", "TFPreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(config, model, model_kwargs)
 
@@ -190,7 +193,10 @@ class Seq2SeqModelPatcher(ModelPatcher):
 
 class WavLMModelPatcher(ModelPatcher):
     def __init__(
-        self, config: "OnnxConfig", model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Dict[str, Any]
+        self,
+        config: "OnnxConfig",
+        model: Union["PreTrainedModel", "TFPreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(config, model, model_kwargs)
 


### PR DESCRIPTION
As per title, described in the doc & requested by @xenova:
* Add a `model_kwargs (Dict[str, Any])` argument to `main_export` to allow to pass arbitrary kwargs to the model during the export and validation
* Add a `custom_onnx_configs (Dict[str, OnnxConfig])` argument to `main_export`, to allow to pass more smoothly custom configs for specific usages. An example is provided in the documentation for `output_attentions=True`.

This PR also disable the use of subprocesses by default in the validation in case `main_export` is not called from `optimum-cli export onnx`, as we use the `spawn` multiprocessing method that requires to use the `if __name__ == "__main__"` guard, that can be a breaking change.