### PR TITLE
Add position ids in ONNX export and ORT

### DIFF
--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -129,6 +129,20 @@ def parse_args_onnx(parser):
             " it."
         ),
     )
+    optional_group.add_argument(
+        "--library-name",
+        type=str,
+        choices=["transformers", "diffusers", "timm"],
+        default=None,
+        help=("The library on the model." " If not provided, will attempt to infer the local checkpoint's library"),
+    )
+    optional_group.add_argument(
+        "--no-position-ids",
+        action="store_true",
+        help=(
+            "Disable the use of position_ids for text-generation models that require it for batched generation. This argument is introduced for backward compatibility and will be removed in a future release of Optimum."
+        ),
+    )
 
     input_group = parser.add_argument_group(
         "Input shapes (if necessary, this allows to override the shapes of the input given to the ONNX exporter, that requires an example input)."
@@ -203,13 +217,6 @@ def parse_args_onnx(parser):
         default=DEFAULT_DUMMY_SHAPES["nb_points_per_image"],
         help="For Segment Anything. It corresponds to the number of points per segmentation masks.",
     )
-    optional_group.add_argument(
-        "--library_name",
-        type=str,
-        choices=["transformers", "diffusers", "timm"],
-        default=None,
-        help=("The library on the model." " If not provided, will attempt to infer the local checkpoint's library"),
-    )
 
     # deprecated argument
     parser.add_argument("--for-ort", action="store_true", help=argparse.SUPPRESS)
@@ -248,5 +255,6 @@ class ONNXExportCommand(BaseOptimumCLICommand):
             use_subprocess=True,
             _variant=self.args.variant,
             library_name=self.args.library_name,
+            no_position_ids=self.args.no_position_ids,
             **input_shapes,
         )

--- a/optimum/exporters/onnx/__init__.py
+++ b/optimum/exporters/onnx/__init__.py
@@ -26,6 +26,7 @@ _import_structure = {
         "get_decoder_models_for_export",
         "get_encoder_decoder_models_for_export",
         "get_stable_diffusion_models_for_export",
+        "MODEL_TYPES_REQUIRING_POSITION_IDS",
     ],
     "__main__": ["main_export"],
 }
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
         get_decoder_models_for_export,
         get_encoder_decoder_models_for_export,
         get_stable_diffusion_models_for_export,
