### PR TITLE
Pin tensorflow<=2.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ EXTRAS_REQUIRE = {
     ],
     "exporters": ["onnx", "onnxruntime", "timm"],
     "exporters-gpu": ["onnx", "onnxruntime-gpu", "timm"],
-    "exporters-tf": ["tensorflow>=2.4", "tf2onnx", "onnx", "onnxruntime", "timm", "h5py", "numpy<1.24.0"],
+    "exporters-tf": ["tensorflow>=2.4,<=2.12.1", "tf2onnx", "onnx", "onnxruntime", "timm", "h5py", "numpy<1.24.0"],
     "diffusers": ["diffusers"],
     "intel": "optimum-intel>=1.10.1",
     "openvino": "optimum-intel[openvino]>=1.10.1",


### PR DESCRIPTION
`pytest tests/exporters/onnx/test_onnx_config_loss.py -k "test_onnx_config_with_loss" -s` segfaults on `2.13` while it does not on `2.12`.