### PR TITLE
add `modules_in_block_to_quantize` arg for gptq

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -221,7 +221,7 @@ class GPTQQuantizer(object):
             layers_to_keep = sum(self.modules_in_block_to_quantize, [])
             for name in list(layers_to_be_replaced.keys()):
                 if not any(name.endswith(layer) for layer in layers_to_keep):
-                    logger.info(f"Quantization disabled for {name} (only modules_in_block_to_quantize={modules_in_block_to_quantize} are quantized)")
+                    logger.info(f"Quantization disabled for {name} (only modules_in_block_to_quantize={self.modules_in_block_to_quantize} are quantized)")
                     del layers_to_be_replaced[name]
         self._replace_by_quant_layers(model, layers_to_be_replaced)
         return model

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -157,7 +157,7 @@ class GPTQQuantizer(object):
             "sym",
             "true_sequential",
             "quant_method",
-            "inside_layer_modules"
+            "inside_layer_modules",
         ]
 
         if self.bits not in [2, 3, 4, 8]:

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -77,7 +77,7 @@ class GPTQQuantizer(object):
         exllama_config: Dict[str, Any] = None,
         max_input_length: Optional[int] = None,
         cache_block_outputs: Optional[bool] = True,
-        inside_layer_modules: Optional[list] = None,
+        inside_layer_modules: Optional[List[List[str]]] = None,
         *args,
         **kwargs,
     ):
@@ -124,7 +124,7 @@ class GPTQQuantizer(object):
             cache_block_outputs (`bool`, defaults to `True`):
                 Whether to cache block outputs to reuse as inputs for the succeeding block. It allows optimization of non-standard models
                 (e.g. ChatGLM) but can require more time.
-            inside_layer_modules (`List`, *optional*, defaults to `None`):
+            inside_layer_modules (`List[List[str]]`, *optional*, defaults to `None`):
                 List of module names to quantize inside block_name_to_quantize. If not set, we will quantize all the linear layers.
         """
 
@@ -215,7 +215,7 @@ class GPTQQuantizer(object):
         block_name = self.block_name_to_quantize
         layers_to_be_replaced = get_layers(model, prefix=block_name)
         if self.inside_layer_modules is not None:
-            layers_to_keep = sum(self.inside_layer_modules,[])
+            layers_to_keep = sum(self.inside_layer_modules, [])
             for name in list(layers_to_be_replaced.keys()):
                 if not any(name.endswith(layer) for layer in layers_to_keep):
                     logger.info(f"{name} has not been quantized. We don't convert it")
@@ -453,7 +453,7 @@ class GPTQQuantizer(object):
             if not has_device_map or get_device(block) == torch.device("cpu"):
                 block = block.to(0)
             layers = get_layers(block)
-            if isinstance(self.inside_layer_modules,list) and len(self.inside_layer_modules)>0:
+            if isinstance(self.inside_layer_modules, list) and len(self.inside_layer_modules) > 0:
                 if self.true_sequential:
                     layers_name_list = [sum(self.inside_layer_modules, [])]
                 else:

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -107,7 +107,7 @@ class GPTQQuantizer(object):
             model_seqlen (`Optional[int]`, defaults to `None`):
                 The maximum sequence length that the model can take.
             block_name_to_quantize (`Optional[str]`, defaults to `None`):
-                The transformers block name to quantize. If None, we will infer the block name using common pattern (e.g. model.layers)
+                The transformers block name to quantize. If None, we will infer the block name using common patterns (e.g. model.layers)
             module_name_preceding_first_block (`Optional[List[str]]`, defaults to `None`):
                 The layers that are preceding the first Transformer block.
             batch_size (`int`, defaults to `1`):

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -126,7 +126,7 @@ class GPTQQuantizer(object):
                 (e.g. ChatGLM) but can require more time.
             modules_to_quantize_inside_block (`List[List[str]]`, *optional*, defaults to `None`):
                 List list of module names to quantize in the block specified. The block to quantize can be specified by setting
-                `block_name_to_quantize`. We will quantize each list sequentially.
+                `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
         """
 
         self.bits = bits

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -157,6 +157,7 @@ class GPTQQuantizer(object):
             "sym",
             "true_sequential",
             "quant_method",
+            "inside_layer_modules"
         ]
 
         if self.bits not in [2, 3, 4, 8]:
@@ -455,9 +456,9 @@ class GPTQQuantizer(object):
             layers = get_layers(block)
             if isinstance(self.inside_layer_modules, list) and len(self.inside_layer_modules) > 0:
                 if self.true_sequential:
