### PR TITLE
Fix opset custom onnx export

### DIFF
--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -573,7 +573,7 @@ class OnnxCustomExport(TestCase):
                 custom_onnx_configs=custom_onnx_configs,
                 no_post_process=True,
                 fn_get_submodels=fn_get_submodels,
-                opset=14
+                opset=14,
             )
 
     def test_custom_export_trust_remote_error(self):
@@ -587,6 +587,7 @@ class OnnxCustomExport(TestCase):
                     task="text-generation-with-past",
                     trust_remote_code=True,
                     no_post_process=True,
+                    opset=14,
                 )
 
         self.assertIn("custom or unsupported architecture", str(context.exception))

--- a/tests/exporters/onnx/test_onnx_export.py
+++ b/tests/exporters/onnx/test_onnx_export.py
@@ -573,6 +573,7 @@ class OnnxCustomExport(TestCase):
                 custom_onnx_configs=custom_onnx_configs,
                 no_post_process=True,
                 fn_get_submodels=fn_get_submodels,
+                opset=14
             )
 
     def test_custom_export_trust_remote_error(self):


### PR DESCRIPTION
# What does this PR do?

Fix opset for onnx export

Current tests fail with this error 

```bash
torch.onnx.errors.UnsupportedOperatorError: Exporting the operator 'aten::tril' to ONNX opset version 13 is not supported. Support for this operator was added in version 14, try exporting with this version.
```
