### PR TITLE
Handling block_size value for models with no sequence length limit.

### DIFF
--- a/examples/onnxruntime/training/language-modeling/run_clm.py
+++ b/examples/onnxruntime/training/language-modeling/run_clm.py
@@ -495,6 +495,8 @@ def main():
 
     if hasattr(config, "max_position_embeddings"):
         max_pos_embeddings = config.max_position_embeddings
+        if max_pos_embeddings < 0:
+            max_pos_embeddings = 1024
     else:
         # Define a default value if the attribute is missing in the config.
         max_pos_embeddings = 1024
@@ -506,10 +508,7 @@ def main():
                 f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
                 f"Using block_size={min(1024, max_pos_embeddings)} instead. You can change that default value by passing --block_size xxx."
             )
-        if max_pos_embeddings > 0:
             block_size = min(1024, max_pos_embeddings)
-        else:
-            block_size = 1024
     else:
         if data_args.block_size > tokenizer.model_max_length:
             logger.warning(

--- a/examples/onnxruntime/training/language-modeling/run_clm.py
+++ b/examples/onnxruntime/training/language-modeling/run_clm.py
@@ -506,7 +506,10 @@ def main():
                 f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
                 f"Using block_size={min(1024, max_pos_embeddings)} instead. You can change that default value by passing --block_size xxx."
             )
+        if max_pos_embeddings > 0:
             block_size = min(1024, max_pos_embeddings)
+        else:
+            block_size = 1024
     else:
         if data_args.block_size > tokenizer.model_max_length:
             logger.warning(


### PR DESCRIPTION
# What does this PR do?
Models with no sequence length limit will fail to create a dataset because the block_size will be -1.
and it will error this:
`ValueError: num_samples should be a positive integer value, but got num_samples=0`

this PR handles the case where max_position_embeddings  is -1, we set block size to a default value.
