### PR TITLE
fix SD XL ONNX export for img2img task

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -171,7 +171,7 @@ class TasksManager:
             "audio-xvector": "AutoModelForAudioXVector",
             "image-to-text": "AutoModelForVision2Seq",
             "stable-diffusion": "StableDiffusionPipeline",
-            "stable-diffusion-xl": "StableDiffusionXLPipeline",
+            "stable-diffusion-xl": "StableDiffusionXLImg2ImgPipeline",
             "zero-shot-image-classification": "AutoModelForZeroShotImageClassification",
             "zero-shot-object-detection": "AutoModelForZeroShotObjectDetection",
         }

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -28,7 +28,7 @@ from diffusers import (
     LMSDiscreteScheduler,
     PNDMScheduler,
     StableDiffusionPipeline,
-    StableDiffusionXLPipeline,
+    StableDiffusionXLImg2ImgPipeline,
 )
 from diffusers.schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
 from diffusers.utils import CONFIG_NAME
@@ -547,7 +547,7 @@ class ORTStableDiffusionInpaintPipeline(ORTStableDiffusionPipelineBase, StableDi
 
 
 class ORTStableDiffusionXLPipelineBase(ORTStableDiffusionPipelineBase):
-    auto_model_class = StableDiffusionXLPipeline
+    auto_model_class = StableDiffusionXLImg2ImgPipeline
 
     def __init__(
         self,

--- a/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
+++ b/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py
@@ -159,7 +159,7 @@ class StableDiffusionXLImg2ImgPipelineMixin(DiffusionPipelineMixin):
                 # Here we concatenate the unconditional and text embeddings into a single batch
                 # to avoid doing two forward passes
                 negative_prompt_embeds_list.append(negative_prompt_embeds)
-            negative_prompt_embeds = np.concatenate(negative_prompt_embeds, axis=-1)
+            negative_prompt_embeds = np.concatenate(negative_prompt_embeds_list, axis=-1)
 
         pooled_prompt_embeds = np.repeat(pooled_prompt_embeds, num_images_per_prompt, axis=0)
         negative_pooled_prompt_embeds = np.repeat(negative_pooled_prompt_embeds, num_images_per_prompt, axis=0)

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -622,6 +622,7 @@ class DummyTimestepInputGenerator(DummyInputGenerator):
         self.task = task
         self.vocab_size = normalized_config.vocab_size
         self.text_encoder_projection_dim = normalized_config.text_encoder_projection_dim
+        self.time_ids = 5 if normalized_config.requires_aesthetics_score else 6
         if random_batch_size_range:
             low, high = random_batch_size_range
             self.batch_size = random.randint(low, high)
@@ -634,7 +635,7 @@ class DummyTimestepInputGenerator(DummyInputGenerator):
         if input_name == "timestep":
             return self.random_int_tensor(shape, max_value=self.vocab_size, framework=framework)
 
-        shape.append(self.text_encoder_projection_dim if input_name == "text_embeds" else 6)
+        shape.append(self.text_encoder_projection_dim if input_name == "text_embeds" else self.time_ids)
         return self.random_float_tensor(shape, max_value=self.vocab_size, framework=framework)
 
 


### PR DESCRIPTION
In this PR we use `StableDiffusionXLImg2ImgPipeline` to load a SD XL pipeline by default before exporting each component as it will allow some components to be [optional](https://github.com/huggingface/diffusers/blob/v0.18.2/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py#L111) during loading.
Depending on the value of `requires_aesthetics_score` we create a dummy input of the corresponding expected shape https://github.com/huggingface/diffusers/blob/v0.18.2/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py#L571 when exporting the U-NET component