### PR TITLE
[ONNX export] Add depth-estimation w/ DPT+GLPN

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -146,9 +146,7 @@ class OnnxConfig(ExportConfig, ABC):
         "audio-frame-classification": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "automatic-speech-recognition": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "audio-xvector": OrderedDict({"logits": {0: "batch_size"}, "embeddings": {0: "batch_size"}}),
-        "depth-estimation": OrderedDict(
-            {"predicted_depth": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}}
-        ),
+        "depth-estimation": OrderedDict({"predicted_depth": {0: "batch_size", 1: "height", 2: "width"}}),
         "document-question-answering": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "feature-extraction": OrderedDict({"last_hidden_state": {0: "batch_size", 1: "sequence_length"}}),
         "fill-mask": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -146,6 +146,9 @@ class OnnxConfig(ExportConfig, ABC):
         "audio-frame-classification": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "automatic-speech-recognition": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "audio-xvector": OrderedDict({"logits": {0: "batch_size"}, "embeddings": {0: "batch_size"}}),
+        "depth-estimation": OrderedDict(
+            {"predicted_depth": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}}
+        ),
         "document-question-answering": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),
         "feature-extraction": OrderedDict({"last_hidden_state": {0: "batch_size", 1: "sequence_length"}}),
         "fill-mask": OrderedDict({"logits": {0: "batch_size", 1: "sequence_length"}}),

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -747,6 +747,10 @@ class DptOnnxConfig(ViTOnnxConfig):
     pass
 
 
+class GlpnOnnxConfig(ViTOnnxConfig):
+    pass
+
+
 class PoolFormerOnnxConfig(ViTOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     ATOL_FOR_VALIDATION = 2e-3

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -743,6 +743,10 @@ class Swin2srOnnxConfig(SwinOnnxConfig):
     pass
 
 
+class DptOnnxConfig(ViTOnnxConfig):
+    pass
+
+
 class PoolFormerOnnxConfig(ViTOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     ATOL_FOR_VALIDATION = 2e-3

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -164,6 +164,7 @@ class TasksManager:
             "audio-xvector": "AutoModelForAudioXVector",
             "automatic-speech-recognition": ("AutoModelForSpeechSeq2Seq", "AutoModelForCTC"),
             "conversational": ("AutoModelForCausalLM", "AutoModelForSeq2SeqLM"),
+            "depth-estimation": "AutoModelForDepthEstimation",
             "feature-extraction": "AutoModel",
             "fill-mask": "AutoModelForMaskedLM",
             "image-classification": "AutoModelForImageClassification",
@@ -496,6 +497,11 @@ class TasksManager:
         "donut-swin": supported_tasks_mapping(
             "feature-extraction",
             onnx="DonutSwinOnnxConfig",
+        ),
+        "dpt": supported_tasks_mapping(
+            "feature-extraction",
+            "depth-estimation",
+            onnx="DptOnnxConfig",
         ),
         "electra": supported_tasks_mapping(
             "feature-extraction",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -539,6 +539,11 @@ class TasksManager:
             onnx="FlaubertOnnxConfig",
             tflite="FlaubertTFLiteConfig",
         ),
+        "glpn": supported_tasks_mapping(
+            "feature-extraction",
+            "depth-estimation",
+            onnx="GlpnOnnxConfig",
+        ),
         "gpt2": supported_tasks_mapping(
             "feature-extraction",
             "feature-extraction-with-past",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -85,6 +85,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
         "fxmarty/tiny-testing-falcon-alibi": ["text-generation", "text-generation-with-past"],
     },
     "flaubert": "hf-internal-testing/tiny-random-flaubert",
+    "glpn": "hf-internal-testing/tiny-random-GLPNModel",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "gpt-bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
     "gpt-neo": "hf-internal-testing/tiny-random-GPTNeoModel",

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -65,6 +65,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "donut-swin": "hf-internal-testing/tiny-random-DonutSwinModel",
     "detr": "hf-internal-testing/tiny-random-DetrModel",  # hf-internal-testing/tiny-random-detr is larger
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
+    "dpt": "hf-internal-testing/tiny-random-DPTModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
     "encoder-decoder": {
         "hf-internal-testing/tiny-random-EncoderDecoderModel-bert-bert": [


### PR DESCRIPTION
# What does this PR do?

This PR adds the ability to export DPT+GLPN models to ONNX for depth-estimation, unblocking https://github.com/xenova/transformers.js/issues/350.

... and it crosses DPT+GLPN off [this list](https://github.com/huggingface/optimum/issues/555).

Running
```
optimum-cli export onnx -m hf-internal-testing/tiny-random-DPTModel o --task depth-estimation
```

now shows:
```
...
Validating ONNX model o/model.onnx...
        -[✓] ONNX model output names match reference model (predicted_depth)
        - Validating ONNX Model output "predicted_depth":
                -[✓] (2, 32, 32) matches (2, 32, 32)
                -[✓] all values close (atol: 1e-05)
The ONNX export succeeded and the exported model was saved at: o
```

Similarly,

```
optimum-cli export onnx -m hf-internal-testing/tiny-random-GLPNForDepthEstimation o
```

produces:
```
...
Validating ONNX model o/model.onnx...
        -[✓] ONNX model output names match reference model (predicted_depth)
        - Validating ONNX Model output "predicted_depth":
                -[✓] (2, 64, 64) matches (2, 64, 64)
                -[✓] all values close (atol: 1e-05)
The ONNX export succeeded and the exported model was saved at: o
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

