### PR TITLE
Fix build PR doc workflow

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -1,7 +1,9 @@
 name: Build PR documentation
 
+# WARNING: As this workflow supports the pull_request_target event, please exercise extra care when editing it.
+
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 concurrency:
@@ -9,7 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  authorize:
+    if: (github.event.action == 'labeled' && github.event.label.name == 'build-pr-doc') || github.event_name != 'pull_request_target' || (! github.event.pull_request.head.repo.fork)
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   build_documentation:
+    needs: authorize
     runs-on: ubuntu-latest
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -27,6 +36,7 @@ jobs:
         with:
           repository: 'huggingface/optimum'
           path: optimum
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - uses: actions/checkout@v2
         with:
@@ -87,6 +97,7 @@ jobs:
           sudo apt update
           sudo apt install -y ca-certificates apt-transport-https gnupg
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 5F03AFA423A751913F249259814F888B20B09A7E
+            # TODO: remove secrets and pull_request_target once archive.furiosa.ai is public
           sudo tee -a /etc/apt/auth.conf.d/furiosa.conf > /dev/null <<EOT
             machine archive.furiosa.ai
             login ${{ secrets.FURIOSA_ACCESS_KEY }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -5,6 +5,7 @@ name: Build PR documentation
 on:
   pull_request_target:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, labeled ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -3,9 +3,11 @@ name: Build PR documentation
 # WARNING: As this workflow supports the pull_request_target event, please exercise extra care when editing it.
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, reopened, labeled ]
+#  pull_request_target:
+#    branches: [ main ]
+#    types: [ opened, synchronize, reopened, labeled ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test_exporters_gpu.yml
+++ b/.github/workflows/test_exporters_gpu.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   start-runner:
+    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || contains( github.event.pull_request.labels.*.name, 'gpu-test') }}
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
     env:

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -12,6 +12,8 @@ specific language governing permissions and limitations under the License.
 
 # Quick tour
 
+Hey I did a change here!
+
 This quick tour is intended for developers who are ready to dive into the code and see examples of how to integrate 🤗 Optimum into their model training and inference workflows.
 
 ## Accelerated inference


### PR DESCRIPTION
The Furiosa docbuilding requires secrets.

PRs from forks need to be labeled `build-pr-doc` to run the workflow.