### PR TITLE
Fix PyTorch tied weights being duplicated in the exported ONNX models

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -445,7 +445,7 @@ def main_export(
                 f" referring to `optimum.exporters.tasks.TaskManager`'s `_TASKS_TO_AUTOMODELS`."
             )
 
-        onnx_files_subpaths = None
+        onnx_files_subpaths = [key + ".onnx" for key in models_and_onnx_configs.keys()]
     else:
         # save the subcomponent configuration
         for model_name in models_and_onnx_configs:
@@ -488,8 +488,6 @@ def main_export(
     if optimize is not None:
         from ...onnxruntime import AutoOptimizationConfig, ORTOptimizer
 
-        if onnx_files_subpaths is None:
-            onnx_files_subpaths = [key + ".onnx" for key in models_and_onnx_configs.keys()]
         optimizer = ORTOptimizer.from_pretrained(output, file_names=onnx_files_subpaths)
 
         optimization_config = AutoOptimizationConfig.with_optimization_level(optimization_level=optimize)

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -19,6 +19,7 @@ import enum
 import gc
 import inspect
 import itertools
+import os
 import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -26,7 +27,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
-from transformers.utils import is_torch_available
+import onnx
+from transformers.utils import is_accelerate_available, is_torch_available
+
+from ...onnx import remove_duplicate_weights_from_tied_info
+
+
+if is_torch_available():
+    import torch.nn as nn
 
 from ...onnx import merge_decoders
 from ...utils import (
@@ -42,9 +50,12 @@ from ...utils import TRANSFORMERS_MINIMUM_VERSION as GLOBAL_MIN_TRANSFORMERS_VER
 from ...utils.doc import add_dynamic_docstring
 from ...utils.import_utils import check_if_transformers_greater, is_onnx_available, is_onnxruntime_available
 from ..base import ExportConfig
-from .constants import ONNX_DECODER_MERGED_NAME, ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME, ONNX_ENCODER_NAME
+from .constants import ONNX_DECODER_MERGED_NAME, ONNX_DECODER_NAME, ONNX_DECODER_WITH_PAST_NAME
 from .model_patcher import ModelPatcher, Seq2SeqModelPatcher
 
+
+if is_accelerate_available():
+    from accelerate.utils import find_tied_parameters
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig, PreTrainedModel, TFPreTrainedModel
@@ -505,9 +516,27 @@ class OnnxConfig(ExportConfig, ABC):
             models_and_onnx_configs (`Dict[str, Tuple[Union["PreTrainedModel", "TFPreTrainedModel", "ModelMixin"], "OnnxConfig"]]`):
                 A dictionnary containing the models t apply post-processing on, and their corresponding ONNX configuration.
             onnx_files_subpaths (`List[str]`):
-            The relative paths from the export directory to the ONNX files to do post-processing on. The order must be the same as*
-            the order of submodels in the ordered dict `models_and_onnx_configs`.
+                The relative paths from the export directory to the ONNX files to do post-processing on. The order must be the same as
+                the order of submodels in the ordered dict `models_and_onnx_configs`.
         """
+        first_key = next(iter(models_and_onnx_configs))
+        if is_torch_available() and isinstance(models_and_onnx_configs[first_key][0], nn.Module):
+            if is_accelerate_available():
+                print("Deduplicating shared (tied) weights...")
+                keys = list(models_and_onnx_configs.keys())
+                for i, subpath in enumerate(onnx_files_subpaths):
+                    onnx_model = onnx.load(os.path.join(path, subpath))
+
+                    torch_model = models_and_onnx_configs[keys[i]][0]
+                    tied_params = find_tied_parameters(torch_model)
+                    remove_duplicate_weights_from_tied_info(
+                        onnx_model, torch_model, tied_params, save_path=os.path.join(path, subpath)
+                    )
+            else:
+                logger.warning(
+                    "Weight deduplication check in the ONNX export requires accelerate. Please install accelerate to run it."
+                )
+
         return models_and_onnx_configs, onnx_files_subpaths
 
 
@@ -918,14 +947,14 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         ],
         onnx_files_subpaths: List[str],
     ):
+        models_and_onnx_configs, onnx_files_subpaths = super().post_process_exported_models(
+            path, models_and_onnx_configs, onnx_files_subpaths
+        )
+
         # Attempt to merge only if the decoder was exported without/with past
         if self.use_past is True and len(models_and_onnx_configs) == 3:
-            if onnx_files_subpaths is not None:
-                decoder_path = Path(path, onnx_files_subpaths[1])
-                decoder_with_past_path = Path(path, onnx_files_subpaths[2])
-            else:
-                decoder_path = Path(path, ONNX_DECODER_NAME + ".onnx")
-                decoder_with_past_path = Path(path, ONNX_DECODER_WITH_PAST_NAME + ".onnx")
+            decoder_path = Path(path, onnx_files_subpaths[1])
+            decoder_with_past_path = Path(path, onnx_files_subpaths[2])
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")
             try:
                 # The decoder with past does not output the cross attention past key values as they are constant,
@@ -940,10 +969,7 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
                 raise Exception(f"Unable to merge decoders. Detailed error: {e}")
 
             # In order to do the validation of the two branches on the same file
-            if onnx_files_subpaths is not None:
-                encoder_path = onnx_files_subpaths[0]
-            else:
-                encoder_path = ONNX_ENCODER_NAME + ".onnx"
+            encoder_path = onnx_files_subpaths[0]
 
             onnx_files_subpaths = [encoder_path, decoder_merged_path.name, decoder_merged_path.name]
 

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -523,11 +523,10 @@ class OnnxConfig(ExportConfig, ABC):
         if is_torch_available() and isinstance(models_and_onnx_configs[first_key][0], nn.Module):
             if is_accelerate_available():
                 logger.info("Deduplicating shared (tied) weights...")
-                keys = list(models_and_onnx_configs.keys())
-                for i, subpath in enumerate(onnx_files_subpaths):
+                for subpath, key in zip(onnx_files_subpaths, models_and_onnx_configs):
                     onnx_model = onnx.load(os.path.join(path, subpath))
 
-                    torch_model = models_and_onnx_configs[keys[i]][0]
+                    torch_model = models_and_onnx_configs[key][0]
                     tied_params = find_tied_parameters(torch_model)
                     remove_duplicate_weights_from_tied_info(
                         onnx_model, torch_model, tied_params, save_path=os.path.join(path, subpath)

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -522,7 +522,7 @@ class OnnxConfig(ExportConfig, ABC):
         first_key = next(iter(models_and_onnx_configs))
         if is_torch_available() and isinstance(models_and_onnx_configs[first_key][0], nn.Module):
             if is_accelerate_available():
-                print("Deduplicating shared (tied) weights...")
+                logger.info("Deduplicating shared (tied) weights...")
                 keys = list(models_and_onnx_configs.keys())
                 for i, subpath in enumerate(onnx_files_subpaths):
                     onnx_model = onnx.load(os.path.join(path, subpath))

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -98,14 +98,14 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
         ],
         onnx_files_subpaths: List[str],
     ):
+        models_and_onnx_configs, onnx_files_subpaths = super().post_process_exported_models(
+            path, models_and_onnx_configs, onnx_files_subpaths
+        )
+
         # Attempt to merge only if the decoder-only was exported separately without/with past
         if self.use_past is True and len(models_and_onnx_configs) == 2:
-            if onnx_files_subpaths is not None:
-                decoder_path = Path(path, onnx_files_subpaths[0])
-                decoder_with_past_path = Path(path, onnx_files_subpaths[1])
-            else:
-                decoder_path = Path(path, ONNX_DECODER_NAME + ".onnx")
-                decoder_with_past_path = Path(path, ONNX_DECODER_WITH_PAST_NAME + ".onnx")
+            decoder_path = Path(path, onnx_files_subpaths[0])
+            decoder_with_past_path = Path(path, onnx_files_subpaths[1])
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")
             try:
                 merge_decoders(

--- a/optimum/onnx/__init__.py
+++ b/optimum/onnx/__init__.py
@@ -22,6 +22,7 @@ _import_structure = {
         "merge_decoders",
         "remove_duplicate_weights",
         "replace_atenops_to_gather",
+        "remove_duplicate_weights_from_tied_info",
     ],
 }
 
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
         cast_slice_nodes_inputs_to_int32,
         merge_decoders,
         remove_duplicate_weights,
+        remove_duplicate_weights_from_tied_info,
         replace_atenops_to_gather,
     )
 else:

--- a/optimum/onnx/graph_transformations.py
+++ b/optimum/onnx/graph_transformations.py
@@ -147,13 +147,22 @@ def check_and_save_model(model: onnx.ModelProto, save_path: Optional[Union[str, 
             save_path = Path(save_path).as_posix()
             onnx.save(model, save_path)
     elif save_path is not None:
+        # path/to/model.onnx
         save_path = Path(save_path).as_posix()
+
+        external_file_name = os.path.basename(save_path) + "_data"
+        # path/to/model.onnx_data
+        external_path = os.path.join(os.path.dirname(save_path), external_file_name)
+        if save_path.endswith(".onnx") and os.path.isfile(save_path):
+            os.remove(save_path)
+        if os.path.isfile(external_path):
+            os.remove(external_path)
         onnx.save(
             model,
             save_path,
             save_as_external_data=True,
             all_tensors_to_one_file=True,
-            location=os.path.basename(save_path) + "_data",
+            location=external_file_name,
         )
         try:
             onnx.checker.check_model(save_path)

--- a/optimum/onnx/graph_transformations.py
+++ b/optimum/onnx/graph_transformations.py
@@ -14,7 +14,7 @@
 import copy
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import onnx
 from onnx import ModelProto
@@ -24,13 +24,20 @@ from .transformations_utils import (
     _create_name_sharing_dict,
     _deduplicated_cross_model_initializers,
     _find_duplicate_initializers,
+    _find_matching_initializers,
     _get_all_inputs,
     _get_onnx_opset,
+    _get_weights_to_tie,
+    _remove_duplicate_initializers,
     _remove_redundant_initializers,
     _replace_input_names,
     _unify_onnx_outputs,
     cast_int64_tensorproto_to_int32,
 )
+
+
+if TYPE_CHECKING:
+    import torch.nn as nn
 
 
 logger = logging.get_logger()
@@ -40,6 +47,8 @@ def remove_duplicate_weights(model: ModelProto, inplace: bool = False) -> ModelP
     """
     Finds and removes duplicate weights in a model by keeping only unique weights, and make the duplicate values point
     to them.
+
+    This function only removes duplicate weights that are exactly identical (e.g., not transposed).
 
     Args:
         model (`onnx.ModelProto`): The model to remove duplicates from.
@@ -57,6 +66,35 @@ def remove_duplicate_weights(model: ModelProto, inplace: bool = False) -> ModelP
     _remove_redundant_initializers(models=[model], name_sharing_dict=name_sharing_dict)
 
     return model
+
+
+def remove_duplicate_weights_from_tied_info(
+    onnx_model: ModelProto, torch_model: "nn.Module", tied_params: List[List[str]], save_path: str
+):
+    """
+    Tries to remove potential duplicate ONNX initializers from the tied information in tied_params.
+
+    Args:
+        onnx_model (`onnx.ModelProto`):
+            The ONNX model for which to tie potentially duplicate initializers.
+        tied_params (`List[List[str]]`):
+            A list of groups of torch parameters that are tied, i.e. shared. For them,
+            the torch module shares the same pointer.
+    """
+    tied_groups_to_tie, tied_groups_ignored = _get_weights_to_tie(tied_params, torch_model)
+
+    initializer_name_to_idx = {}
+    for idx, initializer in enumerate(onnx_model.graph.initializer):
+        initializer_name_to_idx[initializer.name] = idx
+
+    tied_groups_map = _find_matching_initializers(tied_params, onnx_model, initializer_name_to_idx)
+
+    onnx_model = _remove_duplicate_initializers(
+        onnx_model, tied_groups_to_tie, tied_groups_map, initializer_name_to_idx
+    )
+    check_and_save_model(onnx_model, save_path=save_path)
+
+    return onnx_model
 
 
 def replace_atenops_to_gather(model: ModelProto) -> ModelProto:
@@ -87,6 +125,45 @@ def replace_atenops_to_gather(model: ModelProto) -> ModelProto:
 
     onnx.checker.check_model(model)
     return model
+
+
+def check_and_save_model(model: onnx.ModelProto, save_path: Optional[Union[str, Path]]):
+    # for large models, a path must be provided instead of a ModelProto:
+    # https://github.com/onnx/onnx/blob/main/docs/PythonAPIOverview.md#checking-a-large-onnx-model-2gb
+    if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+        # For the try catch, refer to https://github.com/microsoft/onnxruntime/issues/14768
+        try:
+            onnx.checker.check_model(model)
+        except Exception as e:
+            if "No Op registered for" in str(e):
+                pass
+            else:
+                raise e
+        if save_path:
+            # Overwrite.
+            save_path = str(save_path)
+            if save_path.endswith(".onnx") and os.path.isfile(save_path):
+                os.remove(save_path)
+            save_path = Path(save_path).as_posix()
+            onnx.save(model, save_path)
+    elif save_path is not None:
+        save_path = Path(save_path).as_posix()
+        onnx.save(
+            model,
+            save_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=os.path.basename(save_path) + "_data",
+        )
+        try:
+            onnx.checker.check_model(save_path)
+        except Exception as e:
+            if "No Op registered for" in str(e):
+                pass
+            else:
+                raise e
+    else:
+        logger.info("Merged ONNX model exceeds 2GB, the model will not be checked without `save_path` given.")
 
 
 def merge_decoders(
@@ -209,38 +286,7 @@ def merge_decoders(
 
     merged_model = onnx.helper.make_model(merged_graph, producer_name=producer_name, opset_imports=opset_imports)
 
-    # for large models, a path must be provided instead of a ModelProto:
-    # https://github.com/onnx/onnx/blob/main/docs/PythonAPIOverview.md#checking-a-large-onnx-model-2gb
-    if merged_model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
-        # For the try catch, refer to https://github.com/microsoft/onnxruntime/issues/14768
-        try:
-            onnx.checker.check_model(merged_model)
-        except Exception as e:
-            if "No Op registered for" in str(e):
-                pass
-            else:
-                raise e
-        if save_path:
-            save_path = Path(save_path).as_posix()
-            onnx.save(merged_model, save_path)
-    elif save_path is not None:
-        save_path = Path(save_path).as_posix()
-        onnx.save(
-            merged_model,
-            save_path,
-            save_as_external_data=True,
-            all_tensors_to_one_file=True,
-            location=os.path.basename(save_path) + "_data",
-        )
-        try:
-            onnx.checker.check_model(save_path)
-        except Exception as e:
-            if "No Op registered for" in str(e):
-                pass
-            else:
-                raise e
-    else:
-        logger.info("Merged ONNX model exceeds 2GB, the model will not be checked without `save_path` given.")
+    check_and_save_model(merged_model, save_path=save_path)
 
     return merged_model
 

--- a/optimum/onnx/graph_transformations.py
+++ b/optimum/onnx/graph_transformations.py
@@ -77,6 +77,8 @@ def remove_duplicate_weights_from_tied_info(
     Args:
         onnx_model (`onnx.ModelProto`):
             The ONNX model for which to tie potentially duplicate initializers.
+        torch_model (`nn.Module`):
+            The PyTorch model corresponding to the ONNX one.
         tied_params (`List[List[str]]`):
             A list of groups of torch parameters that are tied, i.e. shared. For them,
             the torch module shares the same pointer.

--- a/optimum/onnx/graph_transformations.py
+++ b/optimum/onnx/graph_transformations.py
@@ -22,13 +22,13 @@ from onnx import ModelProto
 from ..utils import logging
 from .transformations_utils import (
     _create_name_sharing_dict,
+    _deduplicate_gather_matmul,
     _deduplicated_cross_model_initializers,
     _find_duplicate_initializers,
     _find_matching_initializers,
     _get_all_inputs,
     _get_onnx_opset,
     _get_weights_to_tie,
-    _remove_duplicate_initializers,
     _remove_redundant_initializers,
     _replace_input_names,
     _unify_onnx_outputs,
@@ -89,9 +89,7 @@ def remove_duplicate_weights_from_tied_info(
 
     tied_groups_map = _find_matching_initializers(tied_params, onnx_model, initializer_name_to_idx)
 
-    onnx_model = _remove_duplicate_initializers(
-        onnx_model, tied_groups_to_tie, tied_groups_map, initializer_name_to_idx
-    )
+    onnx_model = _deduplicate_gather_matmul(onnx_model, tied_groups_to_tie, tied_groups_map, initializer_name_to_idx)
     check_and_save_model(onnx_model, save_path=save_path)
 
     return onnx_model

--- a/optimum/onnx/transformations_utils.py
+++ b/optimum/onnx/transformations_utils.py
@@ -318,10 +318,11 @@ def cast_int64_tensorproto_to_int32(initializer: onnx.TensorProto, cast: bool = 
     initializer.name = original_name
 
 
-def _get_weights_to_tie(tied_params, torch_model: "nn.Module") -> Tuple[List[List[str]]]:
+def _get_weights_to_tie(tied_params: List[List[str]], torch_model: "nn.Module") -> Tuple[List[List[str]]]:
     """
-    Find tied weights in the PyTorch model `model`, and separate them in tied weights
-    for which an untying strategy exists and do not exist.
+    Separates tied weights from the torch_model in groups for which a tying implementation is (and is not) available.
+
+    Currently, only Embedding and Linear weight sharing the same data can be tied.
     """
     SUPPORTED_DEDUPLICATION_OPS = ("Embedding", "Linear")
     tied_groups_to_tie = []
@@ -335,7 +336,7 @@ def _get_weights_to_tie(tied_params, torch_model: "nn.Module") -> Tuple[List[Lis
             if module.__class__.__name__ not in SUPPORTED_DEDUPLICATION_OPS:
                 skip_group = True
             if len(params) != 2:
-                skip_group = 2
+                skip_group = True
 
         if skip_group:
             tied_groups_ignored.append(params)


### PR DESCRIPTION
This is the case for example when the embedding weight and language modeling head share the same weight.

Although PyTorch has a pass to deduplicate identical initializers (https://github.com/pytorch/pytorch/blob/main/torch/csrc/jit/passes/onnx/deduplicate_initializers.cpp), one issue arises when torch.onnx.export does constant folding, that may e.g. transpose a weight (in the nn.Linear case), that later messes up with the initializer deduplication. See details: https://github.com/pytorch/pytorch/issues/108342

For small models, the duplication can result in ONNX weights >30% larger vs pytorch weight. The issue is less severe for large models. Given that doing constant folding is generally good, just passing `do_constant_folding=False` is not really a satisfying solution hence this PR.

e.g. bloom-560m goes from 3.0 GiB to 2.1 GiB.

Fixes https://github.com/pytorch/pytorch/issues/108342 as a post-processing step for nn.Embedding & nn.Linear.