### PR TITLE
Fix BT starcoder fp16

### DIFF
--- a/optimum/bettertransformer/models/attention.py
+++ b/optimum/bettertransformer/models/attention.py
@@ -679,11 +679,7 @@ def gpt_bigcode_wrapped_scaled_dot_product(
     raise_on_head_mask(head_mask)
 
     # TODO: remove once PyTorch 2.1 is released with the scale argument to SDPA
-    if self.scale_attn_weights:
-        softmax_dtype = torch.float32 if self.attention_softmax_in_fp32 else query.dtype
-        if self.scale_attention_softmax_in_fp32 and query.dtype != softmax_dtype:
-            query = query / (self.layer_idx + 1)
-    else:
+    if not self.scale_attn_weights:
         query = query / self.head_dim**0.5
 
     # MQA models: (batch_size, query_length, num_heads * head_dim)


### PR DESCRIPTION
An other small fix. StarCoder is kind of special in that for layer-wise scaling, it unscales just before the softmax. So we actually do not need the `unscale` if we want numerical equivalence.

See https://github.com/huggingface/transformers/blob/641adca55832ed9c5648f54dcd8926d67d3511db/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py#L133 & https://github.com/huggingface/transformers/blob/641adca55832ed9c5648f54dcd8926d67d3511db/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py#L66-L71

Fixes https://github.com/huggingface/optimum/pull/1252#issuecomment-1665369601