### PR TITLE
fix(type): correct BetterTransformer annotations

### DIFF
--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -169,7 +169,7 @@ def set_last_layer(model: torch.nn.Module):
     )
 
 
-class BetterTransformer(object):
+class BetterTransformer:
     r"""
     A conversion wrapper that takes as an input the `transformers` model to be converted
     and returns the converted `BetterTransformer` model. The `BetterTransformer` model is based on the `BetterTransformer`
@@ -179,6 +179,7 @@ class BetterTransformer(object):
     # Original PR from: https://github.com/huggingface/transformers/pull/19553 adapted and wrapped in this script.
     """
 
+    @staticmethod
     @check_if_pytorch_greater(
         "1.13.0",
         "Please upgrade PyTorch following https://pytorch.org/get-started/locally/ in order to use BetterTransformer.",
@@ -308,6 +309,7 @@ class BetterTransformer(object):
 
         return model_fast
 
+    @staticmethod
     def reverse(bt_model: "PreTrainedModel") -> "PreTrainedModel":
         """
         Converts back a model using BetterTransformer to its canonical transformers modeling implementation, in order to save

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
     author_email="hardware@huggingface.co",
     license="Apache",
     packages=find_namespace_packages(include=["optimum*"]),
+    package_data={"optimum": ["py.typed"]},
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS_REQUIRE,
     python_requires=">=3.7.0",


### PR DESCRIPTION
`reverse` and `transforms` should be staticmethod, as BetterTransformer

functions as a mixin

Additionally, since optimum does annotate its function, I added `py.typed` to make `optimum` PEP561 compatible, such that static type checker can infer types correctly without the hassle of generating stubs.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

