### PR TITLE
ORT quantizes by default all ops

### DIFF
--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -359,7 +359,7 @@ def default_quantization_parameters(
     format: Optional[QuantFormat] = None,
     mode: Optional[QuantizationMode] = None,
     operators_to_quantize: Optional[List[str]] = None,
-) -> Tuple[QuantFormat, QuantizationMode]:
+) -> Tuple[QuantFormat, QuantizationMode, List[str]]:
     if format is None:
         format = QuantFormat.QDQ if is_static else QuantFormat.QOperator
 
@@ -408,7 +408,9 @@ class AutoQuantizationConfig:
             operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
+        format, mode, operators_to_quantize = default_quantization_parameters(
+            is_static, operators_to_quantize=operators_to_quantize
+        )
 
         # u8/s8 is faster (than u8/u8) on lower-end ARM64 and identical on higher-end ARM64,
         # so let's use u8/s8 by default
@@ -464,7 +466,9 @@ class AutoQuantizationConfig:
             operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
+        format, mode, operators_to_quantize = default_quantization_parameters(
+            is_static, operators_to_quantize=operators_to_quantize
+        )
 
         return QuantizationConfig(
             is_static=is_static,
@@ -518,7 +522,9 @@ class AutoQuantizationConfig:
             operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
+        format, mode, operators_to_quantize = default_quantization_parameters(
+            is_static, operators_to_quantize=operators_to_quantize
+        )
 
         return QuantizationConfig(
             is_static=is_static,
@@ -573,7 +579,9 @@ class AutoQuantizationConfig:
             operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
+        format, mode, operators_to_quantize = default_quantization_parameters(
+            is_static, operators_to_quantize=operators_to_quantize
+        )
 
         return QuantizationConfig(
             is_static=is_static,
@@ -611,7 +619,9 @@ class AutoQuantizationConfig:
             operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static=True, operators_to_quantize=operators_to_quantize)
+        format, mode, operators_to_quantize = default_quantization_parameters(
+            is_static=True, operators_to_quantize=operators_to_quantize
+        )
 
         return QuantizationConfig(
             is_static=True,

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -26,6 +26,7 @@ from packaging.version import Version, parse
 from onnxruntime import __version__ as ort_version
 from onnxruntime.quantization import CalibraterBase, CalibrationMethod, QuantFormat, QuantizationMode, QuantType
 from onnxruntime.quantization.calibrate import create_calibrator
+from onnxruntime.quantization.registry import IntegerOpsRegistry, QDQRegistry, QLinearOpsRegistry
 from onnxruntime.transformers.fusion_options import FusionOptions
 
 from ..configuration_utils import BaseConfig
@@ -34,11 +35,13 @@ from ..utils import logging
 
 logger = logging.get_logger(__name__)
 
-NodeName = NodeType = str
-
 # This value is used to indicate ORT which axis it should use to quantize an operator "per-channel"
 ORT_DEFAULT_CHANNEL_FOR_OPERATORS = {"MatMul": 1}
-ORT_FULLY_CONNECTED_OPERATORS = ["MatMul", "Add"]
+
+# Reference: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/quantization/registry.py
+ORT_DEFAULT_OPS_DYNAMIC_QUANTIZATION = list(IntegerOpsRegistry.keys())
+ORT_DEFAULT_OPS_STATIC_QUANTIZATION_QDQ = list(QDQRegistry.keys())
+ORT_DEFAULT_OPS_STATIC_QUANTIZATION_QOPS = list(QLinearOpsRegistry.keys())
 
 
 @dataclass
@@ -88,7 +91,7 @@ class CalibrationConfig:
     def create_calibrator(
         self,
         onnx_model_path: Union[str, os.PathLike, Path],
-        operators_to_quantize: Optional[List[NodeType]],
+        operators_to_quantize: Optional[List[str]],
         use_external_data_format: bool = False,
         force_symmetric_range: bool = False,
         augmented_model_name: str = "augmented_model.onnx",
@@ -248,12 +251,12 @@ class QuantizationConfig:
             accuracy while making the quantized model heavier.
         reduce_range (`bool`, defaults to `False`):
             Whether to use reduce-range 7-bits integers instead of 8-bits integers.
-        nodes_to_quantize (`list`):
+        nodes_to_quantize (`List[str]`, defaults to `[]`):
             List of the nodes names to quantize.
-        nodes_to_exclude (`list`):
+        nodes_to_exclude (`List[str]`, defaults to `[]`):
             List of the nodes names to exclude when applying quantization.
-        operators_to_quantize (`list`, defaults to `["MatMul", "Add"]`):
-            List of the operators types to quantize.
+        operators_to_quantize (`List[str]`):
+            List of the operators types to quantize. Defaults to all quantizable operators for the given quantization mode and format.
         qdq_add_pair_to_weight (`bool`, defaults to `False`):
             By default, floating-point weights are quantized and feed to solely inserted DeQuantizeLinear node.
             If set to True, the floating-point weights will remain and both QuantizeLinear / DeQuantizeLinear nodes
@@ -275,9 +278,9 @@ class QuantizationConfig:
     weights_symmetric: bool = True
     per_channel: bool = False
     reduce_range: bool = False
-    nodes_to_quantize: List[NodeName] = field(default_factory=list)
-    nodes_to_exclude: List[NodeName] = field(default_factory=list)
-    operators_to_quantize: List[NodeType] = field(default_factory=list)
+    nodes_to_quantize: List[str] = field(default_factory=list)
+    nodes_to_exclude: List[str] = field(default_factory=list)
+    operators_to_quantize: List[str] = field(default_factory=list)
     qdq_add_pair_to_weight: bool = False
     qdq_dedicated_pair: bool = False
     qdq_op_type_per_channel_support_to_axis: Dict[str, int] = field(
@@ -287,6 +290,13 @@ class QuantizationConfig:
     def __post_init__(self):
         ensure_valid_mode_or_raise(self.is_static, self.mode)
         ensure_valid_data_type_or_raise(self.is_static, self.activations_dtype, self.weights_dtype)
+
+        # If needed, dynamically set operators_to_quantize default.
+        if len(self.operators_to_quantize) == 0:
+            _, _, operators_to_quantize = default_quantization_parameters(
+                self.is_static, self.format, self.mode, self.operators_to_quantize
+            )
+            self.operators_to_quantize = operators_to_quantize
 
     @staticmethod
     def quantization_type_str(activations_dtype: QuantType, weights_dtype: QuantType) -> str:
@@ -345,7 +355,10 @@ def ensure_valid_data_type_or_raise(
 
 
 def default_quantization_parameters(
-    is_static: bool, format: Optional[QuantFormat] = None, mode: Optional[QuantizationMode] = None
+    is_static: bool,
+    format: Optional[QuantFormat] = None,
+    mode: Optional[QuantizationMode] = None,
+    operators_to_quantize: Optional[List[str]] = None,
 ) -> Tuple[QuantFormat, QuantizationMode]:
     if format is None:
         format = QuantFormat.QDQ if is_static else QuantFormat.QOperator
@@ -353,7 +366,15 @@ def default_quantization_parameters(
     if mode is None:
         mode = QuantizationMode.QLinearOps if is_static else QuantizationMode.IntegerOps
 
-    return format, mode
+    if operators_to_quantize is None or len(operators_to_quantize) == 0:
+        if is_static and format == QuantFormat.QDQ:
+            operators_to_quantize = ORT_DEFAULT_OPS_STATIC_QUANTIZATION_QDQ
+        elif is_static and mode == QuantizationMode.QLinearOps:
+            operators_to_quantize = ORT_DEFAULT_OPS_STATIC_QUANTIZATION_QOPS
+        elif not is_static and mode == QuantizationMode.IntegerOps:
+            operators_to_quantize = ORT_DEFAULT_OPS_DYNAMIC_QUANTIZATION
+
+    return format, mode, operators_to_quantize
 
 
 class AutoQuantizationConfig:
@@ -363,9 +384,9 @@ class AutoQuantizationConfig:
         use_symmetric_activations: bool = False,
         use_symmetric_weights: bool = True,
         per_channel: bool = True,
-        nodes_to_quantize: Optional[List[NodeName]] = None,
-        nodes_to_exclude: Optional[List[NodeName]] = None,
-        operators_to_quantize: List[NodeName] = ORT_FULLY_CONNECTED_OPERATORS,
+        nodes_to_quantize: Optional[List[str]] = None,
+        nodes_to_exclude: Optional[List[str]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
     ):
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for ARM64.
@@ -380,14 +401,14 @@ class AutoQuantizationConfig:
             per_channel (`bool`, defaults to `True`):
                 Whether we should quantize per-channel (also known as "per-row"). Enabling this can
                 increase overall accuracy while making the quantized model heavier.
-            nodes_to_quantize (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to quantize. If `None`, all nodes being operators from `operators_to_quantize` will be quantized.
-            nodes_to_exclude (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_exclude (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to exclude from quantization.
-            operators_to_quantize (`List[NodeName]`, defaults to `["MatMul", "Add"]`):
-                Type of nodes to perform quantization on.
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static)
+        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
 
         # u8/s8 is faster (than u8/u8) on lower-end ARM64 and identical on higher-end ARM64,
         # so let's use u8/s8 by default
@@ -413,9 +434,9 @@ class AutoQuantizationConfig:
         use_symmetric_weights: bool = True,
         per_channel: bool = True,
         reduce_range: bool = False,
-        nodes_to_quantize: Optional[List[NodeName]] = None,
-        nodes_to_exclude: Optional[List[NodeName]] = None,
-        operators_to_quantize: List[NodeName] = ORT_FULLY_CONNECTED_OPERATORS,
+        nodes_to_quantize: Optional[List[str]] = None,
+        nodes_to_exclude: Optional[List[str]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for CPU with AVX2 instruction set.
@@ -436,14 +457,14 @@ class AutoQuantizationConfig:
                 accuracy drop is significant, to try with reduced range (reduce_range = True).
                 Intel's CPUs using AVX512 (non VNNI) can suffer from saturation issue when invoking
                 the VPMADDUBSW instruction. To counter this, one should use 7-bits rather than 8-bits integers.
-            nodes_to_quantize (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to quantize. If `None`, all nodes being operators from `operators_to_quantize` will be quantized.
-            nodes_to_exclude (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_exclude (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to exclude from quantization.
-            operators_to_quantize (`List[NodeName]`, defaults to `["MatMul", "Add"]`):
-                Type of nodes to perform quantization on.
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static)
+        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
 
         return QuantizationConfig(
             is_static=is_static,
@@ -467,9 +488,9 @@ class AutoQuantizationConfig:
         use_symmetric_weights: bool = True,
         per_channel: bool = True,
         reduce_range: bool = False,
-        nodes_to_quantize: Optional[List[NodeName]] = None,
-        nodes_to_exclude: Optional[List[NodeName]] = None,
-        operators_to_quantize: List[NodeName] = ORT_FULLY_CONNECTED_OPERATORS,
+        nodes_to_quantize: Optional[List[str]] = None,
+        nodes_to_exclude: Optional[List[str]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for CPU with AVX512 instruction set.
@@ -490,14 +511,14 @@ class AutoQuantizationConfig:
                 accuracy drop is significant, to try with reduced range (reduce_range = True).
                 Intel's CPUs using AVX512 (non VNNI) can suffer from saturation issue when invoking
                 the VPMADDUBSW instruction. To counter this, one should use 7-bits rather than 8-bits integers.
-            nodes_to_quantize (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to quantize. If `None`, all nodes being operators from `operators_to_quantize` will be quantized.
-            nodes_to_exclude (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_exclude (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to exclude from quantization.
-            operators_to_quantize (`List[NodeName]`, defaults to `["MatMul", "Add"]`):
-                Type of nodes to perform quantization on.
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static)
+        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
 
         return QuantizationConfig(
             is_static=is_static,
@@ -520,9 +541,9 @@ class AutoQuantizationConfig:
         use_symmetric_activations: bool = False,
         use_symmetric_weights: bool = True,
         per_channel: bool = True,
-        nodes_to_quantize: Optional[List[NodeName]] = None,
-        nodes_to_exclude: Optional[List[NodeName]] = None,
-        operators_to_quantize: List[NodeName] = ORT_FULLY_CONNECTED_OPERATORS,
+        nodes_to_quantize: Optional[List[str]] = None,
+        nodes_to_exclude: Optional[List[str]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for CPU with AVX512-VNNI instruction set.
@@ -545,14 +566,14 @@ class AutoQuantizationConfig:
             per_channel (`bool`, defaults to `True`):
                 Whether we should quantize per-channel (also known as "per-row"). Enabling this can
                 increase overall accuracy while making the quantized model heavier.
-            nodes_to_quantize (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to quantize. If `None`, all nodes being operators from `operators_to_quantize` will be quantized.
-            nodes_to_exclude (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_exclude (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to exclude from quantization.
-            operators_to_quantize (`List[NodeName]`, defaults to `["MatMul", "Add"]`):
-                Type of nodes to perform quantization on.
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static)
+        format, mode = default_quantization_parameters(is_static, operators_to_quantize=operators_to_quantize)
 
         return QuantizationConfig(
             is_static=is_static,
@@ -572,9 +593,9 @@ class AutoQuantizationConfig:
     @staticmethod
     def tensorrt(
         per_channel: bool = True,
-        nodes_to_quantize: Optional[List[NodeName]] = None,
-        nodes_to_exclude: Optional[List[NodeName]] = None,
-        operators_to_quantize: List[NodeName] = ORT_FULLY_CONNECTED_OPERATORS,
+        nodes_to_quantize: Optional[List[str]] = None,
+        nodes_to_exclude: Optional[List[str]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for TensorRT static quantization, targetting NVIDIA GPUs.
@@ -583,14 +604,14 @@ class AutoQuantizationConfig:
             per_channel (`bool`, defaults to `True`):
                 Whether we should quantize per-channel (also known as "per-row"). Enabling this can
                 increase overall accuracy while making the quantized model heavier.
-            nodes_to_quantize (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to quantize. If `None`, all nodes being operators from `operators_to_quantize` will be quantized.
-            nodes_to_exclude (`Optional[List[NodeName]]`, defaults to `None`):
+            nodes_to_exclude (`Optional[List[str]]`, defaults to `None`):
                 Specific nodes to exclude from quantization.
-            operators_to_quantize (`List[NodeName]`, defaults to `["MatMul", "Add"]`):
-                Type of nodes to perform quantization on.
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized.
         """
-        format, mode = default_quantization_parameters(is_static=True)
+        format, mode = default_quantization_parameters(is_static=True, operators_to_quantize=operators_to_quantize)
 
         return QuantizationConfig(
             is_static=True,

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -32,7 +32,7 @@ from onnxruntime.quantization.qdq_quantizer import QDQQuantizer
 from ..quantization_base import OptimumQuantizer
 from ..utils.save_utils import maybe_save_preprocessors
 from . import ORTQuantizableOperator
-from .configuration import CalibrationConfig, NodeName, NodeType, ORTConfig, QuantizationConfig
+from .configuration import CalibrationConfig, ORTConfig, QuantizationConfig
 from .modeling_decoder import ORTModelForCausalLM
 from .modeling_ort import ORTModel
 from .modeling_seq2seq import ORTModelForConditionalGeneration
@@ -167,7 +167,7 @@ class ORTQuantizer(OptimumQuantizer):
         dataset: Dataset,
         calibration_config: CalibrationConfig,
         onnx_augmented_model_name: Union[str, Path] = "augmented_model.onnx",
-        operators_to_quantize: Optional[List[NodeType]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
         batch_size: int = 1,
         use_external_data_format: bool = False,
         use_gpu: bool = False,
@@ -183,7 +183,7 @@ class ORTQuantizer(OptimumQuantizer):
                 The configuration containing the parameters related to the calibration step.
             onnx_augmented_model_name (`Union[str, Path]`, defaults to `"augmented_model.onnx"`):
                 The path used to save the augmented model used to collect the quantization ranges.
-            operators_to_quantize (`Optional[List[NodeType]]`, defaults to `None`):
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 List of the operators types to quantize.
             batch_size (`int`, defaults to 1):
                 The batch size to use when collecting the quantization ranges values.
@@ -221,7 +221,7 @@ class ORTQuantizer(OptimumQuantizer):
         dataset: Dataset,
         calibration_config: CalibrationConfig,
         onnx_augmented_model_name: Union[str, Path] = "augmented_model.onnx",
-        operators_to_quantize: Optional[List[NodeType]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
         batch_size: int = 1,
         use_external_data_format: bool = False,
         use_gpu: bool = False,
@@ -237,7 +237,7 @@ class ORTQuantizer(OptimumQuantizer):
                 The configuration containing the parameters related to the calibration step.
             onnx_augmented_model_name (`Union[str, Path]`, defaults to `"augmented_model.onnx"`):
                 The path used to save the augmented model used to collect the quantization ranges.
-            operators_to_quantize (`Optional[List[NodeType]]`, defaults to `None`):
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
                 List of the operators types to quantize.
             batch_size (`int`, defaults to 1):
                 The batch size to use when collecting the quantization ranges values.
@@ -266,7 +266,7 @@ class ORTQuantizer(OptimumQuantizer):
         reader = ORTCalibrationDataReader(dataset, batch_size)
         self._calibrator.collect_data(reader)
 
-    def compute_ranges(self) -> Dict[NodeName, Tuple[float, float]]:
+    def compute_ranges(self) -> Dict[str, Tuple[float, float]]:
         """
         Computes the quantization ranges.
 
@@ -286,7 +286,7 @@ class ORTQuantizer(OptimumQuantizer):
         quantization_config: QuantizationConfig,
         save_dir: Union[str, Path],
         file_suffix: Optional[str] = "quantized",
-        calibration_tensors_range: Optional[Dict[NodeName, Tuple[float, float]]] = None,
+        calibration_tensors_range: Optional[Dict[str, Tuple[float, float]]] = None,
         use_external_data_format: bool = False,
         preprocessor: Optional[QuantizationPreprocessor] = None,
     ) -> Path:
@@ -300,7 +300,7 @@ class ORTQuantizer(OptimumQuantizer):
                 The directory where the quantized model should be saved.
             file_suffix (`Optional[str]`, defaults to `"quantized"`):
                 The file_suffix used to save the quantized model.
-            calibration_tensors_range (`Optional[Dict[NodeName, Tuple[float, float]]]`, defaults to `None`):
+            calibration_tensors_range (`Optional[Dict[str, Tuple[float, float]]]`, defaults to `None`):
                 The dictionary mapping the nodes name to their quantization ranges, used and required only when applying static quantization.
             use_external_data_format (`bool`, defaults to `False`):
                 Whether to use external data format to store model which size is >= 2Gb.


### PR DESCRIPTION
As per title

Partially fixes https://github.com/huggingface/optimum/issues/1243 and align with the previous transformers script