### PR TITLE
Guard multiprocessing set start method

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -243,7 +243,7 @@ def main_export(
         fn_get_submodels (`Optional[Callable]`, defaults to `None`):
             Experimental usage: Override the default submodels that are used at the export. This is
             especially useful when exporting a custom architecture that needs to split the ONNX (e.g. encoder-decoder). If unspecified with custom models, optimum will try to use the default submodels used for the given task, with no guarantee of success.
-        use_subprocess (`bool`):
+        use_subprocess (`bool`, defaults to `False`):
             Do the ONNX exported model validation in subprocesses. This is especially useful when
             exporting on CUDA device, where ORT does not release memory at inference session
             destruction. When set to `True`, the `main_export` call should be guarded in
@@ -524,6 +524,10 @@ def main_export(
     elif model.config.model_type in UNPICKABLE_ARCHS:
         # Pickling is bugged for nn.utils.weight_norm: https://github.com/pytorch/pytorch/issues/102983
         # TODO: fix "Cowardly refusing to serialize non-leaf tensor" error for wav2vec2-conformer
+        use_subprocess = False
+
+    if device == "cpu":
+        # Using multiprocessing for validation is useful only on CUDA EP that leaks memory.
         use_subprocess = False
 
     if do_validation is True:

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -54,9 +54,6 @@ if is_tf_available():
     from transformers.modeling_tf_utils import TFPreTrainedModel
 
 
-mp.set_start_method("spawn", force=True)
-
-
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
@@ -217,6 +214,9 @@ def validate_model_outputs(
         ValueError: If the outputs shapes or values do not match between the reference and the exported model.
     """
     if use_subprocess:
+        # InferenceSession do not support the fork start method with some EP: https://github.com/microsoft/onnxruntime/issues/7846
+        mp.set_start_method("spawn", force=True)
+
         io_process = ValidationProcess(
             config, reference_model, onnx_model, onnx_named_outputs, atol, input_shapes, device, dtype, model_kwargs
         )


### PR DESCRIPTION
As per title, we do not want to globally set the multiprocessing start method simply when importing `convert.py`, as it may mess up with external tools that rely on the fork start method.

Fixes https://github.com/huggingface/optimum/issues/1327