### PR TITLE
BetterTransformer support training & autocast for all archs

### DIFF
--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -148,23 +148,6 @@ class BetterTransformerManager:
         "t5",
     }
 
-    REQUIRES_TORCH_20 = {
-        "blenderbot",
-        "bart",
-        "codegen",
-        "gpt2",
-        "gptj",
-        "gpt_neo",
-        "gpt_neox",
-        "llama",
-        "m2m_100",
-        "marian",
-        "mbart",
-        "opt",
-        "pegasus",
-        "t5",
-    }
-
     @staticmethod
     def cannot_support(model_type: str) -> bool:
         """
@@ -208,17 +191,6 @@ class BetterTransformerManager:
                 The model type to check.
         """
         return model_type not in BetterTransformerManager.NOT_REQUIRES_STRICT_VALIDATION
-
-    @staticmethod
-    def requires_torch_20(model_type: str) -> bool:
-        """
-        Returns True if the architecture requires PyTorch 2.0 to be used with BetterTransformer.
-
-        Args:
-            model_type (`str`):
-                The model type to check.
-        """
-        return model_type in BetterTransformerManager.REQUIRES_TORCH_20
 
 
 class warn_uncompatible_save(object):

--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -148,6 +148,19 @@ class BetterTransformerManager:
         "t5",
     }
 
