### PR TITLE
add missing HubertEncoderLayerStableLayerNorm mapping to support hubert large model.

### DIFF
--- a/optimum/bettertransformer/models/__init__.py
+++ b/optimum/bettertransformer/models/__init__.py
@@ -84,7 +84,10 @@ class BetterTransformerManager:
         "gptj": {"GPTJAttention": GPTJAttentionLayerBetterTransformer},
         "gpt_neo": {"GPTNeoSelfAttention": GPTNeoAttentionLayerBetterTransformer},
         "gpt_neox": {"GPTNeoXAttention": GPTNeoXAttentionLayerBetterTransformer},
-        "hubert": {"HubertEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer},
+        "hubert": {
+            "HubertEncoderLayer": Wav2Vec2EncoderLayerBetterTransformer,
+            "HubertEncoderLayerStableLayerNorm": Wav2Vec2EncoderLayerBetterTransformer,
+        },
         "layoutlm": {"LayoutLMLayer": BertLayerBetterTransformer},
         "llama": {"LlamaAttention": LlamaAttentionLayerBetterTransformer},
         "m2m_100": {


### PR DESCRIPTION
# What does this PR do?

add EncoderLayerStableLayerNorm to mapping table for large models, which using EncoderLayerStableLayerNorm


Fixes #1386 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

