### PR TITLE
Fix Falcon ONNX export with alibi

### DIFF
--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -72,7 +72,17 @@ PYTORCH_EXPORT_MODELS_TINY = {
         ],
         "mohitsha/tiny-random-testing-bert2gpt2": ["text2text-generation", "text2text-generation-with-past"],
     },
-    "falcon": "fxmarty/really-tiny-falcon-testing",
+    "falcon": {
+        "fxmarty/really-tiny-falcon-testing": [
+            "feature-extraction",
+            "feature-extraction-with-past",
+            "question-answering",
+            "text-generation",
+            "text-generation-with-past",
+            "token-classification",
+        ],
+        "fxmarty/tiny-testing-falcon-alibi": ["text-generation", "text-generation-with-past"],
+    },
     "flaubert": "hf-internal-testing/tiny-random-flaubert",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "gpt-bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",


### PR DESCRIPTION
Fixes https://github.com/huggingface/optimum/issues/1495

For some reason ORT is unhappy about https://github.com/huggingface/transformers/blob/3ec10e6c76362191b61260300fe1d6173a8dd7e1/src/transformers/models/falcon/modeling_falcon.py#L166, and for some reason PyTorch ONNX export adds a cast to complex128 there.