### PR TITLE
Fix minimum auto-gptq version logic

### DIFF
--- a/optimum/utils/import_utils.py
+++ b/optimum/utils/import_utils.py
@@ -110,7 +110,7 @@ def is_timm_available():
 def is_auto_gptq_available():
     if _auto_gptq_available:
         version_autogptq = packaging.version.parse(importlib_metadata.version("auto_gptq"))
-        if AUTOGPTQ_MINIMUM_VERSION < version_autogptq:
+        if version_autogptq >= AUTOGPTQ_MINIMUM_VERSION:
             return True
         else:
             raise ImportError(


### PR DESCRIPTION
Basically fixes this case:
```
ImportError: Found an incompatible version of auto-gptq. Found version 0.4.2, but only version above 0.4.2 are supported
```

Which I assume to be a bug, but please correct me if I'm wrong!

cc @SunMarc 
