### PR TITLE
Add GPT BigCode to the BT documentation

### DIFF
--- a/docs/source/bettertransformer/overview.mdx
+++ b/docs/source/bettertransformer/overview.mdx
@@ -55,6 +55,7 @@ The list of supported model below:
 - [GPT-j](https://huggingface.co/EleutherAI/gpt-j-6B)
 - [GPT-neo](https://github.com/EleutherAI/gpt-neo)
 - [GPT-neo-x](https://arxiv.org/abs/2204.06745)
+- [GPT BigCode](https://arxiv.org/abs/2301.03988) (SantaCoder, StarCoder)
 - [HuBERT](https://arxiv.org/pdf/2106.07447.pdf)
 - [LayoutLM](https://arxiv.org/abs/1912.13318)
 - [MarkupLM](https://arxiv.org/abs/2110.08518)


### PR DESCRIPTION
Forgot it when adding the support.