### PR TITLE
[ONNX export] Fixed incomplete model memory release issue

### DIFF
--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """ONNX model check and export functions."""
 
+import gc
 import multiprocessing as mp
 import os
 import traceback
@@ -593,6 +594,9 @@ def export_pytorch(
                 # try free model memory
                 del model
                 del onnx_model
+                gc.collect()
+                if device.type == "cuda" and torch.cuda.is_available():
+                    torch.cuda.empty_cache()
 
                 onnx_model = onnx.load(
                     str(output), load_external_data=True


### PR DESCRIPTION
# What does this PR do?

This PR resolves incomplete model memory release issue. The original code only delete the reference of model and onnx_model but not to trigger python gc and to release video memory. I found this issue when I tried to export llama based 13B model using fp16 on a A100 80G card. After showing that `Saving external data to one file...`, the the video memory usage rose up from 52G to 80G, which made the process crashed.

The export command is down below

```bash
optimum-cli export onnx --model TheBloke/Wizard-Vicuna-13B-Uncensored-HF \
--task causal-lm-with-past --fp16 --device cuda {save_dir}
```

There is no existing opening issue about this.

Now the export process will not use more than double the size of model weights memory for correct releasing models, which makes exporting 13B models on 80G video card possible.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

