### PR TITLE
Add fp16 support for split cache

### DIFF
--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -151,7 +151,7 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
 
         self.use_fp16 = False
         for inp in model.get_inputs():
-            if inp.name == "past_key_values" and inp.type == "tensor(float16)":
+            if (inp.name == "past_key_values" or inp.name in self.key_value_input_names) and inp.type == "tensor(float16)":
                 self.use_fp16 = True
                 break
 


### PR DESCRIPTION
# What does this PR do?

It fixes the following error when using a fp16 model with split fp16 input/output cache:

`onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Unexpected input data type. Actual: (tensor(float)) , expected: (tensor(float16))`


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

