### PR TITLE
Version bump + add max_input_length to gptq 

### DIFF
--- a/optimum/gptq/data.py
+++ b/optimum/gptq/data.py
@@ -255,9 +255,9 @@ def get_dataset(
         "ptb": get_ptb,
         "ptb-new": get_ptb_new,
     }
-    if split not in ["train", "test"]:
+    if split not in ["train", "validation"]:
         raise ValueError(f"The split need to be 'train' or 'validation' but found {split}")
     if dataset_name not in get_dataset_map:
         raise ValueError(f"Expected a value in {list(get_dataset_map.keys())} but found {dataset_name}")
     get_dataset_fn = get_dataset_map[dataset_name]
-    return get_dataset_fn(tokenizer=tokenizer, nsamples=nsamples, seqlen=seqlen)
+    return get_dataset_fn(tokenizer=tokenizer, nsamples=nsamples, seqlen=seqlen, split=split)

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -129,6 +129,7 @@ class GPTQQuantizer(object):
         self.pad_token_id = pad_token_id
         self.disable_exllama = disable_exllama
         self.max_input_length = max_input_length
+        self.quant_method = QuantizationMethod.GPTQ
 
         if self.bits not in [2, 3, 4, 8]:
             raise ValueError("only support quantize to [2,3,4,8] bits.")
@@ -443,6 +444,12 @@ class GPTQQuantizer(object):
             if device == torch.device("cpu") or (has_device_map and any(d in devices for d in ["cpu", "disk"])):
                 logger.warning(
                     "Found modules on cpu/disk. Using Exllama backend requires all the modules to be on GPU. Setting `disable_exllama=True`"
+                )
+                self.disable_exllama = True
+            elif self.desc_act:
+                logger.warning(
+                    "Using Exllama backend with act_order will reorder the weights offline, thus you will not be able to save the model with the right weights."
+                    "Setting `disable_exllama=True`. You should only use Exllama backend with act_order for inference. "
                 )
                 self.disable_exllama = True
         # Step 4: Pack the model at the end (Replacing the layers)

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -483,9 +483,12 @@ class GPTQQuantizer(object):
                     "Found modules on cpu/disk. Using Exllama backend requires all the modules to be on GPU."
                     "You can deactivate exllama backend by setting `disable_exllama=True` in the quantization config object"
                 )
+        class StoreAttr(object):
+            pass
+        model.quantize_config = StoreAttr()
         model.quantize_config.desc_act = self.desc_act
         model = autogptq_post_init(model, use_act_order=self.desc_act)
-        if self.desc_act and not self.disable_exllama:
+        if self.desc_act and not self.disable_exllama and not (self.max_input_length is None):
             model = exllama_set_max_input_length(model,self.max_input_length)
         return model
 

--- a/optimum/utils/import_utils.py
+++ b/optimum/utils/import_utils.py
@@ -104,13 +104,14 @@ def is_diffusers_available():
 
 def is_auto_gptq_available():
     if _auto_gptq_available:
-        version_autogptq = packaging.version.parse(importlib_metadata.version('auto_gptq'))
+        version_autogptq = packaging.version.parse(importlib_metadata.version("auto_gptq"))
         if AUTOGPTQ_MINIMUM_VERSION <= version_autogptq:
             return True
         else:
             raise ImportError(
-            f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, but only {AUTOGPTQ_MINIMUM_VERSION} and above are supported"
-        )
+                f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, but only {AUTOGPTQ_MINIMUM_VERSION} and above are supported"
+            )
+
 
 @contextmanager
 def check_if_pytorch_greater(target_version: str, message: str):

--- a/optimum/utils/import_utils.py
+++ b/optimum/utils/import_utils.py
@@ -35,6 +35,7 @@ else:
 TORCH_MINIMUM_VERSION = packaging.version.parse("1.11.0")
 TRANSFORMERS_MINIMUM_VERSION = packaging.version.parse("4.25.0")
 DIFFUSERS_MINIMUM_VERSION = packaging.version.parse("0.18.0")
+AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.4.2")
 
 
 # This is the minimal required version to support some ONNX Runtime features
@@ -102,8 +103,14 @@ def is_diffusers_available():
 
 
 def is_auto_gptq_available():
