### PR TITLE
Add trust remote code option for config

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -328,9 +328,13 @@ class OptimizedModel(PreTrainedModel):
         if config is None:
             if os.path.isdir(os.path.join(model_id, subfolder)) and cls.config_name == CONFIG_NAME:
                 if CONFIG_NAME in os.listdir(os.path.join(model_id, subfolder)):
-                    config = AutoConfig.from_pretrained(os.path.join(model_id, subfolder, CONFIG_NAME))
+                    config = AutoConfig.from_pretrained(
+                        os.path.join(model_id, subfolder, CONFIG_NAME), trust_remote_code=trust_remote_code
+                    )
                 elif CONFIG_NAME in os.listdir(model_id):
-                    config = AutoConfig.from_pretrained(os.path.join(model_id, CONFIG_NAME))
+                    config = AutoConfig.from_pretrained(
+                        os.path.join(model_id, CONFIG_NAME), trust_remote_code=trust_remote_code
+                    )
                     logger.info(
                         f"config.json not found in the specified subfolder {subfolder}. Using the top level config.json."
                     )
@@ -344,6 +348,7 @@ class OptimizedModel(PreTrainedModel):
                     use_auth_token=use_auth_token,
                     force_download=force_download,
                     subfolder=subfolder,
+                    trust_remote_code=trust_remote_code,
                 )
         elif isinstance(config, (str, os.PathLike)):
             config = cls._load_config(
@@ -353,6 +358,7 @@ class OptimizedModel(PreTrainedModel):
                 use_auth_token=use_auth_token,
                 force_download=force_download,
                 subfolder=subfolder,
+                trust_remote_code=trust_remote_code,
             )
 
         if not export and trust_remote_code:


### PR DESCRIPTION
# What does this PR do?
add trust remote code option for config when use xxxx.from_pretrained().
I found the issue when I used `TSModelForCausal` class, I pass the trust_remote_code, but it doesn't work.
```
        user_model = TSModelForCausalLM.from_pretrained(
            args.output_dir, file_name="best_model.pt", trust_remote_code=args.trust_remote_code
        )
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

