### PR TITLE
Add optional position ids to forward pass

### DIFF
--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -330,7 +330,6 @@ class ORTDecoder(ORTModelPart):
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache_branch: None = None,
-        **kwargs,
     ) -> CausalLMOutputWithCrossAttentions:
         # adding use_cache_branch in the signature here is just a hack for IO Binding
         use_torch = isinstance(input_ids, torch.Tensor)

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -329,6 +329,7 @@ class ORTDecoder(ORTModelPart):
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache_branch: None = None,
+        **kwargs,
     ) -> CausalLMOutputWithCrossAttentions:
         # adding use_cache_branch in the signature here is just a hack for IO Binding
         use_torch = isinstance(input_ids, torch.Tensor)
@@ -364,6 +365,9 @@ class ORTDecoder(ORTModelPart):
 
             if "attention_mask" in self.input_names:
                 model_inputs.append(attention_mask)
+
+            if "position_ids" in self.input_names:
+                model_inputs.append(kwargs["position_ids"])
 
             if past_key_values is not None:
                 model_inputs += past_key_values
@@ -413,6 +417,9 @@ class ORTDecoder(ORTModelPart):
                     "attention_mask": attention_mask.cpu().detach().numpy(),
                 }
 
+                if "position_ids" in self.input_names:
+                    onnx_inputs["position_ids"] = kwargs["position_ids"].cpu().detach().numpy()
+
                 if self.parent_model.use_merged is True:
                     onnx_inputs["use_cache_branch"] = use_cache_branch_tensor.cpu().detach().numpy()
 
@@ -428,6 +435,9 @@ class ORTDecoder(ORTModelPart):
                     "input_ids": input_ids,
                     "attention_mask": attention_mask,
                 }
+
+                if "position_ids" in self.input_names:
+                    onnx_inputs["position_ids"] = kwargs["position_ids"]
 
                 if self.parent_model.use_merged is True:
                     onnx_inputs["use_cache_branch"] = use_cache_branch_tensor

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -326,6 +326,7 @@ class ORTDecoder(ORTModelPart):
         self,
         input_ids: torch.LongTensor,
         attention_mask: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache_branch: None = None,
@@ -367,7 +368,7 @@ class ORTDecoder(ORTModelPart):
                 model_inputs.append(attention_mask)
 
             if "position_ids" in self.input_names:
-                model_inputs.append(kwargs["position_ids"])
+                model_inputs.append(position_ids)
 
             if past_key_values is not None:
                 model_inputs += past_key_values
@@ -418,7 +419,7 @@ class ORTDecoder(ORTModelPart):
                 }
 
                 if "position_ids" in self.input_names:
-                    onnx_inputs["position_ids"] = kwargs["position_ids"].cpu().detach().numpy()
+                    onnx_inputs["position_ids"] = position_ids.cpu().detach().numpy()
 
                 if self.parent_model.use_merged is True:
                     onnx_inputs["use_cache_branch"] = use_cache_branch_tensor.cpu().detach().numpy()
@@ -437,7 +438,7 @@ class ORTDecoder(ORTModelPart):
                 }
 
                 if "position_ids" in self.input_names:
-                    onnx_inputs["position_ids"] = kwargs["position_ids"]
+                    onnx_inputs["position_ids"] = position_ids
 
                 if self.parent_model.use_merged is True:
                     onnx_inputs["use_cache_branch"] = use_cache_branch_tensor

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -652,12 +652,14 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 labels=labels,
+                **kwargs,
             )
         elif self.use_merged is True:
             outputs = self.decoder(
                 input_ids=input_ids[:, -1:],
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
+                **kwargs,
             )
         else:
             outputs = self.decoder_with_past(
@@ -665,6 +667,7 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
                 labels=labels,
+                **kwargs,
             )
 
         return CausalLMOutputWithCrossAttentions(

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -642,6 +642,7 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
         self,
         input_ids: torch.LongTensor = None,
         attention_mask: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
         labels: Optional[torch.LongTensor] = None,
         **kwargs,
@@ -650,16 +651,16 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
             outputs = self.decoder(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
+                position_ids=position_ids,
                 past_key_values=past_key_values,
                 labels=labels,
-                **kwargs,
             )
         elif self.use_merged is True:
             outputs = self.decoder(
                 input_ids=input_ids[:, -1:],
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
-                **kwargs,
+                position_ids=position_ids,
             )
         else:
             outputs = self.decoder_with_past(
@@ -667,7 +668,7 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
                 labels=labels,
-                **kwargs,
+                position_ids=position_ids,
             )
 
         return CausalLMOutputWithCrossAttentions(


### PR DESCRIPTION
# What does this PR do?

This PR adds support for providing `position_ids` in the forward pass. Per the [Hugging Face glossary](https://huggingface.co/docs/transformers/glossary#position-ids), absolute positional embeddings are used by default if the `position_ids` input is not provided. Because LLaMA uses rotary positional embeddings, the `position_ids` input is needed. Currently, the exported ONNX models for LLaMA do not have this input because it is missing in the forward pass.

The PR changes are needed to export and run LLaMA with Optimum + ONNX Runtime in this [ORT PR](https://github.com/microsoft/onnxruntime/pull/17020).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