+    DO_NOT_SUPPORT_PADDED_TRAINING = {
+        "blenderbot",
+        "codegen",
+        "gpt2",
+        "gptj",
+        "gpt_neo",
+        "gpt_neox",
+        "llama",
+        "opt",
+        "pegasus",
+        "t5",
+    }
+
     @staticmethod
     def cannot_support(model_type: str) -> bool:
         """

--- a/optimum/bettertransformer/models/base.py
+++ b/optimum/bettertransformer/models/base.py
@@ -55,7 +55,6 @@ class BetterTransformerBaseLayer:
         self.num_layers = None
         self.original_layers_mapping = {}
         self.module_mapping = None
-        self.supports_training = False
         # Some models does not have some attributes thus needs to be ignored
         # e.g. whisper does not have self_attn.k_proj.bias but has self_attn.v_proj.bias & self_attn.q_proj.bias
         self.keys_to_ignore = []
@@ -125,16 +124,6 @@ class BetterTransformerBaseLayer:
                 f"Number of heads {self.num_heads} is not supported"
                 " for `BetterTransformer` integration."
                 f" Number of heads must be even."
-            )
-
-    def forward_checker(self, *args, **kwargs):
-        if torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled():
-            raise ValueError("Autocast is not supported for `BetterTransformer` integration.")
-
-        if self.training and not self.supports_training:
-            raise ValueError(
-                "Training is not supported for `BetterTransformer` integration.",
-                " Please use `model.eval()` before running the model.",
             )
 
     def _revert(self, module: torch.nn.Module) -> torch.nn.Module:

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -65,12 +65,10 @@ class GPT2AttentionLayerBetterTransformer(BetterTransformerBaseLayer, GPT2Attent
             setattr(self, "q_attn", getattr(layer, "q_attn"))
             self.original_layers_mapping["q_attn"] = "q_attn"
 
-        self.supports_training = True
         self.downcast_qk = False
         self.dropout_prob_attn = config.attn_pdrop
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return super().forward(*args, **kwargs)
 
 
@@ -105,11 +103,9 @@ class GPTJAttentionLayerBetterTransformer(BetterTransformerBaseLayer, GPTJAttent
         self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
         self.downcast_qk = True
-        self.supports_training = True
         self.dropout_prob_attn = config.attn_pdrop
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return super().forward(*args, **kwargs)
 
 
@@ -129,11 +125,9 @@ class GPTNeoXAttentionLayerBetterTransformer(BetterTransformerBaseLayer, GPTNeoX
         self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
         self.downcast_qk = True
-        self.supports_training = True
         self.dropout_prob_attn = 0.0  # no dropout for gpt-neox
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return super().forward(*args, **kwargs)
 
 
@@ -159,11 +153,9 @@ class GPTNeoAttentionLayerBetterTransformer(BetterTransformerBaseLayer, GPTNeoSe
         self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
         self.scale = torch.sqrt(torch.tensor(layer.head_dim, dtype=torch.float32)).to(torch.get_default_dtype())
-        self.supports_training = True
         self.dropout_prob_attn = float(config.attention_dropout)
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return super().forward(*args, **kwargs)
 
 
@@ -188,11 +180,9 @@ class CodegenAttentionLayerBetterTransformer(BetterTransformerBaseLayer, CodeGen
 
         self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
-        self.supports_training = True
         self.dropout_prob_attn = config.attn_pdrop
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return super().forward(*args, **kwargs)
 
 
@@ -218,10 +208,7 @@ class OPTAttentionLayerBetterTransformer(BetterTransformerBaseLayer, OPTAttentio
 
         self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
-        self.supports_training = True
-
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return opt_forward(self, *args, **kwargs)
 
 
@@ -249,11 +236,9 @@ class T5AttentionLayerBetterTransformer(BetterTransformerBaseLayer, T5Attention,
 
         self.module_mapping = None
 
-        self.supports_training = True
         self.is_decoder = layer.is_decoder
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return t5_forward(self, *args, **kwargs)
 
 
@@ -274,7 +259,6 @@ def bart_bettertransformer_init(self, layer: "nn.Module", config: "PretrainedCon
 
     self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
-    self.supports_training = True
     self.is_decoder = layer.is_decoder
 
 
@@ -284,7 +268,6 @@ class BartAttentionLayerBetterTransformer(BetterTransformerBaseLayer, BartAttent
         bart_bettertransformer_init(self, layer, config)
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return bart_forward(self, *args, **kwargs)
 
 
@@ -294,7 +277,6 @@ class BlenderbotAttentionLayerBetterTransformer(BetterTransformerBaseLayer, Blen
         bart_bettertransformer_init(self, layer, config)
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return bart_forward(self, *args, **kwargs)
 
 
@@ -304,7 +286,6 @@ class M2M100AttentionLayerBetterTransformer(BetterTransformerBaseLayer, M2M100At
         bart_bettertransformer_init(self, layer, config)
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return bart_forward(self, *args, **kwargs)
 
 
@@ -314,7 +295,6 @@ class MarianAttentionLayerBetterTransformer(BetterTransformerBaseLayer, MarianAt
         bart_bettertransformer_init(self, layer, config)
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return bart_forward(self, *args, **kwargs)
 
 
@@ -323,7 +303,6 @@ class PegasusAttentionLayerBetterTransformer(BetterTransformerBaseLayer, Pegasus
         bart_bettertransformer_init(self, layer, config)
 
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return bart_forward(self, *args, **kwargs)
 
 
@@ -339,8 +318,5 @@ class LlamaAttentionLayerBetterTransformer(BetterTransformerBaseLayer, LlamaAtte
 
         self.original_layers_mapping = {submodule: submodule for submodule in submodules}
 
-        self.supports_training = True
-
     def forward(self, *args, **kwargs):
-        super().forward_checker()
         return llama_forward(self, *args, **kwargs)

--- a/optimum/bettertransformer/models/decoder_models.py
+++ b/optimum/bettertransformer/models/decoder_models.py
@@ -72,7 +72,6 @@ class GPT2AttentionLayerBetterTransformer(BetterTransformerBaseLayer, GPT2Attent
         return super().forward(*args, **kwargs)
 
 
-# TODO: validate
 class GPTJAttentionLayerBetterTransformer(BetterTransformerBaseLayer, GPTJAttention, nn.Module):
     _attn = gpt2_wrapped_scaled_dot_product
 

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -145,7 +145,6 @@ class AlbertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             if hidden_states.is_nested and self.is_last_layer:
                 hidden_states = hidden_states.to_padded_tensor(0.0)
         else:
-            # TODO: check dropout
             qkv = F.linear(hidden_states, weight=self.in_proj_weight, bias=self.in_proj_bias)
 
             qkv = qkv.view(qkv.size()[:-1] + (3, self.num_heads, self.attention_head_size)).permute(2, 0, 3, 1, 4)
@@ -279,8 +278,6 @@ class BertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             "norm2_weight": "output.LayerNorm.weight",
             "norm2_bias": "output.LayerNorm.bias",
         }
-
-        # TODO: cleaner solution
         self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
         self.hidden_dropout_prob = config.hidden_dropout_prob
         self.attention_probs_dropout_prob = config.attention_probs_dropout_prob
@@ -877,7 +874,6 @@ class DistilBertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             if hidden_states.is_nested and self.is_last_layer:
                 hidden_states = hidden_states.to_padded_tensor(0.0)
         else:
-            # TODO: check dropout
             qkv = F.linear(hidden_states, weight=self.in_proj_weight, bias=self.in_proj_bias)
 
             qkv = qkv.view(qkv.size()[:-1] + (3, self.num_heads, self.attention_head_size)).permute(2, 0, 3, 1, 4)
@@ -1041,7 +1037,9 @@ class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module
             if hidden_states.is_nested and self.is_last_layer:
                 hidden_states = hidden_states.to_padded_tensor(0.0)
         else:
-            raise NotImplementedError("TODO")
+            raise NotImplementedError(
+                "Training and Autocast are not implemented for BetterTransformer + Whisper. Please open an issue."
+            )
         return (hidden_states,)
 
 
@@ -1159,7 +1157,9 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             if hidden_states.is_nested and self.is_last_layer:
                 hidden_states = hidden_states.to_padded_tensor(0.0)
         else:
-            raise NotImplementedError("TODO")
+            raise NotImplementedError(
+                "Training and Autocast are not implemented for BetterTransformer + ViT. Please open an issue."
+            )
         return (hidden_states,)
 
 
@@ -1277,7 +1277,9 @@ class ViltLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             if hidden_states.is_nested and self.is_last_layer:
                 hidden_states = hidden_states.to_padded_tensor(0.0)
         else:
-            raise NotImplementedError("TODO")
+            raise NotImplementedError(
+                "Training and Autocast are not implemented for BetterTransformer + Vilt. Please open an issue."
+            )
         return (hidden_states,)
 
 
@@ -1402,7 +1404,9 @@ class Wav2Vec2EncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Modul
             if hidden_states.is_nested and self.is_last_layer:
                 hidden_states = hidden_states.to_padded_tensor(0.0)
         else:
-            raise NotImplementedError("TODO")
+            raise NotImplementedError(
+                "Training and Autocast are not implemented for BetterTransformer + Wav2Vec2. Please open an issue."
+            )
         return (hidden_states,)
 
 
@@ -1788,7 +1792,9 @@ class CLIPLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
                 attention_mask,
             )
         else:
-            raise NotImplementedError("TODO")
+            NotImplementedError(
+                "Training and Autocast are not implemented for BetterTransformer + CLIP. Please open an issue."
+            )
 
         return (hidden_states,)
 

--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import ACT2FN
 
 from .base import BetterTransformerBaseLayer
 
@@ -99,50 +101,109 @@ class AlbertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             "norm2_weight": "full_layer_layer_norm.weight",
             "norm2_bias": "full_layer_layer_norm.bias",
         }
+        self.attention_head_size = config.hidden_size // config.num_attention_heads
+        self.attention_probs_dropout_prob = config.attention_probs_dropout_prob
+        self.hidden_dropout_prob = config.hidden_dropout_prob
 
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, *_):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if hidden_states.is_nested:
+                attention_mask = None
 
-        if hidden_states.is_nested:
-            attention_mask = None
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                attention_mask = attention_mask.bool()
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
 
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            attention_mask = attention_mask.bool()
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            # TODO: check dropout
+            qkv = F.linear(hidden_states, weight=self.in_proj_weight, bias=self.in_proj_bias)
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0)
+            qkv = qkv.view(qkv.size()[:-1] + (3, self.num_heads, self.attention_head_size)).permute(2, 0, 3, 1, 4)
+            query, key, value = qkv[0], qkv[1], qkv[2]
+
+            # TODO: pass scale argument in PyTorch 2.1 release
+            query = (
+                query
+                * torch.sqrt(torch.tensor(query.shape[-1], dtype=torch.float32)).to(torch.get_default_dtype())
+                / 8
+            )
+
+            # NOTE: In PyTorch 2.0, passing an attention_mask will automatically dispatch
+            # to the "math" path and will NOT use flash attention / memory-efficient attention.
+            # We should support xformers / Hazy-flash / rocm-flash directly and stop relying on PyTorch to do the work.
+            attention_out = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attention_mask,
+                is_causal=False,
+                dropout_p=self.attention_probs_dropout_prob if self.training else 0.0,
+            )
+
+            attention_out = attention_out.permute(0, 2, 1, 3).contiguous()
+            new_attention_out_shape = attention_out.size()[:-2] + (self.num_heads * self.attention_head_size,)
+            attention_out = attention_out.view(new_attention_out_shape)
+
+            # BertSelfOutput
+            attention_out = F.layer_norm(
+                F.dropout(
+                    F.linear(attention_out, self.out_proj_weight, self.out_proj_bias),
+                    p=self.hidden_dropout_prob,
+                    training=self.training,
+                )
+                + hidden_states,
+                normalized_shape=self.norm1_weight.shape,  # TODO: stateful
+                weight=self.norm1_weight,
+                bias=self.norm1_bias,
+            )
+
+            # BertIntermediate
+            # TODO: stateful
+            act_fn = ACT2FN[self.act_fn]
+            x = act_fn(F.linear(attention_out, self.linear1_weight, self.linear1_bias))
+
+            # BertOutput
+            hidden_states = F.layer_norm(
+                attention_out
+                + F.dropout(
+                    F.linear(x, self.linear2_weight, self.linear2_bias),
+                    p=self.hidden_dropout_prob,
+                    training=self.training,
+                ),
+                normalized_shape=self.norm2_weight.shape,  # TODO: stateful
+                weight=self.norm2_weight,
+                bias=self.norm2_bias,
+            )
+
         return (hidden_states,)
 
 
@@ -227,49 +288,109 @@ class BertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             "norm2_bias": "output.LayerNorm.bias",
         }
 
+        # TODO: cleaner solution
+        self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
+        self.hidden_dropout_prob = config.hidden_dropout_prob
+        self.attention_probs_dropout_prob = config.attention_probs_dropout_prob
+
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, *_):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if hidden_states.is_nested:
+                attention_mask = None
 
-        if hidden_states.is_nested:
-            attention_mask = None
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                attention_mask = attention_mask.bool()
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
 
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            attention_mask = attention_mask.bool()
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            qkv = F.linear(hidden_states, weight=self.in_proj_weight, bias=self.in_proj_bias)
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0)
+            qkv = qkv.view(qkv.size()[:-1] + (3, self.num_heads, self.attention_head_size)).permute(2, 0, 3, 1, 4)
+            query, key, value = qkv[0], qkv[1], qkv[2]
+
+            # TODO: pass scale argument in PyTorch 2.1 release
+            query = (
+                query
+                * torch.sqrt(torch.tensor(query.shape[-1], dtype=torch.float32)).to(torch.get_default_dtype())
+                / 8
+            )
+
+            # NOTE: In PyTorch 2.0, passing an attention_mask will automatically dispatch
+            # to the "math" path and will NOT use flash attention / memory-efficient attention.
+            # We should support xformers / Hazy-flash / rocm-flash directly and stop relying on PyTorch to do the work.
+            attention_out = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attention_mask,
+                is_causal=False,
+                dropout_p=self.attention_probs_dropout_prob if self.training else 0.0,
+            )
+
+            attention_out = attention_out.permute(0, 2, 1, 3).contiguous()
+            new_attention_out_shape = attention_out.size()[:-2] + (self.num_heads * self.attention_head_size,)
+            attention_out = attention_out.view(new_attention_out_shape)
+
+            # BertSelfOutput
+            attention_out = F.layer_norm(
+                F.dropout(
+                    F.linear(attention_out, self.out_proj_weight, self.out_proj_bias),
+                    p=self.hidden_dropout_prob,
+                    training=self.training,
+                )
+                + hidden_states,
+                normalized_shape=self.norm1_weight.shape,  # TODO: stateful
+                weight=self.norm1_weight,
+                bias=self.norm1_bias,
+            )
+
+            # BertIntermediate
+            # TODO: stateful
+            act_fn = ACT2FN[self.act_fn]
+            x = act_fn(F.linear(attention_out, self.linear1_weight, self.linear1_bias))
+
+            # BertOutput
+            hidden_states = F.layer_norm(
+                attention_out
+                + F.dropout(
+                    F.linear(x, self.linear2_weight, self.linear2_bias),
+                    p=self.hidden_dropout_prob,
+                    training=self.training,
+                ),
+                normalized_shape=self.norm2_weight.shape,  # TODO: stateful
+                weight=self.norm2_weight,
+                bias=self.norm2_bias,
+            )
+
         return (hidden_states,)
 
 
@@ -354,56 +475,53 @@ class BartEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, position_bias=None, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if not hasattr(hidden_states, "original_shape"):
+                original_shape = hidden_states.shape
+            else:
+                original_shape = hidden_states.original_shape
 
-        if not hasattr(hidden_states, "original_shape"):
-            original_shape = hidden_states.shape
+            if hidden_states.is_nested:
+                attention_mask = None
+
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                if len(attention_mask.shape) == 4:
+                    attention_mask = attention_mask.squeeze(1)[:, 0]
+                attention_mask = attention_mask.bool()
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
+
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+
+            if not self.is_last_layer:
+                hidden_states.original_shape = original_shape
+            elif hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
         else:
-            original_shape = hidden_states.original_shape
-
-        if hidden_states.is_nested:
-            attention_mask = None
-
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            if len(attention_mask.shape) == 4:
-                attention_mask = attention_mask.squeeze(1)[:, 0]
-            attention_mask = attention_mask.bool()
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
-
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-
-        if not self.is_last_layer:
-            hidden_states.original_shape = original_shape
-        elif hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
+            raise NotImplementedError("TODO")
         return (hidden_states,)
 
 
@@ -492,56 +610,53 @@ class MBartEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, position_bias=None, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if not hasattr(hidden_states, "original_shape"):
+                original_shape = hidden_states.shape
+            else:
+                original_shape = hidden_states.original_shape
 
-        if not hasattr(hidden_states, "original_shape"):
-            original_shape = hidden_states.shape
+            if hidden_states.is_nested:
+                attention_mask = None
+
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                if len(attention_mask.shape) == 4:
+                    attention_mask = attention_mask.squeeze(1)[:, 0]
+                attention_mask = attention_mask.bool()
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
+
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+
+            if not self.is_last_layer:
+                hidden_states.original_shape = original_shape
+            elif hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
         else:
-            original_shape = hidden_states.original_shape
-
-        if hidden_states.is_nested:
-            attention_mask = None
-
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            if len(attention_mask.shape) == 4:
-                attention_mask = attention_mask.squeeze(1)[:, 0]
-            attention_mask = attention_mask.bool()
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
-
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-
-        if not self.is_last_layer:
-            hidden_states.original_shape = original_shape
-        elif hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
+            raise NotImplementedError("TODO")
         return (hidden_states,)
 
 
@@ -619,54 +734,114 @@ class DistilBertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
             "norm2_weight": "output_layer_norm.weight",
             "norm2_bias": "output_layer_norm.bias",
         }
+        self.attention_dropout = config.attention_dropout
+        self.dropout = config.dropout
+        self.attention_head_size = config.dim // config.n_heads
 
         self.validate_bettertransformer()
 
-    def forward(self, x, attn_mask, head_mask=None, output_attentions=None, *_):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+    def forward(self, hidden_states, attn_mask, head_mask=None, output_attentions=None, *_):
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if hidden_states.is_nested:
+                attn_mask = None
 
-        if x.is_nested:
-            attn_mask = None
+            if attn_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                attn_mask = attn_mask.bool()
+                attn_mask = torch.reshape(attn_mask, (attn_mask.shape[0], attn_mask.shape[-1]))
+                seqlen = attn_mask.shape[1]
+                lengths = torch.sum(~attn_mask, 1)
+                if not all(l == seqlen for l in lengths):
+                    hidden_states = torch._nested_tensor_from_mask(hidden_states, attn_mask)
+                attn_mask = None
 
-        if attn_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            attn_mask = attn_mask.bool()
-            attn_mask = torch.reshape(attn_mask, (attn_mask.shape[0], attn_mask.shape[-1]))
-            seqlen = attn_mask.shape[1]
-            lengths = torch.sum(~attn_mask, 1)
-            if not all(l == seqlen for l in lengths):
-                x = torch._nested_tensor_from_mask(x, attn_mask)
-            attn_mask = None
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attn_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            # TODO: check dropout
+            qkv = F.linear(hidden_states, weight=self.in_proj_weight, bias=self.in_proj_bias)
 
-        x = torch._transformer_encoder_layer_fwd(
-            x,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attn_mask,
-        )
-        if x.is_nested and self.is_last_layer:
-            x = x.to_padded_tensor(0.0)
-        return (x,)
+            qkv = qkv.view(qkv.size()[:-1] + (3, self.num_heads, self.attention_head_size)).permute(2, 0, 3, 1, 4)
+            query, key, value = qkv[0], qkv[1], qkv[2]
+
+            # TODO: pass scale argument in PyTorch 2.1 release
+            query = (
+                query
+                * torch.sqrt(torch.tensor(query.shape[-1], dtype=torch.float32)).to(torch.get_default_dtype())
+                / 8
+            )
+
+            # TODO: Kind of stupid to do that at each layer, should be fixed in transformers
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(2).to(dtype=query.dtype)
+            attn_mask = (1.0 - attn_mask) * torch.finfo(query.dtype).min
+
+            # NOTE: In PyTorch 2.0, passing an attention_mask will automatically dispatch
+            # to the "math" path and will NOT use flash attention / memory-efficient attention.
+            # We should support xformers / Hazy-flash / rocm-flash directly and stop relying on PyTorch to do the work.
+            attention_out = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                is_causal=False,
+                dropout_p=self.attention_dropout if self.training else 0.0,
+            )
+
+            attention_out = attention_out.permute(0, 2, 1, 3).contiguous()
+            new_attention_out_shape = attention_out.size()[:-2] + (self.num_heads * self.attention_head_size,)
+            attention_out = attention_out.view(new_attention_out_shape)
+
+            # BertSelfOutput
+            attention_out = F.layer_norm(
+                F.dropout(
+                    F.linear(attention_out, self.out_proj_weight, self.out_proj_bias),
+                    p=self.dropout,
+                    training=self.training,
+                )
+                + hidden_states,
+                normalized_shape=self.norm1_weight.shape,  # TODO: stateful
+                weight=self.norm1_weight,
+                bias=self.norm1_bias,
+            )
+
+            # BertIntermediate
+            # TODO: stateful
+            act_fn = ACT2FN[self.act_fn]
+            x = act_fn(F.linear(attention_out, self.linear1_weight, self.linear1_bias))
+
+            # BertOutput
+            hidden_states = F.layer_norm(
+                attention_out
+                + F.dropout(
+                    F.linear(x, self.linear2_weight, self.linear2_bias), p=self.dropout, training=self.training
+                ),
+                normalized_shape=self.norm2_weight.shape,  # TODO: stateful
+                weight=self.norm2_weight,
+                bias=self.norm2_bias,
+            )
+        return (hidden_states,)
 
 
 class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
@@ -749,36 +924,34 @@ class WhisperEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
-        attention_mask = None  # attention mask seems to be always None: https://github.com/huggingface/transformers/blob/94b3f544a1f5e04b78d87a2ae32a7ac252e22e31/src/transformers/models/whisper/modeling_whisper.py#L690
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            attention_mask = None  # attention mask seems to be always None: https://github.com/huggingface/transformers/blob/94b3f544a1f5e04b78d87a2ae32a7ac252e22e31/src/transformers/models/whisper/modeling_whisper.py#L690
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0)
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            raise NotImplementedError("TODO")
         return (hidden_states,)
 
 
@@ -869,36 +1042,34 @@ class ViTLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
-        attention_mask = None
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            attention_mask = None
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0)
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            raise NotImplementedError("TODO")
         return (hidden_states,)
 
 
@@ -989,36 +1160,34 @@ class ViltLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
-        attention_mask = None
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            attention_mask = None
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0)
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            raise NotImplementedError("TODO")
         return (hidden_states,)
 
 
@@ -1105,47 +1274,45 @@ class Wav2Vec2EncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Modul
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
-        if hidden_states.is_nested:
-            attention_mask = None
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if hidden_states.is_nested:
+                attention_mask = None
 
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            attention_mask = attention_mask.bool()
-            if len(attention_mask.shape) == 4:
-                attention_mask = attention_mask.squeeze(1)[:, 0]
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                attention_mask = attention_mask.bool()
+                if len(attention_mask.shape) == 4:
+                    attention_mask = attention_mask.squeeze(1)[:, 0]
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0)
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0)
+        else:
+            raise NotImplementedError("TODO")
         return (hidden_states,)
 
 
@@ -1227,61 +1394,59 @@ class FSMTEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, position_bias=None, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
-
-        if not hasattr(hidden_states, "original_shape"):
-            original_shape = hidden_states.shape
-        else:
-            original_shape = hidden_states.original_shape
-
-        if hidden_states.is_nested:
-            attention_mask = None
-
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            attention_mask = attention_mask.bool()
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-
-            # FSMT swaps the first two axis before calling the encoder stack
-            # Reference: https://github.com/huggingface/transformers/blob/699e90437f984d69ad3c9b891dd2e9d0fc2cffe4/src/transformers/models/fsmt/modeling_fsmt.py#L508
-            if hidden_states.shape[0] != attention_mask.shape[0]:
-                hidden_states = hidden_states.transpose(1, 0)
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if not hasattr(hidden_states, "original_shape"):
                 original_shape = hidden_states.shape
+            else:
+                original_shape = hidden_states.original_shape
 
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
+            if hidden_states.is_nested:
+                attention_mask = None
 
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                attention_mask = attention_mask.bool()
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
 
-        if not self.is_last_layer:
-            hidden_states.original_shape = original_shape
-        elif hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
+                # FSMT swaps the first two axis before calling the encoder stack
+                # Reference: https://github.com/huggingface/transformers/blob/699e90437f984d69ad3c9b891dd2e9d0fc2cffe4/src/transformers/models/fsmt/modeling_fsmt.py#L508
+                if hidden_states.shape[0] != attention_mask.shape[0]:
+                    hidden_states = hidden_states.transpose(1, 0)
+                    original_shape = hidden_states.shape
+
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
+
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+
+            if not self.is_last_layer:
+                hidden_states.original_shape = original_shape
+            elif hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
+        else:
+            raise ValueError("Training and Autocast are not supported for BetterTransformer + FSMT.")
+
         return (hidden_states, attention_mask)
 
 
@@ -1368,54 +1533,52 @@ class ProphetNetEncoderLayerBetterTransformer(BetterTransformerBaseLayer, nn.Mod
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            if not hasattr(hidden_states, "original_shape"):
+                original_shape = hidden_states.shape
+            else:
+                original_shape = hidden_states.original_shape
 
-        if not hasattr(hidden_states, "original_shape"):
-            original_shape = hidden_states.shape
+            if hidden_states.is_nested:
+                attention_mask = None
+
+            if attention_mask is not None:
+                # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
+                # 0->false->keep this token -inf->true->mask this token
+                attention_mask = attention_mask.squeeze(1)[:, 0]
+                attention_mask = attention_mask.bool()
+                attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+                hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
+                attention_mask = None
+
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
+            )
+            if not self.is_last_layer:
+                hidden_states.original_shape = original_shape
+            elif hidden_states.is_nested and self.is_last_layer:
+                hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
         else:
-            original_shape = hidden_states.original_shape
+            raise ValueError("Training and Autocast are not supported for BetterTransformer + ProphetNet.")
 
-        if hidden_states.is_nested:
-            attention_mask = None
-
-        if attention_mask is not None:
-            # attention mask comes in with values 0 and -inf. we convert to torch.nn.TransformerEncoder style bool mask
-            # 0->false->keep this token -inf->true->mask this token
-            attention_mask = attention_mask.squeeze(1)[:, 0]
-            attention_mask = attention_mask.bool()
-            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            hidden_states = torch._nested_tensor_from_mask(hidden_states, ~attention_mask)
-            attention_mask = None
-
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
-        if not self.is_last_layer:
-            hidden_states.original_shape = original_shape
-        elif hidden_states.is_nested and self.is_last_layer:
-            hidden_states = hidden_states.to_padded_tensor(0.0, original_shape)
         return (hidden_states,)
 
 
@@ -1502,39 +1665,36 @@ class CLIPLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
         self.validate_bettertransformer()
 
     def forward(self, hidden_states, attention_mask, *_, **__):
-        r"""
-        This is just a wrapper around the forward function proposed in:
-        https://github.com/huggingface/transformers/pull/19553
-        """
-        super().forward_checker()
+        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+            # we expect attention_mask to be None in the vision model
+            if attention_mask is not None:
+                raise ValueError(
+                    "Please do not use attention masks when using `BetterTransformer` converted vision models"
+                )
 
-        # we expect attention_mask to be None in the vision model
-        if attention_mask is not None:
-            raise ValueError(
-                "Please do not use attention masks when using `BetterTransformer` converted vision models"
+            hidden_states = torch._transformer_encoder_layer_fwd(
+                hidden_states,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.out_proj_weight,
+                self.out_proj_bias,
+                self.use_gelu,
+                self.norm_first,
+                self.norm1_eps,
+                self.norm1_weight,
+                self.norm1_bias,
+                self.norm2_weight,
+                self.norm2_bias,
+                self.linear1_weight,
+                self.linear1_bias,
+                self.linear2_weight,
+                self.linear2_bias,
+                attention_mask,
             )
-
-        hidden_states = torch._transformer_encoder_layer_fwd(
-            hidden_states,
-            self.embed_dim,
-            self.num_heads,
-            self.in_proj_weight,
-            self.in_proj_bias,
-            self.out_proj_weight,
-            self.out_proj_bias,
-            self.use_gelu,
-            self.norm_first,
-            self.norm1_eps,
-            self.norm1_weight,
-            self.norm1_bias,
-            self.norm2_weight,
-            self.norm2_bias,
-            self.linear1_weight,
-            self.linear1_bias,
-            self.linear2_weight,
-            self.linear2_bias,
-            attention_mask,
-        )
+        else:
+            raise NotImplementedError("TODO")
 
         return (hidden_states,)
 

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -255,9 +255,9 @@ class BetterTransformer(object):
                     " `keep_original_model=False` and create a new copy of the original"
                     " model somewhere else."
                 )
-            model_fast = replace_to_bettertransformer(model_fast, hf_config).eval()
+            model_fast = replace_to_bettertransformer(model_fast, hf_config)
         else:
-            model_fast = replace_to_bettertransformer(model, hf_config).eval()
+            model_fast = replace_to_bettertransformer(model, hf_config)
             model = None
 
         if BetterTransformerManager.requires_nested_tensor(model_fast.config.model_type):

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -288,7 +288,7 @@ class BetterTransformer(object):
 
         # See: https://github.com/pytorch/pytorch/issues/96099
         # TODO: show the warning only for decoders (which do not need an attention mask for training)
-        if BetterTransformerManager.is_decoder(model_fast.config.model_type):
+        if False:  # BetterTransformerManager.is_decoder(model_fast.config.model_type):
             logging.warning(
                 f"For decoder training, the BetterTransformer implementation for {model_fast.config.model_type} "
                 " architecture currently does not support padding as fused kernels do not support custom"

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -231,12 +231,9 @@ class BetterTransformer(object):
                 f" Currently supported models are: {BetterTransformerManager.MODEL_MAPPING.keys()}."
             )
 
-        # check on 1.14 in case there is any more patch release on 1.13
-        if BetterTransformerManager.requires_torch_20(model.config.model_type) and parse(torch.__version__) <= parse(
-            "1.14"
-        ):
+        if parse(torch.__version__) <= parse("1.14"):
             raise ValueError(
-                f"BetterTransformer for {model.config.model_type} requires torch>=2.0 but {torch.__version__} is installed. Please upgrade PyTorch."
+                f"BetterTransformer requires torch>=2.0 but {torch.__version__} is installed. Please upgrade PyTorch."
             )
 
         hf_config = model.config
@@ -290,9 +287,10 @@ class BetterTransformer(object):
                 model = dispatch_model(model, hf_device_map, offload_dir=offload_dir)
 
         # See: https://github.com/pytorch/pytorch/issues/96099
-        if BetterTransformerManager.requires_torch_20(model_fast.config.model_type):
+        # TODO: show the warning only for decoders (which do not need an attention mask for training)
+        if BetterTransformerManager.is_decoder(model_fast.config.model_type):
             logging.warning(
-                f"For training, the BetterTransformer implementation for {model_fast.config.model_type} "
+                f"For decoder training, the BetterTransformer implementation for {model_fast.config.model_type} "
                 " architecture currently does not support padding as fused kernels do not support custom"
                 " attention masks. Beware that passing padded batched training data may result in unexpected outputs."
             )

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -242,6 +242,8 @@ class BetterTransformer(object):
             # Remove the hooks from the original model to avoid weights being on `meta` device.
             remove_hook_from_module(model, recurse=True)
 
+        training_mode = model.training
+
         if keep_original_model:
             try:
                 if not check_if_pytorch_greater(2.0, "Please upgrade PyTorch to >=2.0 to use training mode"):
@@ -302,6 +304,11 @@ class BetterTransformer(object):
 
         model_fast.save_pretrained = raise_save_or_push_incompatible
         model_fast.push_to_hub = raise_save_or_push_incompatible
+
+        if training_mode:
+            model_fast = model_fast.train()
+        else:
+            model_fast = model_fast.eval()
 
         return model_fast
 

--- a/optimum/bettertransformer/transformation.py
+++ b/optimum/bettertransformer/transformation.py
@@ -287,12 +287,11 @@ class BetterTransformer(object):
                 model = dispatch_model(model, hf_device_map, offload_dir=offload_dir)
 
         # See: https://github.com/pytorch/pytorch/issues/96099
-        # TODO: show the warning only for decoders (which do not need an attention mask for training)
-        if False:  # BetterTransformerManager.is_decoder(model_fast.config.model_type):
-            logging.warning(
-                f"For decoder training, the BetterTransformer implementation for {model_fast.config.model_type} "
-                " architecture currently does not support padding as fused kernels do not support custom"
-                " attention masks. Beware that passing padded batched training data may result in unexpected outputs."
+        if model_fast.config.model_type in BetterTransformerManager.DO_NOT_SUPPORT_PADDED_TRAINING:
+            logger.warning(
+                f"For decoder models (here {model_fast.config.model_type}), the BetterTransformer implementation"
+                " does not support padding during training, as the fused kernels do not support"
+                " attention masks. Beware that passing padded batched data during training may result in unexpected outputs."
             )
 
         # Overwrite the `save_pretrained` method

--- a/optimum/utils/testing_utils.py
+++ b/optimum/utils/testing_utils.py
@@ -23,7 +23,6 @@ from collections.abc import MutableMapping
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 import torch
-from packaging.version import parse
 
 from . import is_accelerate_available, is_diffusers_available
 
@@ -61,11 +60,6 @@ def require_torch_gpu(test_case):
     torch_device = "cuda" if torch.cuda.is_available() else "cpu"
 
     return unittest.skipUnless(torch_device == "cuda", "test requires CUDA")(test_case)
-
-
-def require_torch_20(test_case):
-    """Decorator marking a test that requires torch>=2.0."""
-    return unittest.skipUnless(parse(torch.__version__) > parse("1.14"), "test requires torch>=2.0")(test_case)
 
 
 def require_hf_token(test_case):

--- a/tests/bettertransformer/test_audio.py
+++ b/tests/bettertransformer/test_audio.py
@@ -160,22 +160,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
                     ),
                 )
 
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_autocast(self, model_type: str):
-        model_ids = (
-            MODELS_DICT[model_type] if isinstance(MODELS_DICT[model_type], tuple) else (MODELS_DICT[model_type],)
-        )
-        for model_id in model_ids:
-            self._test_raise_autocast(model_id, model_type=model_type)
-
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_train(self, model_type: str):
-        model_ids = (
-            MODELS_DICT[model_type] if isinstance(MODELS_DICT[model_type], tuple) else (MODELS_DICT[model_type],)
-        )
-        for model_id in model_ids:
-            self._test_raise_train(model_id, model_type=model_type)
-
     @parameterized.expand(grid_parameters(FULL_GRID))
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
         if model_type in ["hubert", "wav2vec2"] and keep_original_model is True:

--- a/tests/bettertransformer/test_audio.py
+++ b/tests/bettertransformer/test_audio.py
@@ -21,7 +21,7 @@ from testing_utils import MODELS_DICT, BetterTransformersTestMixin
 from transformers import AutoFeatureExtractor, AutoModel, AutoProcessor
 
 from optimum.bettertransformer import BetterTransformer
-from optimum.utils.testing_utils import grid_parameters, require_torch_20
+from optimum.utils.testing_utils import grid_parameters
 
 
 ALL_AUDIO_MODELS_TO_TEST = [
@@ -64,21 +64,16 @@ class BetterTransformersWhisperTest(BetterTransformersTestMixin, unittest.TestCa
         return input_dict
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
-        self._skip_on_torch_version(model_type)
         model_id = MODELS_DICT[model_type]
         self._test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_save_load_invertible(self, test_name: str, model_type: str, keep_original_model=False):
-        self._skip_on_torch_version(model_type)
         model_id = MODELS_DICT[model_type]
         self._test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_model_logits(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_invert_model_logits(
@@ -182,7 +177,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
             self._test_raise_train(model_id, model_type=model_type)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
         if model_type in ["hubert", "wav2vec2"] and keep_original_model is True:
             self.skipTest(f"{model_type} does not support keep_original_model=True")
@@ -194,7 +188,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
             self._test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_save_load_invertible(self, test_name: str, model_type: str, keep_original_model=False):
         if model_type in ["hubert", "wav2vec2"] and keep_original_model is True:
             self.skipTest(f"{model_type} does not support keep_original_model=True")
@@ -206,7 +199,6 @@ class BetterTransformersAudioTest(BetterTransformersTestMixin, unittest.TestCase
             self._test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_model_logits(self, test_name: str, model_type: str, keep_original_model=False):
         if model_type == "hubert" and keep_original_model is True:
             self.skipTest("hubert does not support keep_original_model=True")

--- a/tests/bettertransformer/test_common.py
+++ b/tests/bettertransformer/test_common.py
@@ -16,23 +16,17 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-import torch
 import transformers
-from packaging.version import parse
 from parameterized import parameterized
 from testing_utils import MODELS_DICT
 from transformers import AutoModel
 
 from optimum.bettertransformer import BetterTransformer, BetterTransformerManager
 from optimum.pipelines import pipeline
-from optimum.utils.testing_utils import grid_parameters, require_torch_20
+from optimum.utils.testing_utils import grid_parameters
 
 
 class BetterTransformerIntegrationTests(unittest.TestCase):
-    def _skip_on_torch_version(self, model_type: str):
-        if BetterTransformerManager.requires_torch_20(model_type) and parse(torch.__version__) < parse("1.14"):
-            self.skipTest(f"The model type {model_type} require PyTorch 2.0 for BetterTransformer")
-
     def test_raise_error_on_double_transform_call(self):
         model = AutoModel.from_pretrained("hf-internal-testing/tiny-random-BertModel")
 
@@ -60,7 +54,6 @@ class BetterTransformerIntegrationTests(unittest.TestCase):
         r"""
         Test if the conversion properly raises an error if someone tries to save the model using `save_pretrained`.
         """
-        self._skip_on_torch_version(model_type)
         model_ids = (
             MODELS_DICT[model_type] if isinstance(MODELS_DICT[model_type], tuple) else (MODELS_DICT[model_type],)
         )
@@ -76,7 +69,6 @@ class BetterTransformerIntegrationTests(unittest.TestCase):
         This tests if the conversion of a slow model to its BetterTransformer version using fastpath
         has been successful.
         """
