### PR TITLE
Adds default token_type_ids when running on cpu for ORTModelFeatureExtraction

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -941,7 +941,9 @@ class ORTModelForFeatureExtraction(ORTModel):
                     attention_mask = np.ones_like(input_ids)
                 else:
                     attention_mask = attention_mask.cpu().detach().numpy()
-                if token_type_ids is not None:
+                if token_type_ids is None:
+                    token_type_ids = np.ones_like(input_ids)
+                else:
                     token_type_ids = token_type_ids.cpu().detach().numpy()
 
             onnx_inputs = {


### PR DESCRIPTION
1498, added default token_type_ids when running on cpu for ORTModelFeatureExtraction

# What does this PR do?
This PR adds a default token_type_ids when running on cpu for ORTModelFeatureExtraction in the same manner as attention_mask is set.

Fixes #1498 


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