-    return _auto_gptq_available
-
+    if _auto_gptq_available:
+        version_autogptq = packaging.version.parse(importlib_metadata.version('auto_gptq'))
+        if AUTOGPTQ_MINIMUM_VERSION <= version_autogptq:
+            return True
+        else:
+            raise ImportError(
+            f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, but only {AUTOGPTQ_MINIMUM_VERSION} and above are supported"
+        )
 
 @contextmanager
 def check_if_pytorch_greater(target_version: str, message: str):

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 from parameterized import parameterized
-from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.testing_utils import slow
 
 from optimum.gptq import GPTQQuantizer, load_quantized_model
@@ -38,7 +38,7 @@ class GPTQTest(unittest.TestCase):
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a professional photographer and I")
     EXPECTED_OUTPUTS.add("Hello my name is John and I am a very good looking man.")
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
-    
+
     # this seems a little small considering that we are doing 4bit quant but we have a small model and ww don't quantize the embeddings
     EXPECTED_RELATIVE_DIFFERENCE = 1.664253062
 
@@ -128,10 +128,15 @@ class GPTQTest(unittest.TestCase):
             self.quantizer.save(self.quantized_model, tmpdirname)
             self.quantized_model.config.save_pretrained(tmpdirname)
             with init_empty_weights():
-                empty_model = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16)
+                empty_model = AutoModelForCausalLM.from_config(
+                    AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16
+                )
             empty_model.tie_weights()
-            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=self.disable_exllama)
+            quantized_model_from_saved = load_quantized_model(
+                empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=self.disable_exllama
+            )
             self.check_inference_correctness(quantized_model_from_saved)
+
 
 class GPTQTestExllama(GPTQTest):
     disable_exllama = False
@@ -139,28 +144,28 @@ class GPTQTestExllama(GPTQTest):
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a professional photographer and I")
     EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
-    
-    
+
+
 class GPTQTestActOrder(GPTQTest):
-    
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
     EXPECTED_OUTPUTS.add("Hello my name is jessie and i am a very sweet and")
     EXPECTED_OUTPUTS.add("Hello my name is nathalie, I am a young girl from")
-    
+
     disable_exllama = True
-    desc_act=True
-    
+    desc_act = True
+
     def test_generate_quality(self):
         # act_order don't work with qlinear_cuda kernel
         pass
+
     def test_serialization(self):
         # act_order don't work with qlinear_cuda kernel
         pass
-    
+
     def test_exllama_serialization(self):
         """
-        Test the serialization of the model and the loading of the quantized weights with exllama kernel 
+        Test the serialization of the model and the loading of the quantized weights with exllama kernel
         """
         from accelerate import init_empty_weights
 
@@ -168,36 +173,45 @@ class GPTQTestActOrder(GPTQTest):
             self.quantizer.save(self.quantized_model, tmpdirname)
             self.quantized_model.config.save_pretrained(tmpdirname)
             with init_empty_weights():
-                empty_model = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16)
+                empty_model = AutoModelForCausalLM.from_config(
+                    AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16
+                )
             empty_model.tie_weights()
-            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=False)
+            quantized_model_from_saved = load_quantized_model(
+                empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=False
+            )
             self.check_inference_correctness(quantized_model_from_saved)
-        
+
     def test_exllama_max_input_length(self):
         """
         Test if the max_input_length works with exllama + act_order
         """
         from accelerate import init_empty_weights
-        
+
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.quantizer.save(self.quantized_model, tmpdirname)
             self.quantized_model.config.save_pretrained(tmpdirname)
             with init_empty_weights():
-                empty_model = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16)
+                empty_model = AutoModelForCausalLM.from_config(
+                    AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16
+                )
             empty_model.tie_weights()
-            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=False, max_input_length = 4028)
-            
+            quantized_model_from_saved = load_quantized_model(
+                empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=False, max_input_length=4028
+            )
+
             prompt = "I am in Paris and" * 1000
             inp = self.tokenizer(prompt, return_tensors="pt").to(0)
             self.assertTrue(inp["input_ids"].shape[1] > 4028)
             with self.assertRaises(RuntimeError) as cm:
-                res = quantized_model_from_saved.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
+                quantized_model_from_saved.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
                 self.assertTrue("temp_state buffer is too small" in str(cm.exception))
-            
+
             prompt = "I am in Paris and" * 500
             inp = self.tokenizer(prompt, return_tensors="pt").to(0)
             self.assertTrue(inp["input_ids"].shape[1] < 4028)
