### PR TITLE
ONNX export for custom architectures & models with custom modeling code

### DIFF
--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -242,6 +242,8 @@ You can then pass one of these tasks to the `--task` argument in the `optimum-cl
 
 ## Custom export of Transformers models
 
+### Customize the export of official Transformers models
+
 Optimum allows for advanced users a finer-grained control over the configuration for the ONNX export. This is especially useful if you would like to export models with different keyword arguments, for example using `output_attentions=True` or `output_hidden_states=True`.
 
 To support these use cases, [~exporters.__main__.main_export] supports two arguments: `model_kwargs` and `custom_onnx_configs`, which are used in the following fashion:
@@ -317,3 +319,105 @@ main_export(
     custom_onnx_configs=custom_onnx_configs
 )
 ```
+
+### Customize the export of Transformers models with custom modeling
+
+Optimum supports the export of Transformers models with custom modeling that use [`trust_remote_code=True`](), not officially supported in the Transormers library but usable with its functionality as [pipelines]() and [generation]()
+
+Examples of such models are [THUDM/chatglm2-6b](https://huggingface.co/THUDM/chatglm2-6b) and [mosaicml/mpt-30b](https://huggingface.co/mosaicml/mpt-30b).
+
+To export custom models, a dictionary `custom_onnx_configs` needs to be passed, with the ONNX config definition for all the subparts of the model to export (for example, encoder and decoder subparts). The example below allows to export `mosaicml/mpt-7b` model:
+
+```python
+from optimum.exporters.onnx import main_export
+
+from transformers import AutoConfig
+
+from optimum.exporters.onnx.config import TextDecoderOnnxConfig
+from optimum.utils import NormalizedTextConfig, DummyPastKeyValuesGenerator
+from typing import Dict
+
+
+class MPTDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
+    """
+    MPT swaps the two last dimensions for the key cache compared to usual transformers
+    decoder models, thus the redefinition here.
+    """
+    def generate(self, input_name: str, framework: str = "pt"):
+        past_key_shape = (
+            self.batch_size,
+            self.num_attention_heads,
+            self.hidden_size // self.num_attention_heads,
+            self.sequence_length,
+        )
+        past_value_shape = (
+            self.batch_size,
+            self.num_attention_heads,
+            self.sequence_length,
+            self.hidden_size // self.num_attention_heads,
+        )
+        return [
+            (
+                self.random_float_tensor(past_key_shape, framework=framework),
+                self.random_float_tensor(past_value_shape, framework=framework),
+            )
+            for _ in range(self.num_layers)
+        ]
+
+class CustomMPTOnnxConfig(TextDecoderOnnxConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (MPTDummyPastKeyValuesGenerator,) + TextDecoderOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES
+    DUMMY_PKV_GENERATOR_CLASS = MPTDummyPastKeyValuesGenerator
+
+    DEFAULT_ONNX_OPSET = 14  # aten::tril operator requires opset>=14
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
+        hidden_size="d_model",
+        num_layers="n_layers",
+        num_attention_heads="n_heads"
+    )
+
+    def add_past_key_values(self, inputs_or_outputs: Dict[str, Dict[int, str]], direction: str):
+        """
+        Adapted from https://github.com/huggingface/optimum/blob/v1.9.0/optimum/exporters/onnx/base.py#L625
+        """
+        if direction not in ["inputs", "outputs"]:
+            raise ValueError(f'direction must either be "inputs" or "outputs", but {direction} was given')
+
+        if direction == "inputs":
+            decoder_sequence_name = "past_sequence_length"
+            name = "past_key_values"
+        else:
+            decoder_sequence_name = "past_sequence_length + 1"
+            name = "present"
+
+        for i in range(self._normalized_config.num_layers):
+            inputs_or_outputs[f"{name}.{i}.key"] = {0: "batch_size", 3: decoder_sequence_name}
+            inputs_or_outputs[f"{name}.{i}.value"] = {0: "batch_size", 2: decoder_sequence_name}
+
+
+model_id = "/home/fxmarty/hf_internship/optimum/tiny-mpt-random-remote-code"
+config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
+
+onnx_config = CustomMPTOnnxConfig(
+    config=config,
+    task="text-generation",
+    use_past_in_inputs=False,
+    use_present_in_outputs=True,
+)
+onnx_config_with_past = CustomMPTOnnxConfig(config, task="text-generation", use_past=True)
+
+custom_onnx_configs = {
+    "decoder_model": onnx_config,
+    "decoder_with_past_model": onnx_config_with_past,
+}
+
+main_export(
+    model_id,
+    output="mpt_onnx",
+    task="text-generation-with-past",
+    trust_remote_code=True,
+    custom_onnx_configs=custom_onnx_configs,
+    no_post_process=True,
+)
+```
+
+Moreover, the advanced argument `fn_get_submodels` to `main_export` allows to customize how the submodels are extracted in case the model needs to be exported in several submodels. Examples of such functions can be [consulted here](TODO).

--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -246,7 +246,7 @@ You can then pass one of these tasks to the `--task` argument in the `optimum-cl
 
 Optimum allows for advanced users a finer-grained control over the configuration for the ONNX export. This is especially useful if you would like to export models with different keyword arguments, for example using `output_attentions=True` or `output_hidden_states=True`.
 
-To support these use cases, [~exporters.__main__.main_export] supports two arguments: `model_kwargs` and `custom_onnx_configs`, which are used in the following fashion:
+To support these use cases, [`~exporters.main_export`] supports two arguments: `model_kwargs` and `custom_onnx_configs`, which are used in the following fashion:
 
 * `model_kwargs` allows to override some of the default arguments to the models `forward`, in practice as `model(**reference_model_inputs, **model_kwargs)`.
 * `custom_onnx_configs` should be a `Dict[str, OnnxConfig]`, mapping from the submodel name (usually `model`, `encoder_model`, `decoder_model`, or `decoder_model_with_past` - [reference](https://github.com/huggingface/optimum/blob/main/optimum/exporters/onnx/constants.py)) to a custom ONNX configuration for the given submodel.
@@ -254,7 +254,7 @@ To support these use cases, [~exporters.__main__.main_export] supports two argum
 A complete example is given below, allowing to export models with `output_attentions=True`.
 
 ```python
-from optimum.exporters.onnx.__main__ import main_export
+from optimum.exporters.onnx import main_export
 from optimum.exporters.onnx.model_configs import WhisperOnnxConfig
 from transformers import AutoConfig
 
@@ -326,7 +326,7 @@ Optimum supports the export of Transformers models with custom modeling that use
 
 Examples of such models are [THUDM/chatglm2-6b](https://huggingface.co/THUDM/chatglm2-6b) and [mosaicml/mpt-30b](https://huggingface.co/mosaicml/mpt-30b).
 
-To export custom models, a dictionary `custom_onnx_configs` needs to be passed, with the ONNX config definition for all the subparts of the model to export (for example, encoder and decoder subparts). The example below allows to export `mosaicml/mpt-7b` model:
+To export custom models, a dictionary `custom_onnx_configs` needs to be passed to [`~optimum.exporters.onnx.main_export`], with the ONNX config definition for all the subparts of the model to export (for example, encoder and decoder subparts). The example below allows to export `mosaicml/mpt-7b` model:
 
 ```python
 from optimum.exporters.onnx import main_export

--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -322,7 +322,7 @@ main_export(
 
 ### Customize the export of Transformers models with custom modeling
 
-Optimum supports the export of Transformers models with custom modeling that use [`trust_remote_code=True`](), not officially supported in the Transormers library but usable with its functionality as [pipelines]() and [generation]()
+Optimum supports the export of Transformers models with custom modeling that use [`trust_remote_code=True`](https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModel.from_pretrained.trust_remote_code), not officially supported in the Transormers library but usable with its functionality as [pipelines](https://huggingface.co/docs/transformers/main_classes/pipelines) and [generation](https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationMixin.generate).
 
 Examples of such models are [THUDM/chatglm2-6b](https://huggingface.co/THUDM/chatglm2-6b) and [mosaicml/mpt-30b](https://huggingface.co/mosaicml/mpt-30b).
 
@@ -420,4 +420,4 @@ main_export(
 )
 ```
 
-Moreover, the advanced argument `fn_get_submodels` to `main_export` allows to customize how the submodels are extracted in case the model needs to be exported in several submodels. Examples of such functions can be [consulted here](TODO).
+Moreover, the advanced argument `fn_get_submodels` to `main_export` allows to customize how the submodels are extracted in case the model needs to be exported in several submodels. Examples of such functions can be [consulted here](link to utils.py relevant code once merged).

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -312,7 +312,7 @@ def main_export(
     )
 
     custom_architecture = False
-    if model.config.model_type.replace("_", "-") not in TasksManager.get_supported_model_type_for_task(
+    if model.config.model_type.replace("-", "_") not in TasksManager.get_supported_model_type_for_task(
         task, exporter="onnx"
     ):
         custom_architecture = True

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -39,6 +39,9 @@ from .base import OnnxConfigWithPast
 from .constants import UNPICKABLE_ARCHS
 from .convert import export_models, validate_models_outputs
 from .utils import (
+    _get_submodels_for_export_decoder,
+    _get_submodels_for_export_encoder_decoder,
+    _get_submodels_for_export_stable_diffusion,
     get_decoder_models_for_export,
     get_encoder_decoder_models_for_export,
     get_stable_diffusion_models_for_export,
@@ -48,14 +51,86 @@ from .utils import (
 if is_torch_available():
     import torch
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 
 if TYPE_CHECKING:
+    from transformers import PreTrainedModel, TFPreTrainedModel
+
     from .base import OnnxConfig
 
 logger = logging.get_logger()
 logger.setLevel(logging.INFO)
+
+
+def _get_submodels_and_onnx_configs(
+    model: Union["PreTrainedModel", "TFPreTrainedModel"],
+    task: str,
+    monolith: bool,
+    custom_onnx_configs: Dict,
+    custom_architecture: bool,
+    fn_get_submodels: Optional[Callable] = None,
+):
+    if not custom_architecture:
+        if task == "stable-diffusion":
+            onnx_config = None
+            models_and_onnx_configs = get_stable_diffusion_models_for_export(model)
+        else:
+            onnx_config_constructor = TasksManager.get_exporter_config_constructor(
+                model=model, exporter="onnx", task=task
+            )
+            onnx_config = onnx_config_constructor(model.config)
+
+            if (
+                model.config.is_encoder_decoder
+                and task.startswith(TasksManager._ENCODER_DECODER_TASKS)
+                and not monolith
+            ):
+                models_and_onnx_configs = get_encoder_decoder_models_for_export(model, onnx_config)
+            elif task.startswith("text-generation") and not monolith:
+                models_and_onnx_configs = get_decoder_models_for_export(model, onnx_config)
+            else:
+                models_and_onnx_configs = {"model": (model, onnx_config)}
+    else:
+        onnx_config = None
+        submodels_for_export = None
+        models_and_onnx_configs = {}
+
+        if fn_get_submodels is not None:
+            submodels_for_export = fn_get_submodels(model)
+        else:
+            if task == "stable-diffusion":
+                submodels_for_export = _get_submodels_for_export_stable_diffusion(model)
+            elif (
+                model.config.is_encoder_decoder
+                and task.startswith(TasksManager._ENCODER_DECODER_TASKS)
+                and not monolith
+            ):
+                submodels_for_export = _get_submodels_for_export_encoder_decoder(
+                    model, use_past=task.endswith("-with-past")
+                )
+            elif task.startswith("text-generation") and not monolith:
+                submodels_for_export = _get_submodels_for_export_decoder(model, use_past=task.endswith("-with-past"))
+            else:
+                submodels_for_export = {"model": model}
+
+        if submodels_for_export.keys() != custom_onnx_configs.keys():
+            logger.error(f"ONNX custom configs for: {', '.join(custom_onnx_configs.keys())}")
+            logger.error(f"Submodels to export: {', '.join(submodels_for_export.keys())}")
+            raise ValueError(
+                "Trying to export a custom model, but could not find as many custom ONNX configs as the number of submodels to export. Please specifiy the fn_get_submodels argument, that should return a dictionary of submodules with as many items as the provided custom_onnx_configs dictionary."
+            )
+
+    # When specifying custom ONNX configs for supported transformers architectures, we do
+    # not force to specify a custom ONNX config for each submodel.
+    for key, custom_onnx_config in custom_onnx_configs.items():
+        models_and_onnx_configs[key] = (submodels_for_export[key], custom_onnx_config)
+
+    # Default to the first ONNX config for stable-diffusion and custom architecture case.
+    if onnx_config is None:
+        onnx_config = next(iter(models_and_onnx_configs.values()))[1]
+
+    return onnx_config, models_and_onnx_configs
 
 
 def main_export(
@@ -82,6 +157,7 @@ def main_export(
     do_validation: bool = True,
     model_kwargs: Optional[Dict[str, Any]] = None,
     custom_onnx_configs: Optional[Dict[str, "OnnxConfig"]] = None,
+    fn_get_submodels: Optional[Callable] = None,
     use_subprocess: bool = False,
     **kwargs_shapes,
 ):
@@ -149,6 +225,9 @@ def main_export(
             `model_kwargs={"output_attentions": True}` is passed).
         custom_onnx_configs (`Optional[Dict[str, OnnxConfig]]`, defaults to `None`):
             Experimental usage: override the default ONNX config used for the given model. This argument may be useful for advanced users that desire a finer-grained control on the export. An example is available [here](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model).
+        fn_get_submodels (`Optional[Callable]`, defaults to `None`):
+            Experimental usage: Override the default submodels that are used at the export. This is
+            especially useful when exporting a custom architecture that needs to split the ONNX (e.g. encoder-decoder). If unspecified with custom models, optimum will try to use the default submodels used for the given task, with no guarantee of success.
         use_subprocess (`bool`):
             Do the ONNX exported model validation in subprocesses. This is especially useful when
             exporting on CUDA device, where ORT does not release memory at inference session
@@ -164,6 +243,20 @@ def main_export(
     >>> main_export("gpt2", output="gpt2_onnx/")
     ```
     """
+    if optimize == "O4" and device != "cuda":
+        raise ValueError(
+            "Requested O4 optimization, but this optimization requires to do the export on GPU."
+            " Please pass the argument `--device cuda`."
+        )
+
+    if (framework == "tf" and fp16 is True) or not is_torch_available():
+        raise ValueError("The --fp16 option is supported only for PyTorch.")
+
+    if fp16 is True and device == "cpu":
+        raise ValueError(
+            "The --fp16 option is supported only when exporting on GPU. Please pass the option `--device cuda`."
+        )
+
     output = Path(output)
     if not output.exists():
         output.mkdir(parents=True)
@@ -178,14 +271,6 @@ def main_export(
     task = TasksManager.map_from_synonym(task)
 
     framework = TasksManager.determine_framework(model_name_or_path, subfolder=subfolder, framework=framework)
-
-    if (framework == "tf" and fp16 is True) or not is_torch_available():
-        raise ValueError("The --fp16 option is supported only for PyTorch.")
-
-    if fp16 is True and device == "cpu":
-        raise ValueError(
-            "The --fp16 option is supported only when exporting on GPU. Please pass the option `--device cuda`."
-        )
 
     # get the shapes to be used to generate dummy inputs
     input_shapes = {}
@@ -223,8 +308,28 @@ def main_export(
         device=device,
     )
 
-    if task != "stable-diffusion" and task + "-with-past" in TasksManager.get_supported_tasks_for_model_type(
-        model.config.model_type.replace("_", "-"), "onnx"
+    custom_architecture = False
+    if model.config.model_type.replace("_", "-") not in TasksManager.get_supported_model_type_for_task(
+        task, exporter="onnx"
+    ):
+        custom_architecture = True
+
+    # TODO: support onnx_config.py in the model repo
+    if custom_architecture and custom_onnx_configs is None:
+        raise ValueError(
+            "Trying to export a model with a custom architecture, but no custom onnx configuration was passed as `custom_onnx_configs`. Please refer to https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model#custom-export-of-transformers-models for an example on how to export custom models."
+        )
+
+    if custom_architecture and original_task == "auto":
+        raise ValueError(
+            f'Automatic task detection is not supported with custom architectures. Please specify the `task` argument (suggetion: task="{task}" or task="{task}-with-past" if the model is decoder-based and supports KV cache)'
+        )
+
+    if (
+        not custom_architecture
+        and task != "stable-diffusion"
+        and task + "-with-past"
+        in TasksManager.get_supported_tasks_for_model_type(model.config.model_type.replace("_", "-"), "onnx")
     ):
         if original_task == "auto":  # Make -with-past the default if --task was not explicitely specified
             task = task + "-with-past"
@@ -250,10 +355,16 @@ def main_export(
             possible_synonyms = ""
         logger.info(f"Automatic task detection to {task}{possible_synonyms}.")
 
-    if task != "stable-diffusion":
-        onnx_config_constructor = TasksManager.get_exporter_config_constructor(model=model, exporter="onnx", task=task)
-        onnx_config = onnx_config_constructor(model.config)
+    onnx_config, models_and_onnx_configs = _get_submodels_and_onnx_configs(
+        model=model,
+        task=task,
+        monolith=monolith,
+        custom_onnx_configs=custom_onnx_configs if custom_onnx_configs is not None else {},
+        custom_architecture=custom_architecture,
+        fn_get_submodels=fn_get_submodels,
+    )
 
+    if task != "stable-diffusion":
         needs_pad_token_id = (
             isinstance(onnx_config, OnnxConfigWithPast)
             and getattr(model.config, "pad_token_id", None) is None
@@ -278,7 +389,7 @@ def main_export(
         if opset < onnx_config.DEFAULT_ONNX_OPSET:
             raise ValueError(
                 f"Opset {opset} is not sufficient to export {model.config.model_type}. "
-                f"At least  {onnx_config.DEFAULT_ONNX_OPSET} is required."
+                f"At least {onnx_config.DEFAULT_ONNX_OPSET} is required."
             )
         if atol is None:
             atol = onnx_config.ATOL_FOR_VALIDATION
@@ -292,15 +403,21 @@ def main_export(
             generation_config.save_pretrained(output)
         maybe_save_preprocessors(model_name_or_path, output)
 
-    if task == "stable-diffusion":
+        if model.config.is_encoder_decoder and task.startswith("text-generation"):
+            raise ValueError(
+                f"model.config.is_encoder_decoder is True and task is `{task}`, which are incompatible. If the task was auto-inferred, please fill a bug report"
+                f"at https://github.com/huggingface/optimum, if --task was explicitely passed, make sure you selected the right task for the model,"
+                f" referring to `optimum.exporters.tasks.TaskManager`'s `_TASKS_TO_AUTOMODELS`."
+            )
+
+        onnx_files_subpaths = None
+    else:
         onnx_files_subpaths = [
             DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER,
             DIFFUSION_MODEL_UNET_SUBFOLDER,
             DIFFUSION_MODEL_VAE_ENCODER_SUBFOLDER,
             DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER,
         ]
-
-        models_and_onnx_configs = get_stable_diffusion_models_for_export(model)
 
         # save the subcomponent configuration
         for model_name, name_dir in zip(models_and_onnx_configs, onnx_files_subpaths):
@@ -318,38 +435,6 @@ def main_export(
         if model.feature_extractor is not None:
             model.feature_extractor.save_pretrained(output.joinpath("feature_extractor"))
         model.save_config(output)
-    else:
-        if model.config.is_encoder_decoder and task.startswith("text-generation"):
-            raise ValueError(
-                f"model.config.is_encoder_decoder is True and task is `{task}`, which are incompatible. If the task was auto-inferred, please fill a bug report"
-                f"at https://github.com/huggingface/optimum, if --task was explicitely passed, make sure you selected the right task for the model,"
-                f" referring to `optimum.exporters.tasks.TaskManager`'s `_TASKS_TO_AUTOMODELS`."
-            )
-
-        onnx_files_subpaths = None
-        if (
-            model.config.is_encoder_decoder
-            and task.startswith(
-                (
-                    "text2text-generation",
-                    "automatic-speech-recognition",
-                    "image-to-text",
-                    "feature-extraction-with-past",
-                    "visual-question-answering",
-                    "document-question-answering",
-                )
-            )
-            and not monolith
-        ):
-            models_and_onnx_configs = get_encoder_decoder_models_for_export(model, onnx_config)
-        elif task.startswith("text-generation") and not monolith:
-            models_and_onnx_configs = get_decoder_models_for_export(model, onnx_config)
-        else:
-            models_and_onnx_configs = {"model": (model, onnx_config)}
-
-    if custom_onnx_configs is not None:
-        for key, custom_onnx_config in custom_onnx_configs.items():
-            models_and_onnx_configs[key] = (models_and_onnx_configs[key][0], custom_onnx_config)
 
     _, onnx_outputs = export_models(
         models_and_onnx_configs=models_and_onnx_configs,
@@ -361,12 +446,6 @@ def main_export(
         dtype="fp16" if fp16 is True else None,
         model_kwargs=model_kwargs,
     )
-
-    if optimize == "O4" and device != "cuda":
-        raise ValueError(
-            "Requested O4 optimization, but this optimization requires to do the export on GPU."
-            " Please pass the argument `--device cuda`."
-        )
 
     if optimize is not None:
         from ...onnxruntime import AutoOptimizationConfig, ORTOptimizer

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -91,6 +91,11 @@ def _get_submodels_and_onnx_configs(
                 models_and_onnx_configs = get_decoder_models_for_export(model, onnx_config)
             else:
                 models_and_onnx_configs = {"model": (model, onnx_config)}
+
+        # When specifying custom ONNX configs for supported transformers architectures, we do
+        # not force to specify a custom ONNX config for each submodel.
+        for key, custom_onnx_config in custom_onnx_configs.items():
+            models_and_onnx_configs[key] = (models_and_onnx_configs[key][0], custom_onnx_config)
     else:
         onnx_config = None
         submodels_for_export = None
@@ -121,10 +126,8 @@ def _get_submodels_and_onnx_configs(
                 "Trying to export a custom model, but could not find as many custom ONNX configs as the number of submodels to export. Please specifiy the fn_get_submodels argument, that should return a dictionary of submodules with as many items as the provided custom_onnx_configs dictionary."
             )
 
-    # When specifying custom ONNX configs for supported transformers architectures, we do
-    # not force to specify a custom ONNX config for each submodel.
-    for key, custom_onnx_config in custom_onnx_configs.items():
-        models_and_onnx_configs[key] = (submodels_for_export[key], custom_onnx_config)
+        for key, custom_onnx_config in custom_onnx_configs.items():
+            models_and_onnx_configs[key] = (submodels_for_export[key], custom_onnx_config)
 
     # Default to the first ONNX config for stable-diffusion and custom architecture case.
     if onnx_config is None:

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -322,7 +322,7 @@ def main_export(
 
     if custom_architecture and original_task == "auto":
         raise ValueError(
-            f'Automatic task detection is not supported with custom architectures. Please specify the `task` argument (suggetion: task="{task}" or task="{task}-with-past" if the model is decoder-based and supports KV cache)'
+            f'Automatic task detection is not supported with custom architectures. Please specify the `task` argument. Suggestion: task="{task}" (or task="{task}-with-past" if the model is decoder-based and supports KV cache)'
         )
 
     if (

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -312,9 +312,9 @@ def main_export(
     )
 
     custom_architecture = False
-    if model.config.model_type.replace("-", "_") not in TasksManager.get_supported_model_type_for_task(
-        task, exporter="onnx"
-    ):
+    if task != "stable-diffusion" and model.config.model_type.replace(
+        "-", "_"
+    ) not in TasksManager.get_supported_model_type_for_task(task, exporter="onnx"):
         custom_architecture = True
 
     # TODO: support onnx_config.py in the model repo

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """ONNX model check and export functions."""
 
+import copy
 import gc
 import multiprocessing as mp
 import os
@@ -322,11 +323,14 @@ def _run_validation(
                 value=reference_model_inputs[key], dtype=dtype, start_dtype=torch.float32
             )
 
+    # Some models may modify in place the inputs, hence the copy.
+    copy_reference_model_inputs = copy.deepcopy(reference_model_inputs)
+
     if is_torch_available() and isinstance(reference_model, nn.Module):
         with torch.inference_mode():
-            ref_outputs = reference_model(**reference_model_inputs, **model_kwargs)
+            ref_outputs = reference_model(**copy_reference_model_inputs, **model_kwargs)
     else:
-        ref_outputs = reference_model(**reference_model_inputs, **model_kwargs)
+        ref_outputs = reference_model(**copy_reference_model_inputs, **model_kwargs)
     ref_outputs_dict = {}
 
     # We flatten potential collection of outputs (i.e. past_keys) to a flat structure

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -17,7 +17,7 @@
 import copy
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
-import packaging
+from packaging import version
 import torch
 from transformers.utils import is_tf_available, is_torch_available
 
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
         from diffusers import ModelMixin, StableDiffusionPipeline
 
 
-def check_onnxruntime_requirements(minimum_version: packaging.version.Version):
+def check_onnxruntime_requirements(minimum_version: version.Version):
     """
     Checks that ONNX Runtime is installed and if version is recent enough.
 
@@ -85,7 +85,7 @@ def check_onnxruntime_requirements(minimum_version: packaging.version.Version):
             " and relaunch the conversion."
         )
 
-    ort_version = packaging.version.parse(onnxruntime.__version__)
+    ort_version = version.parse(onnxruntime.__version__)
     if ort_version < ORT_QUANTIZE_MINIMUM_VERSION:
         raise ImportError(
             f"We found an older version of ONNX Runtime ({onnxruntime.__version__}) "
@@ -112,14 +112,14 @@ def _get_submodels_for_export_stable_diffusion(
 
     # VAE Encoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L565
     vae_encoder = copy.deepcopy(pipeline.vae)
-    if not packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0"):
+    if not version.parse(torch.__version__) >= version.parse("2.1.0"):
         vae_encoder = override_diffusers_2_0_attn_processors(vae_encoder)
     vae_encoder.forward = lambda sample: {"latent_sample": vae_encoder.encode(x=sample)["latent_dist"].sample()}
     models_for_export["vae_encoder"] = vae_encoder
 
     # VAE Decoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L600
     vae_decoder = copy.deepcopy(pipeline.vae)
-    if not packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0"):
+    if not version.parse(torch.__version__) >= version.parse("2.1.0"):
         vae_decoder = override_diffusers_2_0_attn_processors(vae_decoder)
     vae_decoder.forward = lambda latent_sample: vae_decoder.decode(z=latent_sample)
     models_for_export["vae_decoder"] = vae_decoder

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -17,8 +17,8 @@
 import copy
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
-from packaging import version
 import torch
+from packaging import version
 from transformers.utils import is_tf_available, is_torch_available
 
 from ...utils import (

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -94,6 +94,71 @@ def check_onnxruntime_requirements(minimum_version: packaging.version.Version):
         )
 
 
+def _get_submodels_for_export_stable_diffusion(
+    pipeline: "StableDiffusionPipeline",
+) -> Dict[str, Union["PreTrainedModel", "ModelMixin"]]:
+    """
+    Returns the components of a Stable Diffusion model.
+    """
+    models_for_export = {}
+
+    # Text encoder
+    models_for_export["text_encoder"] = pipeline.text_encoder
+
+    # U-NET
+    # PyTorch does not support the ONNX export of torch.nn.functional.scaled_dot_product_attention
+    pipeline.unet.set_attn_processor(AttnProcessor())
+    models_for_export["unet"] = pipeline.unet
+
+    # VAE Encoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L565
+    vae_encoder = copy.deepcopy(pipeline.vae)
+    if not packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0"):
+        vae_encoder = override_diffusers_2_0_attn_processors(vae_encoder)
+    vae_encoder.forward = lambda sample: {"latent_sample": vae_encoder.encode(x=sample)["latent_dist"].sample()}
+    models_for_export["vae_encoder"] = vae_encoder
+
+    # VAE Decoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L600
+    vae_decoder = copy.deepcopy(pipeline.vae)
+    if not packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0"):
+        vae_decoder = override_diffusers_2_0_attn_processors(vae_decoder)
+    vae_decoder.forward = lambda latent_sample: vae_decoder.decode(z=latent_sample)
+    models_for_export["vae_decoder"] = vae_decoder
+
+    return models_for_export
+
+
+def _get_submodels_for_export_decoder(
+    model: Union["PreTrainedModel", "TFPreTrainedModel"], use_past: bool
+) -> Dict[str, Union["PreTrainedModel", "TFPreTrainedModel"]]:
+    """
+    Returns the decoder part of the model.
+    """
+    models_for_export = {}
+
+    models_for_export[ONNX_DECODER_NAME] = model
+    if use_past:
+        models_for_export[ONNX_DECODER_WITH_PAST_NAME] = model
+
+    return models_for_export
+
+
+def _get_submodels_for_export_encoder_decoder(
+    model: Union["PreTrainedModel", "TFPreTrainedModel"], use_past: bool
+) -> Dict[str, Union["PreTrainedModel", "TFPreTrainedModel"]]:
+    """
+    Returns the encoder and decoder parts of the model.
+    """
+    models_for_export = {}
+
+    encoder_model = model.get_encoder()
+    models_for_export[ONNX_ENCODER_NAME] = encoder_model
+    models_for_export[ONNX_DECODER_NAME] = model
+    if use_past:
+        models_for_export[ONNX_DECODER_WITH_PAST_NAME] = model
+
+    return models_for_export
+
+
 def get_encoder_decoder_models_for_export(
     model: Union["PreTrainedModel", "TFPreTrainedModel"], config: "OnnxConfig"
 ) -> Dict[str, Tuple[Union["PreTrainedModel", "TFPreTrainedModel"], "OnnxConfig"]]:
@@ -110,18 +175,20 @@ def get_encoder_decoder_models_for_export(
         `Dict[str, Tuple[Union[`PreTrainedModel`, `TFPreTrainedModel`], `OnnxConfig`]: A Dict containing the model and
         onnx configs for the encoder and decoder parts of the model.
     """
-    models_for_export = {}
+    models_for_export = _get_submodels_for_export_encoder_decoder(model, use_past=config.use_past)
 
-    encoder_model = model.get_encoder()
     encoder_onnx_config = config.with_behavior("encoder")
-    models_for_export[ONNX_ENCODER_NAME] = (encoder_model, encoder_onnx_config)
+    models_for_export[ONNX_ENCODER_NAME] = (models_for_export[ONNX_ENCODER_NAME], encoder_onnx_config)
 
     decoder_onnx_config = config.with_behavior("decoder", use_past=False)
-    models_for_export[ONNX_DECODER_NAME] = (model, decoder_onnx_config)
+    models_for_export[ONNX_DECODER_NAME] = (models_for_export[ONNX_DECODER_NAME], decoder_onnx_config)
 
     if config.use_past:
         decoder_onnx_config_with_past = config.with_behavior("decoder", use_past=True)
-        models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (model, decoder_onnx_config_with_past)
+        models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (
+            models_for_export[ONNX_DECODER_WITH_PAST_NAME],
+            decoder_onnx_config_with_past,
+        )
 
     return models_for_export
 
@@ -148,16 +215,19 @@ def get_decoder_models_for_export(
         `Dict[str, Tuple[Union[PreTrainedModel, TFPreTrainedModel], OnnxConfig]]: A Dict containing the model and
         onnx configs for the encoder and decoder parts of the model.
     """
-    models_for_export = {}
+    models_for_export = _get_submodels_for_export_decoder(model, use_past=config.use_past)
 
     onnx_config = config.__class__(
         model.config, task=config.task, use_past_in_inputs=False, use_present_in_outputs=True
     )
-    models_for_export[ONNX_DECODER_NAME] = (model, onnx_config)
+    models_for_export[ONNX_DECODER_NAME] = (models_for_export[ONNX_DECODER_NAME], onnx_config)
 
     if config.use_past:
         onnx_config_with_past = config.__class__(model.config, task=config.task, use_past=True)
-        models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (model, onnx_config_with_past)
+        models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (
+            models_for_export[ONNX_DECODER_WITH_PAST_NAME],
+            onnx_config_with_past,
+        )
 
     return models_for_export
 
@@ -176,30 +246,24 @@ def get_stable_diffusion_models_for_export(
         `Dict[str, Tuple[Union[`PreTrainedModel`, `TFPreTrainedModel`], `OnnxConfig`]: A Dict containing the model and
         onnx configs for the different components of the model.
     """
-    models_for_export = {}
+    models_for_export = _get_submodels_for_export_stable_diffusion(pipeline)
 
     # Text encoder
     text_encoder_config_constructor = TasksManager.get_exporter_config_constructor(
         model=pipeline.text_encoder, exporter="onnx", task="feature-extraction"
     )
     text_encoder_onnx_config = text_encoder_config_constructor(pipeline.text_encoder.config)
-    models_for_export["text_encoder"] = (pipeline.text_encoder, text_encoder_onnx_config)
+    models_for_export["text_encoder"] = (models_for_export["text_encoder"], text_encoder_onnx_config)
 
     # U-NET
     onnx_config_constructor = TasksManager.get_exporter_config_constructor(
         model=pipeline.unet, exporter="onnx", task="semantic-segmentation", model_type="unet"
     )
     unet_onnx_config = onnx_config_constructor(pipeline.unet.config)
-
-    # PyTorch does not support the ONNX export of torch.nn.functional.scaled_dot_product_attention
-    pipeline.unet.set_attn_processor(AttnProcessor())
-    models_for_export["unet"] = (pipeline.unet, unet_onnx_config)
+    models_for_export["unet"] = (models_for_export["unet"], unet_onnx_config)
 
     # VAE Encoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L565
-    vae_encoder = copy.deepcopy(pipeline.vae)
-    if not packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0"):
-        vae_encoder = override_diffusers_2_0_attn_processors(vae_encoder)
-    vae_encoder.forward = lambda sample: {"latent_sample": vae_encoder.encode(x=sample)["latent_dist"].sample()}
+    vae_encoder = models_for_export["vae_encoder"]
     vae_config_constructor = TasksManager.get_exporter_config_constructor(
         model=vae_encoder, exporter="onnx", task="semantic-segmentation", model_type="vae-encoder"
     )
@@ -207,10 +271,7 @@ def get_stable_diffusion_models_for_export(
     models_for_export["vae_encoder"] = (vae_encoder, vae_onnx_config)
 
     # VAE Decoder https://github.com/huggingface/diffusers/blob/v0.11.1/src/diffusers/models/vae.py#L600
-    vae_decoder = copy.deepcopy(pipeline.vae)
-    if not packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0"):
-        vae_decoder = override_diffusers_2_0_attn_processors(vae_decoder)
-    vae_decoder.forward = lambda latent_sample: vae_decoder.decode(z=latent_sample)
+    vae_decoder = models_for_export["vae_decoder"]
     vae_config_constructor = TasksManager.get_exporter_config_constructor(
         model=vae_decoder, exporter="onnx", task="semantic-segmentation", model_type="vae-decoder"
     )

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -232,6 +232,16 @@ class TasksManager:
         ("pt", "vision-encoder-decoder", "document-question-answering"): ("transformers", "VisionEncoderDecoderModel"),
     }
 
+    # TODO: why feature-extraction-with-past is here?
+    _ENCODER_DECODER_TASKS = (
+        "text2text-generation",
+        "automatic-speech-recognition",
+        "image-to-text",
+        "feature-extraction-with-past",
+        "visual-question-answering",
+        "document-question-answering",
+    )
+
     _TASKS_TO_LIBRARY = {
         "conversational": "transformers",
         "document-question-answering": "transformers",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -771,7 +771,7 @@ class TasksManager:
             tflite="RoFormerTFLiteConfig",
         ),
         "sam": supported_tasks_mapping(
-            "mask-generation",
+            "feature-extraction",
             onnx="SamOnnxConfig",
         ),
         "segformer": supported_tasks_mapping(

--- a/optimum/utils/save_utils.py
+++ b/optimum/utils/save_utils.py
@@ -24,26 +24,41 @@ from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
 logger = logging.getLogger(__name__)
 
 
-def maybe_load_preprocessors(src_name_or_path: Union[str, Path], subfolder: str = "") -> List:
+def maybe_load_preprocessors(
+    src_name_or_path: Union[str, Path], subfolder: str = "", trust_remote_code: bool = False
+) -> List:
     preprocessors = []
     try:
-        preprocessors.append(AutoTokenizer.from_pretrained(src_name_or_path, subfolder=subfolder))
+        preprocessors.append(
+            AutoTokenizer.from_pretrained(src_name_or_path, subfolder=subfolder, trust_remote_code=trust_remote_code)
+        )
     except Exception:
         pass
 
     try:
-        preprocessors.append(AutoProcessor.from_pretrained(src_name_or_path, subfolder=subfolder))
+        preprocessors.append(
+            AutoProcessor.from_pretrained(src_name_or_path, subfolder=subfolder, trust_remote_code=trust_remote_code)
+        )
     except Exception:
         pass
 
     try:
-        preprocessors.append(AutoFeatureExtractor.from_pretrained(src_name_or_path, subfolder=subfolder))
+        preprocessors.append(
+            AutoFeatureExtractor.from_pretrained(
+                src_name_or_path, subfolder=subfolder, trust_remote_code=trust_remote_code
+            )
+        )
     except Exception:
         pass
     return preprocessors
 
 
-def maybe_save_preprocessors(src_name_or_path: Union[str, Path], dest_dir: Union[str, Path], src_subfolder: str = ""):
+def maybe_save_preprocessors(
+    src_name_or_path: Union[str, Path],
+    dest_dir: Union[str, Path],
+    src_subfolder: str = "",
+    trust_remote_code: bool = False,
+):
     """
     Saves the tokenizer, the processor and the feature extractor when found in `src_dir` in `dest_dir`.
 
@@ -55,10 +70,14 @@ def maybe_save_preprocessors(src_name_or_path: Union[str, Path], dest_dir: Union
         src_subfolder (`str`, defaults to `""`):
             In case the preprocessor files are located inside a subfolder of the model directory / repo on the Hugging
             Face Hub, you can specify the subfolder name here.
+        trust_remote_code (`bool`, defaults to `False`):
+            Whether to allow to save preprocessors that is allowed to run arbitrary code. Use this option at your own risk.
     """
     if not isinstance(dest_dir, Path):
         dest_dir = Path(dest_dir)
 
     dest_dir.mkdir(exist_ok=True)
-    for preprocessor in maybe_load_preprocessors(src_name_or_path, subfolder=src_subfolder):
+    for preprocessor in maybe_load_preprocessors(
+        src_name_or_path, subfolder=src_subfolder, trust_remote_code=trust_remote_code
+    ):
         preprocessor.save_pretrained(dest_dir)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ TESTS_REQUIRE = [
     "torchvision",
     "diffusers>=0.17.0",
     "torchaudio",
+    "einops",
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff>=0.0.241,<=0.0.259"]

--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -38,8 +38,9 @@ from optimum.exporters.onnx import (
 )
 from optimum.exporters.onnx.__main__ import main_export
 from optimum.exporters.onnx.base import ConfigBehavior
+from optimum.exporters.onnx.config import TextDecoderOnnxConfig
 from optimum.exporters.onnx.model_configs import WhisperOnnxConfig
-from optimum.utils import is_diffusers_available
+from optimum.utils import DummyPastKeyValuesGenerator, NormalizedTextConfig, is_diffusers_available
 from optimum.utils.testing_utils import grid_parameters, require_diffusers
 
 from ..exporters_utils import (
@@ -443,8 +444,70 @@ class CustomWhisperOnnxConfig(WhisperOnnxConfig):
             return {}
 
 
+class MPTDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
+    """
+    MPT swaps the two last dimensions for the key cache compared to usual transformers
+    decoder models, thus the redefinition here.
+    """
+
+    def generate(self, input_name: str, framework: str = "pt"):
+        past_key_shape = (
+            self.batch_size,
+            self.num_attention_heads,
+            self.hidden_size // self.num_attention_heads,
+            self.sequence_length,
+        )
+        past_value_shape = (
+            self.batch_size,
+            self.num_attention_heads,
+            self.sequence_length,
+            self.hidden_size // self.num_attention_heads,
+        )
+        return [
+            (
+                self.random_float_tensor(past_key_shape, framework=framework),
+                self.random_float_tensor(past_value_shape, framework=framework),
+            )
+            for _ in range(self.num_layers)
+        ]
+
+
+class CustomMPTOnnxConfig(TextDecoderOnnxConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        MPTDummyPastKeyValuesGenerator,
+    ) + TextDecoderOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES
+    DUMMY_PKV_GENERATOR_CLASS = MPTDummyPastKeyValuesGenerator
+
+    DEFAULT_ONNX_OPSET = 14  # aten::tril operator requires opset>=14
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
+        hidden_size="d_model", num_layers="n_layers", num_attention_heads="n_heads"
+    )
+
+    def add_past_key_values(self, inputs_or_outputs: Dict[str, Dict[int, str]], direction: str):
+        """
+        Adapted from https://github.com/huggingface/optimum/blob/v1.9.0/optimum/exporters/onnx/base.py#L625
+        """
+        if direction not in ["inputs", "outputs"]:
+            raise ValueError(f'direction must either be "inputs" or "outputs", but {direction} was given')
+
+        if direction == "inputs":
+            decoder_sequence_name = "past_sequence_length"
+            name = "past_key_values"
+        else:
+            decoder_sequence_name = "past_sequence_length + 1"
+            name = "present"
+
+        for i in range(self._normalized_config.num_layers):
+            inputs_or_outputs[f"{name}.{i}.key"] = {0: "batch_size", 3: decoder_sequence_name}
+            inputs_or_outputs[f"{name}.{i}.value"] = {0: "batch_size", 2: decoder_sequence_name}
+
+
+def fn_get_submodels_custom(model):
+    return {"decoder_model": model, "decoder_with_past_model": model}
+
+
 class OnnxCustomExport(TestCase):
-    def test_custom_export(self):
+    def test_custom_export_official_model(self):
         model_id = "openai/whisper-tiny.en"
         config = AutoConfig.from_pretrained(model_id)
 
@@ -477,3 +540,32 @@ class OnnxCustomExport(TestCase):
             output_names = [outp.name for outp in model.graph.output]
             assert "decoder_attentions.0" in output_names
             assert "cross_attentions.0" in output_names
+
+    @parameterized.expand([(None,), (fn_get_submodels_custom,)])
+    def test_custom_export_trust_remote(self, fn_get_submodels):
+        model_id = "fxmarty/tiny-mpt-random-remote-code"
+        config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
+
+        onnx_config = CustomMPTOnnxConfig(
+            config=config,
+            task="text-generation",
+            use_past_in_inputs=False,
+            use_present_in_outputs=True,
+        )
+        onnx_config_with_past = CustomMPTOnnxConfig(config, task="text-generation", use_past=True)
+
+        custom_onnx_configs = {
+            "decoder_model": onnx_config,
+            "decoder_with_past_model": onnx_config_with_past,
+        }
+
+        with TemporaryDirectory() as tmpdirname:
+            main_export(
+                model_id,
+                output=tmpdirname,
+                task="text-generation-with-past",
+                trust_remote_code=True,
+                custom_onnx_configs=custom_onnx_configs,
+                no_post_process=True,
+                fn_get_submodels=fn_get_submodels,
+            )

--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -569,3 +569,18 @@ class OnnxCustomExport(TestCase):
                 no_post_process=True,
                 fn_get_submodels=fn_get_submodels,
             )
+
+    def test_custom_export_trust_remote_error(self):
+        model_id = "fxmarty/tiny-mpt-random-remote-code"
+
+        with self.assertRaises(ValueError) as context:
+            with TemporaryDirectory() as tmpdirname:
+                main_export(
+                    model_id,
+                    output=tmpdirname,
+                    task="text-generation-with-past",
+                    trust_remote_code=True,
+                    no_post_process=True,
+                )
+
+        self.assertIn("export a model with a custom architecture, but no custom onnx", str(context.exception))


### PR DESCRIPTION
As per title. As a next step, we should support loading an `onnx_config.py` file from the custom model repository and use it for the ONNX export, so that e.g. the CLI works as well.

Fixes https://github.com/huggingface/optimum/issues/1061 https://github.com/huggingface/optimum/issues/1040 https://github.com/huggingface/optimum/issues/1134