### PR TITLE
Fix ORTModule uses fp32 model issue

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -538,6 +538,7 @@ class ORTTrainer(Trainer):
         logger.info("Wrap ORTModule for ONNX Runtime training.")
         model = ORTModule(self.model)
         self.model_wrapped = model
+        self.model = model
 
         # We need to reset the scheduler, as its parameters may be different on subsequent calls
         if self._created_lr_scheduler:


### PR DESCRIPTION
# What does this PR do?

Fix throughput drop using ORTModule. ORTModule gets a fp32 model therefore much slower now

Fixes # (issue)
Command
python -m torch.distributed.launch --nproc_per_node=8 --use-env optimum/examples/onnxruntime/training/text-classification/run_glue.py --model_name_or_path microsoft/deberta-large  \
--task_name MRPC --max_seq_length 128 --learning_rate 3e-6 --do_train --output_dir /dev/shm --overwrite_output_dir --max_steps 200 --logging_steps 200 --per_device_train_batch_size 32 --fp16 

Before
 85%|████████▌ | 170/200 [01:31<00:08,  3.64it/s]
 86%|████████▌ | 171/200 [01:31<00:07,  3.64it/s]

Now
 85%|████████▌ | 170/200 [02:46<00:22,  1.35it/s]
 86%|████████▌ | 171/200 [02:46<00:21,  1.35it/s]


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

