### PR TITLE
Add ONNX export for MGP-STR

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -571,6 +571,10 @@ class ConvNextOnnxConfig(ViTOnnxConfig):
     pass
 
 
+class MgpstrOnnxConfig(ViTOnnxConfig):
+    pass
+
+
 class MobileViTOnnxConfig(ViTOnnxConfig):
     ATOL_FOR_VALIDATION = 1e-4
 

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -619,6 +619,10 @@ class TasksManager:
         #     "automatic-speech-recognition",
         #     onnx="MCTCTOnnxConfig",
         # ),
+        "mgp-str": supported_tasks_mapping(
+            "feature-extraction",
+            onnx="MgpstrOnnxConfig",
+        ),
         "mobilebert": supported_tasks_mapping(
             "feature-extraction",
             "fill-mask",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -73,6 +73,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "m2m-100": "hf-internal-testing/tiny-random-m2m_100",
     "marian": "sshleifer/tiny-marian-en-de",  # hf-internal-testing ones are broken
     "mbart": "hf-internal-testing/tiny-random-mbart",
+    "mgp-str": "hf-internal-testing/tiny-random-mgp-str",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
     "mobilenet-v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
     "mobilenet-v1": "google/mobilenet_v1_0.75_192",
@@ -189,6 +190,7 @@ PYTORCH_EXPORT_MODELS_LARGE = {
     "m2m-100": "hf-internal-testing/tiny-random-m2m_100",  # Not using facebook/m2m100_418M because it takes too much time for testing.
     "marian": "Helsinki-NLP/opus-mt-en-de",
     "mbart": "sshleifer/tiny-mbart",
+    "mgp-str": "alibaba-damo/mgp-str-base",
     "mobilebert": "google/mobilebert-uncased",
     # "mobilenet_v1": "google/mobilenet_v1_0.75_192",
     # "mobilenet_v2": "google/mobilenet_v2_0.35_96",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -73,7 +73,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "m2m-100": "hf-internal-testing/tiny-random-m2m_100",
     "marian": "sshleifer/tiny-marian-en-de",  # hf-internal-testing ones are broken
     "mbart": "hf-internal-testing/tiny-random-mbart",
-    "mgp-str": "hf-internal-testing/tiny-random-mgp-str",
+    "mgp-str": "hf-tiny-model-private/tiny-random-MgpstrForSceneTextRecognition",
     "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
     "mobilenet-v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
     "mobilenet-v1": "google/mobilenet_v1_0.75_192",


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the [MGP-STR](https://huggingface.co/docs/transformers/model_doc/mgp-str) model which can perform text scene recognition in images.

However this is not an official task yet, so I was wondering what the best way is to support this. For the moment I've only included "feature-extraction" but would like to also include the head model.