-            res = quantized_model_from_saved.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
+            quantized_model_from_saved.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
+
 
 class GPTQUtilsTest(unittest.TestCase):
     """

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -36,9 +36,8 @@ class GPTQTest(unittest.TestCase):
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is John and I am a professional photographer. I")
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a professional photographer and I")
-    EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
-    EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
     EXPECTED_OUTPUTS.add("Hello my name is John and I am a very good looking man.")
+    EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
     
     # this seems a little small considering that we are doing 4bit quant but we have a small model and ww don't quantize the embeddings
     EXPECTED_RELATIVE_DIFFERENCE = 1.664253062
@@ -131,15 +130,54 @@ class GPTQTest(unittest.TestCase):
             with init_empty_weights():
                 empty_model = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16)
             empty_model.tie_weights()
-            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0})
+            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=self.disable_exllama)
             self.check_inference_correctness(quantized_model_from_saved)
 
 class GPTQTestExllama(GPTQTest):
     disable_exllama = False
+    EXPECTED_OUTPUTS = set()
+    EXPECTED_OUTPUTS.add("Hello my name is John, I am a professional photographer and I")
+    EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
+    EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
+    
+    
+class GPTQTestActOrder(GPTQTest):
+    
+    EXPECTED_OUTPUTS = set()
+    EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
+    EXPECTED_OUTPUTS.add("Hello my name is jessie and i am a very sweet and")
+    EXPECTED_OUTPUTS.add("Hello my name is nathalie, I am a young girl from")
+    
+    disable_exllama = True
     desc_act=True
-    def test_exllama_max_input_length(self):
+    
+    def test_generate_quality(self):
+        # act_order don't work with qlinear_cuda kernel
+        pass
+    def test_serialization(self):
+        # act_order don't work with qlinear_cuda kernel
+        pass
+    
+    def test_exllama_serialization(self):
+        """
+        Test the serialization of the model and the loading of the quantized weights with exllama kernel 
+        """
         from accelerate import init_empty_weights
-        max_input_length = 4028
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.quantizer.save(self.quantized_model, tmpdirname)
+            self.quantized_model.config.save_pretrained(tmpdirname)
+            with init_empty_weights():
+                empty_model = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16)
+            empty_model.tie_weights()
+            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=False)
+            self.check_inference_correctness(quantized_model_from_saved)
+        
+    def test_exllama_max_input_length(self):
+        """
+        Test if the max_input_length works with exllama + act_order
+        """
+        from accelerate import init_empty_weights
         
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.quantizer.save(self.quantized_model, tmpdirname)
@@ -147,16 +185,19 @@ class GPTQTestExllama(GPTQTest):
             with init_empty_weights():
                 empty_model = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16)
             empty_model.tie_weights()
-            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0})
+            quantized_model_from_saved = load_quantized_model(empty_model, save_folder=tmpdirname, device_map={"": 0}, disable_exllama=False, max_input_length = 4028)
             
-            prompt = "I am in Paris and" * 450
-
+            prompt = "I am in Paris and" * 1000
             inp = self.tokenizer(prompt, return_tensors="pt").to(0)
-            self.assertTrue(inp["input_ids"].shape[1] > 2048)
-
+            self.assertTrue(inp["input_ids"].shape[1] > 4028)
             with self.assertRaises(RuntimeError) as cm:
                 res = quantized_model_from_saved.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
-            self.assertTrue("temp_state buffer is too small" in str(cm.exception))
+                self.assertTrue("temp_state buffer is too small" in str(cm.exception))
+            
+            prompt = "I am in Paris and" * 500
+            inp = self.tokenizer(prompt, return_tensors="pt").to(0)
+            self.assertTrue(inp["input_ids"].shape[1] < 4028)
+            res = quantized_model_from_saved.generate(**inp, num_beams=1, min_new_tokens=3, max_new_tokens=3)
 
 class GPTQUtilsTest(unittest.TestCase):
     """


### PR DESCRIPTION
# What does this PR do ? 
This PR bumps the minimum required version of `auto_gptq` and adds the possibility to change the max input length when using exllama + act_order with gptq. 
We also do a couple of fixes: 
- disable exllama kernel when doing quantization with act order because the user may save the model with the weights in the wrong order. exllama + act_order should only be used for inference and the user should not save the model. This is a temporary measure until we are able to reorder the weights.
- `self.quant_method = QuantizationMethod.GPTQ `for people who wants to quantize with optimum api and load it with transformers like this [tutorial](https://www.philschmid.de/gptq-llama) . 