-        self._skip_on_torch_version(model_type)
         model_ids = (
             MODELS_DICT[model_type] if isinstance(MODELS_DICT[model_type], tuple) else (MODELS_DICT[model_type],)
         )
@@ -93,13 +85,11 @@ class BetterTransformerIntegrationTests(unittest.TestCase):
             self.assertTrue(hasattr(converted_model, "generate"))
 
     @parameterized.expand(grid_parameters({"model_type": MODELS_DICT.keys(), "keep_original_model": [True, False]}))
-    @require_torch_20
     def test_raise_save_pretrained_error(self, test_name: str, model_type: str, keep_original_model: bool):
         r"""
         Test if the converted model raises an error when calling `save_pretrained`
         but not when the model is reverted
         """
-        self._skip_on_torch_version(model_type)
         if model_type in ["wav2vec2", "hubert"] and keep_original_model is True:
             self.skipTest("These architectures do not support deepcopy")
 
@@ -125,7 +115,6 @@ class BetterTransformerIntegrationTests(unittest.TestCase):
         A tests that checks if the conversion raises an error if the model contains an activation function
         that is not supported by `BetterTransformer`. Here we need to loop over the config files
         """
-        self._skip_on_torch_version(model_type)
         if BetterTransformerManager.requires_strict_validation(model_type) is False:
             self.skipTest("The architecture does not require a specific activation function")
 

--- a/tests/bettertransformer/test_decoder.py
+++ b/tests/bettertransformer/test_decoder.py
@@ -182,11 +182,6 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         )
 
     @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_autocast(self, model_type: str):
-        model_id = MODELS_DICT[model_type]
-        self._test_raise_autocast(model_id, model_type=model_type)
-
-    @parameterized.expand(SUPPORTED_ARCH)
     @pytest.mark.training
     def test_train(self, model_type: str):
         model_id = MODELS_DICT[model_type]

--- a/tests/bettertransformer/test_decoder.py
+++ b/tests/bettertransformer/test_decoder.py
@@ -23,7 +23,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from optimum.bettertransformer import BetterTransformer
 from optimum.utils import DummyPastKeyValuesGenerator, NormalizedConfigManager
-from optimum.utils.testing_utils import grid_parameters, require_accelerate, require_torch_20, require_torch_gpu
+from optimum.utils.testing_utils import grid_parameters, require_accelerate, require_torch_gpu
 
 
 class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCase):
@@ -34,7 +34,9 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         "keep_original_model": [True, False],
     }
 
-    def prepare_inputs_for_class(self, model_id: str, model_type: str, batch_size: int = 2, **preprocessor_kwargs):
+    def prepare_inputs_for_class(
+        self, model_id: str, model_type: str, batch_size: int = 2, no_padding: bool = False, **preprocessor_kwargs
+    ):
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         if not hasattr(tokenizer, "pad_token") or tokenizer.pad_token is None:
             if tokenizer.eos_token != "":
@@ -45,12 +47,11 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         padding = preprocessor_kwargs.pop("padding", True)
         if batch_size == 1:
             texts = ["a dummy input yeah!"]
+        elif no_padding:
+            texts = ["a dummy input yeah!"] * batch_size
         else:
             texts = ["a dummy input yeah!"] + ["and two"] * (batch_size - 1)
         inputs = tokenizer(texts, return_tensors="pt", padding=padding, max_length=20, **preprocessor_kwargs)
-
-        if model_type == "llama":
-            del inputs["token_type_ids"]
 
         return inputs
 
@@ -64,12 +65,23 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         )
     )
     def test_logits_without_cache(self, test_name: str, model_type: str, padding, batch_size: int):
-        self._skip_on_torch_version(model_type)
         if batch_size == 1 and padding == "max_length":
             self.skipTest("batch_size=1 + padding='max_length' is unsupported")
 
         model_id = MODELS_DICT[model_type]
         self._test_logits(model_id, model_type=model_type, padding=padding, batch_size=batch_size)
+
+    @parameterized.expand(
+        grid_parameters(
+            {
+                "model_type": SUPPORTED_ARCH,
+                "batch_size": [1, 3],
+            }
+        )
+    )
+    def test_logits_backward(self, test_name: str, model_type: str, batch_size: int):
+        model_id = MODELS_DICT[model_type]
+        self._test_logits_backward(model_id, model_type=model_type, no_padding=True, batch_size=batch_size)
 
     @parameterized.expand(
         grid_parameters(
@@ -84,8 +96,6 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
     @require_torch_gpu
     @pytest.mark.gpu_test
     def test_fp16_inference(self, test_name: str, model_type: str, use_to_operator: bool, batch_size: int):
-        self._skip_on_torch_version(model_type)
-
         model_id = MODELS_DICT[model_type]
         self._test_fp16_inference(
             model_id,
@@ -104,7 +114,6 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         )
     )
     def test_logits_with_cache(self, test_name: str, model_type: str, batch_size: int):
-        self._skip_on_torch_version(model_type)
         input_ids = torch.randint(low=1, high=10, size=(batch_size, 1))
         seq_length = 12
         attention_mask = torch.ones(batch_size, seq_length + 1, dtype=torch.int32)
@@ -138,7 +147,6 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
         grid_parameters({"model_type": SUPPORTED_ARCH, "batch_size": [1, 3], "padding": [True, "max_length"]})
     )
     def test_generation(self, test_name: str, model_type: str, batch_size: int, padding: str):
-        self._skip_on_torch_version(model_type)
         if batch_size == 1 and padding == "max_length":
             self.skipTest("batch_size=1 + padding='max_length' is unsupported")
 
@@ -175,33 +183,26 @@ class BetterTransformersDecoderTest(BetterTransformersTestMixin, unittest.TestCa
 
     @parameterized.expand(SUPPORTED_ARCH)
     def test_raise_autocast(self, model_type: str):
-        self._skip_on_torch_version(model_type)
         model_id = MODELS_DICT[model_type]
         self._test_raise_autocast(model_id, model_type=model_type)
 
     @parameterized.expand(SUPPORTED_ARCH)
     @pytest.mark.training
     def test_train(self, model_type: str):
-        self._skip_on_torch_version(model_type)
         model_id = MODELS_DICT[model_type]
         self._test_train_decoder(model_id, model_type=model_type)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
-        self._skip_on_torch_version(model_type)
         model_id = MODELS_DICT[model_type]
         self._test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_save_load_invertible(self, test_name: str, model_type: str, keep_original_model=False):
-        self._skip_on_torch_version(model_type)
         model_id = MODELS_DICT[model_type]
         self._test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_model_logits(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_invert_model_logits(

--- a/tests/bettertransformer/test_encoder.py
+++ b/tests/bettertransformer/test_encoder.py
@@ -256,6 +256,7 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
         )
     )
     def test_logits(self, test_name: str, model_type: str, batch_size: int):
+        # TODO: enable those tests
         if model_type in ["rocbert", "splinter", "markuplm", "bert-generation"]:
             self.skipTest(f"tiny tokenizers are broken on the Hub {model_type}")
         if model_type in ["tapas"]:
@@ -273,6 +274,7 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
         )
     )
     def test_logits_backward(self, test_name: str, model_type: str, batch_size: int):
+        # TODO: enable those tests
         if model_type in ["rocbert", "splinter", "markuplm", "bert-generation"]:
             self.skipTest(f"tiny tokenizer is broken on the Hub for {model_type}")
         if model_type in ["tapas"]:
@@ -293,6 +295,12 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
 
     @parameterized.expand(grid_parameters(FULL_GRID))
     def test_invert_model_logits(self, test_name: str, model_type: str, keep_original_model=False):
+        # TODO: reenable those tests
+        if model_type in ["rocbert", "splinter", "markuplm", "bert-generation"]:
+            self.skipTest(f"tiny tokenizers are broken on the Hub {model_type}")
+        if model_type in ["tapas"]:
+            self.skipTest(f"{model_type} requires dataframe")
+
         model_id = MODELS_DICT[model_type]
         self._test_invert_model_logits(
             model_id=model_id, model_type=model_type, keep_original_model=keep_original_model

--- a/tests/bettertransformer/test_encoder.py
+++ b/tests/bettertransformer/test_encoder.py
@@ -23,7 +23,8 @@ from testing_utils import MODELS_DICT, BetterTransformersTestMixin
 from transformers import AutoModel, AutoProcessor, AutoTokenizer
 
 from optimum.bettertransformer import BetterTransformer
-from optimum.utils.testing_utils import grid_parameters, require_accelerate, require_torch_20, require_torch_gpu
+from optimum.pipelines import pipeline
+from optimum.utils.testing_utils import grid_parameters, require_accelerate, require_torch_gpu
 
 
 class BetterTransformersEncoderTest(BetterTransformersTestMixin):
@@ -144,8 +145,6 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
         r"""
         This test runs pipeline together with Better Transformers converted models using optimum `pipeline`.
         """
-        from optimum.pipelines import pipeline
-
         model_name = "distilbert-base-uncased"
         unmasker = pipeline("fill-mask", model_name, accelerator="bettertransformer")
 
@@ -160,8 +159,6 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
         r"""
         This test runs pipeline together with Better Transformers converted models using optimum `pipeline`.
         """
-        from optimum.pipelines import pipeline
-
         model_name = "distilbert-base-uncased"
         unmasker = pipeline("fill-mask", model_name, accelerator="bettertransformer", device="cuda:0")
 
@@ -300,19 +297,16 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
         self._test_logits_backward(model_id=model_id, model_type=model_type, batch_size=batch_size)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_save_load_invertible(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
 
     @parameterized.expand(grid_parameters(FULL_GRID))
-    @require_torch_20
     def test_invert_model_logits(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_invert_model_logits(

--- a/tests/bettertransformer/test_encoder.py
+++ b/tests/bettertransformer/test_encoder.py
@@ -209,21 +209,6 @@ class BetterTransformersEncoderTest(BetterTransformersTestMixin):
         self.assertTrue(torch.allclose(output_bt[0][1, 3:], torch.zeros_like(output_bt[0][1, 3:])))
         gc.collect()
 
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_autocast(self, model_type: str):
-        if model_type == "rocbert":
-            self.skipTest(
-                "unrelated issue with torch.amp.autocast with rocbert (expected scalar type BFloat16 but found Float)"
-            )
-
-        model_id = MODELS_DICT[model_type]
-        self._test_raise_autocast(model_id, model_type)
-
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_train(self, model_type: str):
-        model_id = MODELS_DICT[model_type]
-        self._test_raise_train(model_id, model_type)
-
     @pytest.mark.gpu_test
     @pytest.mark.accelerate_test
     def test_accelerate_compatibility_cpu_gpu(self):

--- a/tests/bettertransformer/test_encoder_decoder.py
+++ b/tests/bettertransformer/test_encoder_decoder.py
@@ -89,19 +89,6 @@ class BetterTransformersEncoderDecoderTest(BetterTransformersTestMixin, unittest
         model_id = MODELS_DICT[model_type]
         self._test_logits_backward(model_id, model_type=model_type, padding=padding, max_length=max_length)
 
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_autocast(self, model_type: str):
-        model_id = MODELS_DICT[model_type]
-        self._test_raise_autocast(model_id, model_type=model_type)
-
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_train(self, model_type: str):
-        model_id = MODELS_DICT[model_type]
-        if model_type not in ["blenderbot", "pegasus", "t5"]:
-            self._test_raise_train(model_id, model_type=model_type)
-        else:
-            self._test_train_decoder(model_id, model_type=model_type)
-
     @parameterized.expand(grid_parameters(FULL_GRID))
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]

--- a/tests/bettertransformer/test_vision.py
+++ b/tests/bettertransformer/test_vision.py
@@ -20,7 +20,7 @@ from PIL import Image
 from testing_utils import MODELS_DICT, BetterTransformersTestMixin
 from transformers import AutoFeatureExtractor, AutoProcessor
 
-from optimum.utils.testing_utils import grid_parameters, require_torch_20
+from optimum.utils.testing_utils import grid_parameters
 
 
 class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCase):
@@ -93,7 +93,6 @@ class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCas
             }
         )
     )
-    @require_torch_20
     def test_invert_modules(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_invert_modules(model_id=model_id, keep_original_model=keep_original_model)
@@ -106,7 +105,6 @@ class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCas
             }
         )
     )
-    @require_torch_20
     def test_save_load_invertible(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_save_load_invertible(model_id=model_id, keep_original_model=keep_original_model)
@@ -119,7 +117,6 @@ class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCas
             }
         )
     )
-    @require_torch_20
     def test_invert_model_logits(self, test_name: str, model_type: str, keep_original_model=False):
         model_id = MODELS_DICT[model_type]
         self._test_invert_model_logits(

--- a/tests/bettertransformer/test_vision.py
+++ b/tests/bettertransformer/test_vision.py
@@ -73,18 +73,6 @@ class BetterTransformersVisionTest(BetterTransformersTestMixin, unittest.TestCas
         model_id = MODELS_DICT[model_type]
         self._test_logits(model_id, model_type=model_type)
 
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_autocast(self, model_type: str):
-        model_id = MODELS_DICT[model_type]
-        self._test_raise_autocast(model_id, model_type=model_type)
-
-    @parameterized.expand(SUPPORTED_ARCH)
-    def test_raise_train(self, model_type: str):
-        if model_type in ["blip-2"]:
-            self.skipTest("can be trained")
-        model_id = MODELS_DICT[model_type]
-        self._test_raise_train(model_id, model_type=model_type)
-
     @parameterized.expand(
         grid_parameters(
             {


### PR DESCRIPTION
WIP, support training for (almost) all archs.

Though for now for encoders we pass `attention_mask` to SDPA, so it will only dispatch to the math path. I tried to use nestedtensor https://github.com/pytorch/pytorch/issues/105913 without much success.

We probably should be more flexible to allow to use xformers / Hazy-flash that do support either custom mask or indexing.

cc @younesbelkada 

Fixes https://github.com/huggingface/optimum/issues/1081 https://github.com/huggingface/optimum/issues/952 https://github.com/huggingface/optimum/issues/971

Still some tests to add / make pass, and precise the doc