### PR TITLE
fix a argument error

### DIFF
--- a/optimum/gptq/data.py
+++ b/optimum/gptq/data.py
@@ -53,7 +53,7 @@ def prepare_dataset(
             "You need to pass a `pad_token_id` in `quantize_model` if you want to have examples with batch size > 1"
         )
     new_examples = [
-        collate_data(new_examples[start : start + batch_size], pad_token_id)
+        collate_data(new_examples[start : start + batch_size], contain_labels=False, pad_token_id=pad_token_id)
         for start in range(0, len(new_examples), batch_size)
     ]
     return new_examples

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -245,10 +245,18 @@ class GPTQQuantizer(object):
                     out_features = layer.weight.shape[1]
                 if not (self.desc_act) or self.group_size == -1:
                     new_layer = QuantLinear(
-                        self.bits, self.group_size, in_features, out_features, True, use_cuda_fp16=self.use_cuda_fp16, weight_dtype=layer.weight.dtype
+                        self.bits,
+                        self.group_size,
+                        in_features,
+                        out_features,
+                        True,
+                        use_cuda_fp16=self.use_cuda_fp16,
+                        weight_dtype=layer.weight.dtype,
                     )
                 else:
-                    new_layer = QuantLinear(self.bits, self.group_size, in_features, out_features, True, weight_dtype=layer.weight.dtype)
+                    new_layer = QuantLinear(
+                        self.bits, self.group_size, in_features, out_features, True, weight_dtype=layer.weight.dtype
+                    )
                 new_layer.device = device
                 setattr(module, attr, new_layer.to(device))
         for name1, child in module.named_children():


### PR DESCRIPTION
# What does this PR do?

This PR fixes the error when pad_token_id is set ( in order to user batch size > 1). 
```bash 
>>>  File "optimum/optimum/gptq/data.py", line 57, in <listcomp>
collate_data(new_examples[start : start + batch_size], pad_token_id)
  File "optimum/optimum/gptq/data.py", line 88, in collate_data
    label_blocks = [block["labels"] for block in blocks]
  File "optimum/optimum/gptq/data.py", line 88, in <listcomp>
    label_blocks = [block["labels"] for block in blocks]
KeyError: 'labels'
```
@SunMarc  Please have a look 