### PR TITLE
Add name_or_path for donut generation

### DIFF
--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -607,6 +607,7 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
             preprocessors=preprocessors,
         )
         self.config = config
+        self.name_or_path = config.name_or_path
 
         self.onnx_paths = onnx_paths
         self.use_cache = use_cache

--- a/tests/benchmark/benchmark_bettertransformer.py
+++ b/tests/benchmark/benchmark_bettertransformer.py
@@ -1,13 +1,14 @@
 import argparse
 
+import numpy as np
+import pandas as pd
 import torch
 from tqdm import tqdm
 from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer, GenerationConfig
 
 from optimum.bettertransformer import BetterTransformer
 from optimum.exporters import TasksManager
-import numpy as np
-import pandas as pd
+
 
 def get_parser():
     parser = argparse.ArgumentParser()
@@ -59,11 +60,7 @@ def get_parser():
         "--use-mask",
         action="store_true",
     )
-    parser.add_argument(
-        "--is_decoder",
-        action="store_true",
-        help="Benchmark the generate method."
-    )
+    parser.add_argument("--is_decoder", action="store_true", help="Benchmark the generate method.")
     parser.add_argument(
         "--sweep",
         action="store_true",


### PR DESCRIPTION
Fix following https://github.com/huggingface/transformers/pull/22955

cc @mht-sharma @IlyasMoutawwakil

Currently if `decoder_input_ids` is passed (which is typically the case for donut, see https://huggingface.co/docs/transformers/v4.32.1/en/model_doc/donut#inference), inference with ORT for donut will fail:

```
  File "/home/fxmarty/hf_internship/transformers/src/transformers/generation/utils.py", line 1499, in generate
    input_ids, model_kwargs = self._prepare_decoder_input_ids_for_generation(
  File "/home/fxmarty/hf_internship/transformers/src/transformers/generation/utils.py", line 695, in _prepare_decoder_input_ids_for_generation
    elif self.config.model_type == "vision-encoder-decoder" and "donut" in self.name_or_path.lower():
AttributeError: 'ORTModelForVision2Seq' object has no attribute 'name_or_path'
```

due to https://github.com/huggingface/transformers/blob/bfb1895e3346cb8a2bf2560c75d45e70edf46a47/src/transformers/generation/utils.py#L694

Found out about the issue thanks to https://github.com/huggingface/optimum/issues/1337