+        MODEL_TYPES_REQUIRING_POSITION_IDS,
     )
     from .__main__ import main_export
 else:

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -31,6 +31,7 @@ from .base import OnnxConfigWithPast
 from .constants import UNPICKABLE_ARCHS
 from .convert import export_models, validate_models_outputs
 from .utils import (
+    MODEL_TYPES_REQUIRING_POSITION_IDS,
     _get_submodels_for_export_decoder,
     _get_submodels_for_export_encoder_decoder,
     _get_submodels_for_export_stable_diffusion,
@@ -67,6 +68,7 @@ def _get_submodels_and_onnx_configs(
     float_dtype: str = "fp32",
     fn_get_submodels: Optional[Callable] = None,
     preprocessors: Optional[List[Any]] = None,
+    no_position_ids: bool = False,
 ):
     is_stable_diffusion = "stable-diffusion" in task
     if not custom_architecture:
@@ -79,8 +81,16 @@ def _get_submodels_and_onnx_configs(
             onnx_config_constructor = TasksManager.get_exporter_config_constructor(
                 model=model, exporter="onnx", task=task
             )
+            onnx_config_kwargs = {}
+            if task.startswith("text-generation"):
+                onnx_config_kwargs["no_position_ids"] = no_position_ids
+
             onnx_config = onnx_config_constructor(
-                model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors
+                model.config,
+                int_dtype=int_dtype,
+                float_dtype=float_dtype,
+                preprocessors=preprocessors,
+                **onnx_config_kwargs,
             )
 
             onnx_config.variant = _variant
@@ -174,6 +184,7 @@ def main_export(
     use_subprocess: bool = False,
     _variant: str = "default",
     library_name: Optional[str] = None,
+    no_position_ids: bool = False,
     **kwargs_shapes,
 ):
     """
@@ -253,6 +264,8 @@ def main_export(
         library_name (`Optional[str]`, defaults to `None`):
             The library of the model(`"tansformers"` or `"diffusers"` or `"timm"`). If not provided, will attempt to automatically detect
             the library name for the checkpoint.
+        no_position_ids (`bool`, defaults to `False`):
+            Disable the use of position_ids for text-generation models that require it for batched generation. This argument is introduced for backward compatibility and will be removed in a future release of Optimum.
         **kwargs_shapes (`Dict`):
             Shapes to use during inference. This argument allows to override the default shapes used during the ONNX export.
 
@@ -340,6 +353,11 @@ def main_export(
     is_stable_diffusion = "stable-diffusion" in task
     model_type = "stable-diffusion" if is_stable_diffusion else model.config.model_type.replace("_", "-")
 
+    if no_position_ids and model_type in MODEL_TYPES_REQUIRING_POSITION_IDS and task.startswith("text-generation"):
+        logger.warning(
+            f"no_position_ids=True was specified in the ONNX export, although the model {model_name_or_path} (model type {model_type}) requires position_ids for batched inference. Passing `no_position_ids=True` is strongly discouraged, and this option will be removed in a future release. Reference: https://github.com/huggingface/optimum/pull/1381"
+        )
+
     if not is_stable_diffusion:
         if model_type in TasksManager._UNSUPPORTED_CLI_MODEL_TYPE:
             raise ValueError(
@@ -406,6 +424,7 @@ def main_export(
         fn_get_submodels=fn_get_submodels,
         preprocessors=preprocessors,
         _variant=_variant,
+        no_position_ids=no_position_ids,
     )
 
     if not is_stable_diffusion:

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -82,7 +82,7 @@ def _get_submodels_and_onnx_configs(
                 model=model, exporter="onnx", task=task
             )
             onnx_config_kwargs = {}
-            if task.startswith("text-generation"):
+            if task.startswith("text-generation") and no_position_ids:
                 onnx_config_kwargs["no_position_ids"] = no_position_ids
 
             onnx_config = onnx_config_constructor(

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -664,7 +664,7 @@ class OnnxConfigWithPast(OnnxConfig, ABC):
             self.use_past
             and self.use_past_in_inputs
             and self.use_cache_branch is not False
-            and input_name in ["decoder_input_ids", "input_ids"]
+            and input_name in ["decoder_input_ids", "input_ids", "position_ids"]
         ):
             sequence_length = dummy_input_gen.sequence_length
             # Use a sequence length of 1 when the KV cache is already populated.

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -66,6 +66,29 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, DummyPastKeyValuesGenerator)
     DUMMY_PKV_GENERATOR_CLASS = DummyPastKeyValuesGenerator
 
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        use_past: bool = False,
+        use_past_in_inputs: bool = False,
+        preprocessors: Optional[List[Any]] = None,
+        no_position_ids: bool = False,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            use_past=use_past,
+            use_past_in_inputs=use_past_in_inputs,
+            preprocessors=preprocessors,
+        )
+        # TODO: remove no_position_ids once optimum is sufficiently above 1.13
+        self.no_position_ids = no_position_ids
+
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:
         if self.use_past_in_inputs:

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -183,10 +183,11 @@ class GPT2OnnxConfig(TextDecoderOnnxConfig):
         # Decoders based on GPT2 require a position_ids input to avoid
         # generating wrong position_ids in the model itself:
         # https://github.com/huggingface/transformers/blob/v4.33.1/src/transformers/models/gpt2/modeling_gpt2.py#L802
-        if self.use_past_in_inputs:
-            common_inputs["position_ids"] = {0: "batch_size"}
-        else:
-            common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
+        if not self.no_position_ids:
+            if self.use_past_in_inputs:
+                common_inputs["position_ids"] = {0: "batch_size"}
+            else:
+                common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
 
         return common_inputs
 
@@ -222,10 +223,11 @@ class GPTNeoOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if self.use_past_in_inputs:
-            common_inputs["position_ids"] = {0: "batch_size"}
-        else:
-            common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
+        if not self.no_position_ids:
+            if self.use_past_in_inputs:
+                common_inputs["position_ids"] = {0: "batch_size"}
+            else:
+                common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
         return common_inputs
 
 
@@ -238,10 +240,11 @@ class GPTNeoXOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if self.use_past_in_inputs:
-            common_inputs["position_ids"] = {0: "batch_size"}
-        else:
-            common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
+        if not self.no_position_ids:
+            if self.use_past_in_inputs:
+                common_inputs["position_ids"] = {0: "batch_size"}
+            else:
+                common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
         return common_inputs
 
 
@@ -260,10 +263,11 @@ class LlamaOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if self.use_past_in_inputs:
-            common_inputs["position_ids"] = {0: "batch_size"}
-        else:
-            common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
+        if not self.no_position_ids:
+            if self.use_past_in_inputs:
+                common_inputs["position_ids"] = {0: "batch_size"}
+            else:
+                common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
         return common_inputs
 
 
@@ -341,10 +345,11 @@ class GPTBigCodeOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if self.use_past_in_inputs:
-            common_inputs["position_ids"] = {0: "batch_size"}
-        else:
-            common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
+        if not self.no_position_ids:
+            if self.use_past_in_inputs:
+                common_inputs["position_ids"] = {0: "batch_size"}
+            else:
+                common_inputs["position_ids"] = {0: "batch_size", 1: "sequence_length"}
         return common_inputs
 
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -183,7 +183,7 @@ class GPT2OnnxConfig(TextDecoderOnnxConfig):
         # Decoders based on GPT2 require a position_ids input to avoid
         # generating wrong position_ids in the model itself:
         # https://github.com/huggingface/transformers/blob/v4.33.1/src/transformers/models/gpt2/modeling_gpt2.py#L802
-        if not self.no_position_ids:
+        if not self.no_position_ids and self.task == "text-generation":
             if self.use_past_in_inputs:
                 common_inputs["position_ids"] = {0: "batch_size"}
             else:
@@ -223,7 +223,7 @@ class GPTNeoOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if not self.no_position_ids:
+        if not self.no_position_ids and self.task == "text-generation":
             if self.use_past_in_inputs:
                 common_inputs["position_ids"] = {0: "batch_size"}
             else:
@@ -240,7 +240,7 @@ class GPTNeoXOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if not self.no_position_ids:
+        if not self.no_position_ids and self.task == "text-generation":
             if self.use_past_in_inputs:
                 common_inputs["position_ids"] = {0: "batch_size"}
             else:
@@ -263,7 +263,7 @@ class LlamaOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if not self.no_position_ids:
+        if not self.no_position_ids and self.task == "text-generation":
             if self.use_past_in_inputs:
                 common_inputs["position_ids"] = {0: "batch_size"}
             else:
@@ -345,7 +345,7 @@ class GPTBigCodeOnnxConfig(TextDecoderOnnxConfig):
         common_inputs = super().inputs
 
         # Refer to GPT2OnnxConfig inputs comment.
-        if not self.no_position_ids:
+        if not self.no_position_ids and self.task == "text-generation":
             if self.use_past_in_inputs:
                 common_inputs["position_ids"] = {0: "batch_size"}
             else:

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -247,26 +247,24 @@ def get_decoder_models_for_export(
     """
     models_for_export = _get_submodels_for_export_decoder(model, use_past=config.use_past)
 
+    onnx_kwargs = {"task": config.task, "float_dtype": config.float_dtype, "int_dtype": config.int_dtype}
+    if model.config.model_type.replace("_", "-") in MODEL_TYPES_REQUIRING_POSITION_IDS:
+        onnx_kwargs["no_position_ids"] = config.no_position_ids
+
     onnx_config = config.__class__(
         model.config,
-        task=config.task,
         use_past=config.use_past,
         use_past_in_inputs=False,
-        float_dtype=config.float_dtype,
-        int_dtype=config.int_dtype,
-        no_position_ids=config.no_position_ids,
+        **onnx_kwargs,
     )
     models_for_export[ONNX_DECODER_NAME] = (models_for_export[ONNX_DECODER_NAME], onnx_config)
 
     if config.use_past:
         onnx_config_with_past = config.__class__(
             model.config,
-            task=config.task,
             use_past=True,
             use_past_in_inputs=True,
-            float_dtype=config.float_dtype,
-            int_dtype=config.int_dtype,
-            no_position_ids=config.no_position_ids,
+            **onnx_kwargs,
         )
         models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (
             models_for_export[ONNX_DECODER_WITH_PAST_NAME],

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -65,6 +65,18 @@ if TYPE_CHECKING:
         from diffusers import ModelMixin, StableDiffusionPipeline
 
 
+MODEL_TYPES_REQUIRING_POSITION_IDS = {
+    "codegen",
+    "gpt2",
+    "gpt-bigcode",
+    "gpt-neo",
+    "gpt-neox",
+    "gptj",
+    "imagegpt",
+    "llama",
+}
+
+
 def check_onnxruntime_requirements(minimum_version: version.Version):
     """
     Checks that ONNX Runtime is installed and if version is recent enough.
@@ -242,6 +254,7 @@ def get_decoder_models_for_export(
         use_past_in_inputs=False,
         float_dtype=config.float_dtype,
         int_dtype=config.int_dtype,
+        no_position_ids=config.no_position_ids,
     )
     models_for_export[ONNX_DECODER_NAME] = (models_for_export[ONNX_DECODER_NAME], onnx_config)
 
@@ -253,6 +266,7 @@ def get_decoder_models_for_export(
             use_past_in_inputs=True,
             float_dtype=config.float_dtype,
             int_dtype=config.int_dtype,
+            no_position_ids=config.no_position_ids,
         )
         models_for_export[ONNX_DECODER_WITH_PAST_NAME] = (
             models_for_export[ONNX_DECODER_WITH_PAST_NAME],

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -326,6 +326,7 @@ class ORTDecoder(ORTModelPart):
         self,
         input_ids: torch.LongTensor,
         attention_mask: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache_branch: None = None,
@@ -364,6 +365,9 @@ class ORTDecoder(ORTModelPart):
 
             if "attention_mask" in self.input_names:
                 model_inputs.append(attention_mask)
+
+            if "position_ids" in self.input_names:
+                model_inputs.append(position_ids)
 
             if past_key_values is not None:
                 model_inputs += past_key_values
@@ -421,6 +425,9 @@ class ORTDecoder(ORTModelPart):
                     for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
                         onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
 
+                if "position_ids" in self.input_names:
+                    onnx_inputs["position_ids"] = position_ids.cpu().detach().numpy()
+
                 if "labels" in self.input_names:
                     onnx_inputs["labels"] = labels.cpu().detach().numpy()
             else:
@@ -436,6 +443,9 @@ class ORTDecoder(ORTModelPart):
                     # Add the past_key_values to the decoder inputs
                     for input_name, past_key_value in zip(self.key_value_input_names, past_key_values):
                         onnx_inputs[input_name] = past_key_value
+
+                if "position_ids" in self.input_names:
+                    onnx_inputs["position_ids"] = position_ids
 
                 if "labels" in self.input_names:
                     onnx_inputs["labels"] = labels

--- a/optimum/onnxruntime/base.py
+++ b/optimum/onnxruntime/base.py
@@ -368,6 +368,8 @@ class ORTDecoder(ORTModelPart):
                 model_inputs.append(attention_mask)
 
             if "position_ids" in self.input_names:
+                if position_ids is None:
+                    raise ValueError("position_ids was not passed but is a required input for this ONNX model.")
                 model_inputs.append(position_ids.contiguous())
 
             if past_key_values is not None:
@@ -427,6 +429,8 @@ class ORTDecoder(ORTModelPart):
                         onnx_inputs[input_name] = past_key_value.cpu().detach().numpy()
 
                 if "position_ids" in self.input_names:
+                    if position_ids is None:
+                        raise ValueError("position_ids was not passed but is a required input for this ONNX model.")
                     onnx_inputs["position_ids"] = position_ids.cpu().detach().numpy()
 
                 if "labels" in self.input_names:
@@ -446,6 +450,8 @@ class ORTDecoder(ORTModelPart):
                         onnx_inputs[input_name] = past_key_value
 
                 if "position_ids" in self.input_names:
+                    if position_ids is None:
+                        raise ValueError("position_ids was not passed but is a required input for this ONNX model.")
                     onnx_inputs["position_ids"] = position_ids
 
                 if "labels" in self.input_names:

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -687,7 +687,7 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
     def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
         # if model is used as a decoder in encoder-decoder model, the decoder attention mask is created on the fly
 
-        attention_mask = kwargs.get("attention_mask", None)  # input_ids.new_ones(input_ids.shape)
+        attention_mask = kwargs.get("attention_mask", None)
         use_cache = kwargs.get("use_cache", None)
 
         position_ids = kwargs.get("position_ids", None)
@@ -779,7 +779,7 @@ class ORTBloomForCausalLM(ORTModelForCausalLM):
 class ORTOPTForCausalLM(ORTModelForCausalLM):
     # Adapted from transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
     def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
-        attention_mask = kwargs.get("attention_mask", None)  # input_ids.new_ones(input_ids.shape)
+        attention_mask = kwargs.get("attention_mask", None)
         use_cache = kwargs.get("use_cache", None)
 
         return {
@@ -794,7 +794,7 @@ class ORTOPTForCausalLM(ORTModelForCausalLM):
 class ORTMPTForCausalLM(ORTModelForCausalLM):
     # Adapted from transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
     def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
-        attention_mask = kwargs.get("attention_mask", None)  # input_ids.new_ones(input_ids.shape)
+        attention_mask = kwargs.get("attention_mask", None)
         use_cache = kwargs.get("use_cache", None)
 
         return {

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -683,7 +683,6 @@ class ORTModelForCausalLM(ORTModelDecoder, GenerationMixin):
         attention_mask = kwargs.get("attention_mask", None)  # input_ids.new_ones(input_ids.shape)
         use_cache = kwargs.get("use_cache", None)
 
-        # TODO: this is not relevant for bloom, mpt, opt! We should probably inherit and have ORTBloomModelForCausalLM, ORTMPTModelForCausalLM, ORTOPTModelForCausalLM (initialized from ORTModelForCausalLM)
         position_ids = kwargs.get("position_ids", None)
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -741,7 +741,6 @@ class ORTModel(OptimizedModel):
         Returns:
             `Tuple[ort.IOBinding, Dict[str, Tuple[int]], Dict[str, torch.Tensor]`: The IOBinding object, a dictionary
             containing the shape of each output, and another one pointing to the buffers containing the outputs data.
-
         """
         io_binding = model.io_binding()
 

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -324,6 +324,7 @@ class DummyTextInputGenerator(DummyInputGenerator):
         "input_ids",
         "attention_mask",
         "token_type_ids",
+        "position_ids",
     )
 
     def __init__(

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1043,6 +1043,11 @@ class ORTModelIntegrationTest(unittest.TestCase):
 
         inputs = tokenizer("My name is", return_tensors="pt")
 
+        input_shape = inputs["input_ids"].shape
+        inputs["position_ids"] = (
+            torch.arange(0, input_shape[-1], dtype=torch.long).unsqueeze(0).view(-1, input_shape[-1])
+        )
+
         with torch.inference_mode():
             pt_logits = pt_model(**inputs).logits
 


### PR DESCRIPTION
Supersede https://github.com/huggingface/optimum/pull/1289 & https://github.com/huggingface/optimum/pull/984

Fix a critical issue where the exported ONNX models could not produce meaningful results for batch size > 1 due to a very strong assumption in transformers: that all sequences are of the same length if `position_ids` is not passed. See: https://github.com/huggingface/transformers/blob/a796f7eea6c86b54671a6f522cebbe41f630bb62/src/transformers/models/gpt2/modeling_gpt2.py#L802

Left to do:
- [x] Add an option to export without position_ids for backward compatibility (disabled by default)
- [ ] Fix models on the Hub [will only do for those under Optimum namespace - but not until we have a release]
- [x] Add ORT tests that would have catched the issue [the added batched generation test indeed fails on `main`)

cc @xenova 