### PR TITLE
send both negative prompt embeds to ORT SDXL

### DIFF
--- a/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl.py
+++ b/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl.py
@@ -158,7 +158,7 @@ class StableDiffusionXLPipelineMixin(DiffusionPipelineMixin):
                 # Here we concatenate the unconditional and text embeddings into a single batch
                 # to avoid doing two forward passes
                 negative_prompt_embeds_list.append(negative_prompt_embeds)
-            negative_prompt_embeds = np.concatenate(negative_prompt_embeds, axis=-1)
+            negative_prompt_embeds = np.concatenate(negative_prompt_embeds_list, axis=-1)
 
         pooled_prompt_embeds = np.repeat(pooled_prompt_embeds, num_images_per_prompt, axis=0)
         negative_pooled_prompt_embeds = np.repeat(negative_pooled_prompt_embeds, num_images_per_prompt, axis=0)


### PR DESCRIPTION
# What does this PR do?

Running the SDXL ORT pipeline with a negative prompt throws an error related to the shape of the embeds:

```
Traceback (most recent call last):
  File "/opt/onnx-web/api/onnx_web/chain/base.py", line 158, in stage_tile
    output_tile = stage_pipe.run(
  File "/opt/onnx-web/api/onnx_web/chain/source_txt2img.py", line 109, in run
    result = pipe(
  File "/home/ssube/miniconda3/envs/onnx-web-rocm-pytorch2/lib/python3.9/site-packages/optimum/onnxruntime/modeling_diffusion.py", line 590, in __call__
    return StableDiffusionXLPipelineMixin.__call__(self, *args, **kwargs)
  File "/home/ssube/miniconda3/envs/onnx-web-rocm-pytorch2/lib/python3.9/site-packages/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl.py", line 446, in __call__
    prompt_embeds = np.concatenate((negative_prompt_embeds, prompt_embeds), axis=0)
  File "<__array_function__ internals>", line 200, in concatenate
ValueError: all the input array dimensions except for the concatenation axis must match exactly, but along dimension 2, the array at index 0 has size 1280 and the array at index 1 has size 2048
```

It looks like the `negative_prompt_embeds` and `negative_prompt_embeds_list` got mixed up on https://github.com/huggingface/optimum/blob/main/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl.py#L161C53-L161C75. Using `negative_prompt_embeds = np.concatenate(negative_prompt_embeds_list, axis=-1)` fixes the error.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

