### PR TITLE
switch to a config_dict instead of disable_exllamav2

### DIFF
--- a/docs/source/llm_quantization/usage_guides/quantization.mdx
+++ b/docs/source/llm_quantization/usage_guides/quantization.mdx
@@ -89,7 +89,7 @@ empty_model.tie_weights()
 quantized_model = load_quantized_model(empty_model, save_folder=save_folder, device_map="auto")
 ```
 
-If you wish to use exllama kernels, you will have to disable exllamav2 kernels:
+If you wish to use exllama kernels, you will have to change the version by setting `exllama_config`:
 
 ```py
 from optimum.gptq import GPTQQuantizer, load_quantized_model
@@ -99,7 +99,7 @@ from accelerate import init_empty_weights
 with init_empty_weights():
     empty_model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)
 empty_model.tie_weights()
-quantized_model = load_quantized_model(empty_model, save_folder=save_folder, device_map="auto", disable_exllamav2=True)
+quantized_model = load_quantized_model(empty_model, save_folder=save_folder, device_map="auto", exllama_config = {"version":1})
 ```
 
 Note that only 4-bit models are supported with exllama/exllamav2 kernels for now. Furthermore, it is recommended to disable exllama/exllamav2 kernels when you are finetuning your model with peft.

--- a/optimum/utils/import_utils.py
+++ b/optimum/utils/import_utils.py
@@ -35,7 +35,7 @@ else:
 TORCH_MINIMUM_VERSION = packaging.version.parse("1.11.0")
 TRANSFORMERS_MINIMUM_VERSION = packaging.version.parse("4.25.0")
 DIFFUSERS_MINIMUM_VERSION = packaging.version.parse("0.18.0")
-AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.5.0")
+AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.4.2")
 
 
 # This is the minimal required version to support some ONNX Runtime features


### PR DESCRIPTION
# What does this PR do ?
This PR removes the `disable_exllamav2` arg in favor of `exllama_config` which is more flexible. See related [PR](https://github.com/huggingface/transformers/pull/27111) in Transformers. I will have to merge this PR first before Transformers one. 

TODO: tests to check