-                    layers_name_list = [sum(self.inside_layer_modules, [])]
-                else:
                     layers_name_list = self.inside_layer_modules
+                else:
+                    layers_name_list = [sum(self.inside_layer_modules, [])]
             else:
                 if self.true_sequential:
                     # lazy sequential but works well
@@ -748,6 +749,7 @@ def load_quantized_model(
             f"Failed to load quantization config from {save_folder} (lookup for traceback): {err}\nTip: If the save directory is saved from a transformers.PreTrainedModel, make sure that `config.json` contains a 'quantization_config' key."
         ) from err
     quantizer = GPTQQuantizer.from_dict(quantize_config_dict)
+    print(quantizer.to_dict())
     quantizer.disable_exllama = disable_exllama
     quantizer.exllama_config = exllama_config
     quantizer.exllama_version = quantizer.exllama_config["version"]

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -749,7 +749,6 @@ def load_quantized_model(
             f"Failed to load quantization config from {save_folder} (lookup for traceback): {err}\nTip: If the save directory is saved from a transformers.PreTrainedModel, make sure that `config.json` contains a 'quantization_config' key."
         ) from err
     quantizer = GPTQQuantizer.from_dict(quantize_config_dict)
-    print(quantizer.to_dict())
     quantizer.disable_exllama = disable_exllama
     quantizer.exllama_config = exllama_config
     quantizer.exllama_version = quantizer.exllama_config["version"]

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -221,7 +221,9 @@ class GPTQQuantizer(object):
             layers_to_keep = sum(self.modules_in_block_to_quantize, [])
             for name in list(layers_to_be_replaced.keys()):
                 if not any(name.endswith(layer) for layer in layers_to_keep):
-                    logger.info(f"Quantization disabled for {name} (only modules_in_block_to_quantize={self.modules_in_block_to_quantize} are quantized)")
+                    logger.info(
+                        f"Quantization disabled for {name} (only modules_in_block_to_quantize={self.modules_in_block_to_quantize} are quantized)"
+                    )
                     del layers_to_be_replaced[name]
         self._replace_by_quant_layers(model, layers_to_be_replaced)
         return model
@@ -456,10 +458,7 @@ class GPTQQuantizer(object):
             if not has_device_map or get_device(block) == torch.device("cpu"):
                 block = block.to(0)
             layers = get_layers(block)
-            if (
-                isinstance(self.modules_in_block_to_quantize, list)
-                and len(self.modules_in_block_to_quantize) > 0
-            ):
+            if isinstance(self.modules_in_block_to_quantize, list) and len(self.modules_in_block_to_quantize) > 0:
                 if self.true_sequential:
                     layers_name_list = self.modules_in_block_to_quantize
                 else:

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -53,7 +53,7 @@ class GPTQTest(unittest.TestCase):
     disable_exllama = True
     exllama_config = None
     cache_block_outputs = True
-    inside_layer_modules = None
+    modules_to_quantize_inside_block = None
 
     dataset = [
         "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm."
@@ -79,7 +79,7 @@ class GPTQTest(unittest.TestCase):
             disable_exllama=cls.disable_exllama,
             exllama_config=cls.exllama_config,
             cache_block_outputs=cls.cache_block_outputs,
-            inside_layer_modules=cls.inside_layer_modules,
+            modules_to_quantize_inside_block=cls.modules_to_quantize_inside_block,
         )
 
         cls.quantized_model = cls.quantizer.quantize_model(cls.model_fp16, cls.tokenizer)
@@ -303,9 +303,13 @@ class GPTQTestNoBlockCaching(GPTQTest):
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
 
 
-class GPTQTestInsideLayerModules(GPTQTest):
+class GPTQTestModuleQuant(GPTQTest):
     # all layers are quantized apart from self_attention.dense
-    inside_layer_modules = [["self_attention.query_key_value"], ["mlp.dense_h_to_4h"], ["mlp.dense_4h_to_h"]]
+    modules_to_quantize_inside_block = [
+        ["self_attention.query_key_value"],
+        ["mlp.dense_h_to_4h"],
+        ["mlp.dense_4h_to_h"],
+    ]
     EXPECTED_RELATIVE_DIFFERENCE = 1.57705236164535
 
     def test_not_converted_layers(self):

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -305,7 +305,7 @@ class GPTQTestNoBlockCaching(GPTQTest):
 
 class GPTQTestModuleQuant(GPTQTest):
     # all layers are quantized apart from self_attention.dense
