### PR TITLE
Fix forward pass for merged model

### DIFF
--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -204,7 +204,7 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
         loss = None
         if self.use_cache:
             if past_key_values is not None:
-                input_ids = input_ids[:, -1:]
+                input_ids = input_ids[:, -1:] if past_key_values[0][0].shape[2] != 0 else input_ids
                 # Flatten the past_key_values (no need to flatten for models using multi-query attn)
                 if self.config.model_type not in MULTI_QUERY_ATTN_MODELS:
                     past_key_values = tuple(


### PR DESCRIPTION
# What does this PR do?

After exporting a merged model with [this PR](https://github.com/huggingface/optimum/pull/1257), the forward pass has to support both the prompt and token generation steps. When running the prompt step, `input_ids` should be of shape `(batch_size, sequence_length)` and when running the token generation step, `input_ids` should be of shape `(batch_size, 1)`. However, currently `input_ids` only has shape `(batch_size, 1)`.

This PR fixes the shape of `input_ids` during the forward pass by first checking the size of `past_sequence_length` in one of the `past_key_values` to automatically determine which step is occurring. Then, the shape of `input_ids` is modified accordingly.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

