### PR TITLE
Fix: local variable 'dataset' referenced before assignment

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -357,6 +357,7 @@ class GPTQQuantizer(object):
 
         # Step 1: Prepare the data
         if isinstance(self.dataset, list) and not isinstance(self.dataset[0], str):
+            dataset = self.dataset
             logger.info("GPTQQuantizer dataset appears to be already tokenized. Skipping tokenization.")
         else:
             if isinstance(tokenizer, str):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes local variable 'dataset' referenced before assignment

### Reproduce

```python
from transformers import AutoModelForCausalLM, AutoTokenizer, GPTQConfig

model_id = "facebook/opt-125m"
tokenizer = AutoTokenizer.from_pretrained(model_id)
dataset = [{"input_ids": [0, 1, 2, 3, 4], "attention_mask": [1, 1, 1, 1, 1]}]
gptq_config = GPTQConfig(bits=4, dataset=dataset, tokenizer=tokenizer)
quantized_model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", quantization_config=gptq_config)
```

The logic is broken if we pass a tokenized dataset to the GPTQQuantizer.

https://github.com/huggingface/optimum/blob/7376c6ad7f0a852cb81dfbb9e9539eb6ed14fd36/optimum/gptq/quantizer.py#L358-L382

```
Traceback (most recent call last):
  File "lib/python3.10/site-packages/transformers/models/auto/auto_factory.py", line 566, in from_pretrained
    return model_class.from_pretrained(
  File "lib/python3.10/site-packages/transformers/modeling_utils.py", line 3768, in from_pretrained
    quantizer.quantize_model(model, quantization_config.tokenizer)
  File "lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "lib/python3.10/site-packages/optimum/gptq/quantizer.py", line 382, in quantize_model
    dataset = prepare_dataset(dataset, pad_token_id=self.pad_token_id, batch_size=self.batch_size)
UnboundLocalError: local variable 'dataset' referenced before assignment
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

