### PR TITLE
Fix wrong dtype in the ONNX export

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -272,10 +272,11 @@ def main_export(
     if (framework == "tf" and fp16 is True) or not is_torch_available():
         raise ValueError("The --fp16 option is supported only for PyTorch.")
 
-    if fp16 is True and device == "cpu":
-        raise ValueError(
-            "FP16 export is supported only when exporting on GPU. Please pass the option `--device cuda`."
-        )
+    if fp16:
+        if device == "cpu":
+            raise ValueError(
+                "FP16 export is supported only when exporting on GPU. Please pass the option `--device cuda`."
+            )
         float_dtype = "fp16"
     else:
         float_dtype = "fp32"

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -847,8 +847,6 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
     def with_behavior(
         self,
         behavior: Union[str, ConfigBehavior],
-        int_dtype: str = "int64",
-        float_dtype: str = "fp32",
         use_past: bool = False,
     ) -> "OnnxSeq2SeqConfigWithPast":
         """
@@ -859,10 +857,6 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
                 The behavior to use for the new instance.
             use_past (`bool`, defaults to `False`):
                 Whether or not the new instance should use past.
-            int_dtype (`str`, defaults to `"int64"`):
-                The data type of integer tensors, could be ["int64", "int32", "int8"], default to "int64".
-            float_dtype (`str`, defaults to `"fp32"`):
-                The data type of float tensors, could be ["fp32", "fp16", "bf16"], default to "fp32".
 
         Returns:
             `OnnxSeq2SeqConfigWithPast`
@@ -872,8 +866,8 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
         return self.__class__(
             self._config,
             task=self.task,
-            int_dtype=int_dtype,
-            float_dtype=float_dtype,
+            int_dtype=self.int_dtype,
+            float_dtype=self.float_dtype,
             use_past=use_past,
             behavior=behavior,
             preprocessors=self._preprocessors,

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -236,12 +236,19 @@ def get_decoder_models_for_export(
     models_for_export = _get_submodels_for_export_decoder(model, use_past=config.use_past)
 
     onnx_config = config.__class__(
-        model.config, task=config.task, use_past_in_inputs=False, use_present_in_outputs=True
+        model.config,
+        task=config.task,
+        use_past_in_inputs=False,
+        use_present_in_outputs=True,
+        float_dtype=config.float_dtype,
+        int_dtype=config.int_dtype,
     )
     models_for_export[ONNX_DECODER_NAME] = (models_for_export[ONNX_DECODER_NAME], onnx_config)
 
     if config.use_past:
-        onnx_config_with_past = config.__class__(model.config, task=config.task, use_past=True)
+        onnx_config_with_past = config.__class__(
+            model.config, task=config.task, use_past=True, float_dtype=config.float_dtype, int_dtype=config.int_dtype
+        )
         models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (
             models_for_export[ONNX_DECODER_WITH_PAST_NAME],
             onnx_config_with_past,


### PR DESCRIPTION
Bug introduced in https://github.com/huggingface/optimum/pull/1307, not catched in the review and visibly the GPU tests were not run offline. This will need a patch release as the fp16 ONNX export is broken.