-    modules_to_quantize_inside_block = [
+    modules_in_block_to_quantize = [
         ["self_attention.query_key_value"],
         ["mlp.dense_h_to_4h"],
         ["mlp.dense_4h_to_h"],

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -53,6 +53,7 @@ class GPTQTest(unittest.TestCase):
     disable_exllama = True
     exllama_config = None
     cache_block_outputs = True
+    inside_layer_modules = None
 
     dataset = [
         "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm."
@@ -78,6 +79,7 @@ class GPTQTest(unittest.TestCase):
             disable_exllama=cls.disable_exllama,
             exllama_config=cls.exllama_config,
             cache_block_outputs=cls.cache_block_outputs,
+            inside_layer_modules=cls.inside_layer_modules
         )
 
         cls.quantized_model = cls.quantizer.quantize_model(cls.model_fp16, cls.tokenizer)
@@ -142,6 +144,7 @@ class GPTQTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.quantizer.save(self.quantized_model, tmpdirname)
             self.quantized_model.config.save_pretrained(tmpdirname)
+            print(self.quantized_model.config)
             with init_empty_weights():
                 empty_model = AutoModelForCausalLM.from_config(
                     AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16
@@ -299,6 +302,18 @@ class GPTQTestNoBlockCaching(GPTQTest):
     EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
 
+class GPTQTestInsideLayerModules(GPTQTest):
+    # all layers are quantized apart from self_attention.dense
+    inside_layer_modules = [
+        ["self_attention.query_key_value"],
+        ["mlp.dense_h_to_4h"],
+        ["mlp.dense_4h_to_h"]
+    ]
+    EXPECTED_RELATIVE_DIFFERENCE = 1.57705236164535
+
+    def test_not_converted_layers(self):
+        # self_attention.dense should not be converted
+        self.assertTrue(self.quantized_model.transformer.h[0].self_attention.dense.__class__.__name__== "Linear")
 
 class GPTQUtilsTest(unittest.TestCase):
     """

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -79,7 +79,7 @@ class GPTQTest(unittest.TestCase):
             disable_exllama=cls.disable_exllama,
             exllama_config=cls.exllama_config,
             cache_block_outputs=cls.cache_block_outputs,
-            inside_layer_modules=cls.inside_layer_modules
+            inside_layer_modules=cls.inside_layer_modules,
         )
 
         cls.quantized_model = cls.quantizer.quantize_model(cls.model_fp16, cls.tokenizer)
@@ -302,18 +302,16 @@ class GPTQTestNoBlockCaching(GPTQTest):
     EXPECTED_OUTPUTS.add("Hello my name is jay and i am a student at university.")
     EXPECTED_OUTPUTS.add("Hello my name is John, I am a student in the University of")
 
+
 class GPTQTestInsideLayerModules(GPTQTest):
     # all layers are quantized apart from self_attention.dense
-    inside_layer_modules = [
-        ["self_attention.query_key_value"],
-        ["mlp.dense_h_to_4h"],
-        ["mlp.dense_4h_to_h"]
-    ]
+    inside_layer_modules = [["self_attention.query_key_value"], ["mlp.dense_h_to_4h"], ["mlp.dense_4h_to_h"]]
     EXPECTED_RELATIVE_DIFFERENCE = 1.57705236164535
 
     def test_not_converted_layers(self):
         # self_attention.dense should not be converted
-        self.assertTrue(self.quantized_model.transformer.h[0].self_attention.dense.__class__.__name__== "Linear")
+        self.assertTrue(self.quantized_model.transformer.h[0].self_attention.dense.__class__.__name__ == "Linear")
+
 
 class GPTQUtilsTest(unittest.TestCase):
     """

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -144,7 +144,6 @@ class GPTQTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.quantizer.save(self.quantized_model, tmpdirname)
             self.quantized_model.config.save_pretrained(tmpdirname)
-            print(self.quantized_model.config)
             with init_empty_weights():
                 empty_model = AutoModelForCausalLM.from_config(
                     AutoConfig.from_pretrained(self.model_name), torch_dtype=torch.float16


### PR DESCRIPTION
# What does this PR do?
This PR adds the `inside_layer_modules` arg for GPTQ quantization. This will enable the user to quantize specific modules inside a block. This is needed for quantizing model and run quantized model such as https://huggingface.co/TheBloke/Mixtral-8x7B-v0.1-GPTQ