### PR TITLE
Disable bart onnx export for text-classification and question-answering

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -301,8 +301,10 @@ class TasksManager:
             "text-generation-with-past",
             "text2text-generation",
             "text2text-generation-with-past",
-            "text-classification",
-            "question-answering",
+            # text-classification and question-answering can be supported, but the ONNX export is currently broken due to a regression in PyTorch 2.1.
+            # Reference: https://github.com/pytorch/pytorch/issues/110597.
+            # "text-classification",
+            # "question-answering",
             onnx="BartOnnxConfig",
         ),
         # BEiT cannot be used with the masked image modeling autoclass, so this task is excluded here

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1055,7 +1055,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
 class ORTModelForQuestionAnsweringIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        "bart",
+        # "bart",  # see tasks.py
         "bert",
         # "big_bird",
         # "bigbird_pegasus",
@@ -1372,7 +1372,7 @@ class ORTModelForMaskedLMIntegrationTest(ORTModelTestMixin):
 class ORTModelForSequenceClassificationIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        "bart",
+        # "bart",  # see tasks.py
         "bert",
         # "big_bird",
         # "bigbird_pegasus",

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -89,7 +89,6 @@ class ORTOptimizerTestMixin(unittest.TestCase):
 class ORTOptimizerTest(unittest.TestCase):
     # Contribution note: Please add test models in alphabetical order. Find test models here: https://huggingface.co/hf-internal-testing.
     SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = (
-        (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bart"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bert"),
         # (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-big_bird"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-distilbert"),

--- a/tests/onnxruntime/test_quantization.py
+++ b/tests/onnxruntime/test_quantization.py
@@ -76,7 +76,6 @@ class ORTDynamicQuantizationTest(unittest.TestCase):
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 30),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-roberta", 30),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-distilbert", 30),
-        (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bart", 32),
     )
 
     SUPPORTED_DECODER_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (


### PR DESCRIPTION
PyTorch 2.1 introduced a breaking change in torchscript graph capture that make the export of bart for those tasks fail.

Given that there is probably low usage anyway, let's simply remove the support for it and let's try to get the CI green.

See details: https://github.com/pytorch/pytorch/issues/110597