### PR TITLE
Add smooth quant

### DIFF
--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -278,7 +278,7 @@ class QuantizationConfig:
             It only works if SmoothQuant is True. If enabled, inserted Mul ops during
             SmoothQuant will be folded into the previous op if the previous op is foldable.
         smooth_quant_op_types (`List[str]`, defaults to `[]`):
-            The op types to be smooth quantized
+            The op types to be smooth quantized. Defaults to ["Gemm", "Conv", "MatMul", "FusedConv"].
     """
 
     is_static: bool

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -286,6 +286,9 @@ class QuantizationConfig:
     qdq_op_type_per_channel_support_to_axis: Dict[str, int] = field(
         default_factory=lambda: ORT_DEFAULT_CHANNEL_FOR_OPERATORS
     )
+    SmoothQuant: bool = False
+    SmoothQuantAlpha: float = 0.5
+    SmoothQuantFolding: bool = True
 
     def __post_init__(self):
         ensure_valid_mode_or_raise(self.is_static, self.mode)

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -267,6 +267,18 @@ class QuantizationConfig:
         qdq_op_type_per_channel_support_to_axis (`Dict[str, int]`):
             Set the channel axis for a specific operator type. Effective only when per channel quantization is
             supported and `per_channel` is set to True.
+        smooth_quant (`bool`, defaults to `False`) :
+            Default is False. If enabled, SmoothQuant algorithm will be applied before quantization to do
+            fake input channel quantization.
+        smooth_quant_alpha (`float`, defaults to `0.5`) :
+            Default is 0.5. It only works if SmoothQuant is True. It controls the difficulty of weight
+            and activation quantization. A larger alpha value could be used on models with more significant
+            activation outliers to migrate more quantization difficulty to weights.
+        smooth_quant_folding (`bool`, defaults to `True`) :
+            It only works if SmoothQuant is True. If enabled, inserted Mul ops during
+            SmoothQuant will be folded into the previous op if the previous op is foldable.
+        smooth_quant_op_types (`List[str]`, defaults to `[]`):
+            The op types to be smooth quantized
     """
 
     is_static: bool
@@ -396,7 +408,6 @@ class AutoQuantizationConfig:
         nodes_to_quantize: Optional[List[str]] = None,
         nodes_to_exclude: Optional[List[str]] = None,
         operators_to_quantize: Optional[List[str]] = None,
-        smooth_quant_op_types: Optional[List[str]] = None,
     ):
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for ARM64.
@@ -450,7 +461,6 @@ class AutoQuantizationConfig:
         nodes_to_quantize: Optional[List[str]] = None,
         nodes_to_exclude: Optional[List[str]] = None,
         operators_to_quantize: Optional[List[str]] = None,
-        smooth_quant_op_types: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for CPU with AVX2 instruction set.
@@ -508,7 +518,6 @@ class AutoQuantizationConfig:
         nodes_to_quantize: Optional[List[str]] = None,
         nodes_to_exclude: Optional[List[str]] = None,
         operators_to_quantize: Optional[List[str]] = None,
-        smooth_quant_op_types: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for CPU with AVX512 instruction set.
@@ -565,7 +574,6 @@ class AutoQuantizationConfig:
         nodes_to_quantize: Optional[List[str]] = None,
         nodes_to_exclude: Optional[List[str]] = None,
         operators_to_quantize: Optional[List[str]] = None,
-        smooth_quant_op_types: Optional[List[str]] = None,
     ) -> QuantizationConfig:
         """
         Creates a [`~onnxruntime.QuantizationConfig`] fit for CPU with AVX512-VNNI instruction set.

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -482,6 +482,7 @@ class ORTQuantizer(OptimumQuantizer):
     def get_calibration_dataset(
         self,
         dataset_name: str,
+        data_files: str = None,
         num_samples: int = 100,
         dataset_config_name: Optional[str] = None,
         dataset_split: Optional[str] = None,
@@ -525,6 +526,7 @@ class ORTQuantizer(OptimumQuantizer):
         calib_dataset = load_dataset(
             dataset_name,
             name=dataset_config_name,
+            data_files=data_files,
             split=dataset_split,
             use_auth_token=use_auth_token,
         )


### PR DESCRIPTION
# What does this PR do?

Integrates the `SmoothQuant` into the `Optimum ONNXRuntime Quantizer`.

1. The implementation uses `INC` behind the scenes for the quantisation.
2. To apply smooth quant call the `quantizer.apply_smooth_quant` before the calibration step in the regular quantization process.

## Usage
```python
# Load calibration dataset
calibration_dataset = quantizer.get_calibration_dataset(...)

# Apply smooth quantization to the model
quantizer.apply_smooth_quant(
    dataset=calibration_dataset,
    save_dir=save_dir,
    quantization_config=qconfig,
)

# Perform calibration
quantizer.fit(...)

```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

