### PR TITLE
Support float16 images in StableDiffusionXLWatermarker

### DIFF
--- a/optimum/pipelines/diffusers/watermark.py
+++ b/optimum/pipelines/diffusers/watermark.py
@@ -18,6 +18,10 @@ class StableDiffusionXLWatermarker:
         if images.shape[-1] < 256:
             return images
 
+        # cv2 doesn't support float16
+        if images.dtype == np.float16:
+            images = images.astype(np.float32)
+
         images = (255 * (images / 2 + 0.5)).transpose((0, 2, 3, 1))
 
         images = np.array([self.encoder.encode(image, "dwtDct") for image in images]).transpose((0, 3, 1, 2))


### PR DESCRIPTION
# What does this PR do?
`StableDiffusionXLPipelineMixin` https://github.com/huggingface/optimum/blob/7376c6ad7f0a852cb81dfbb9e9539eb6ed14fd36/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl.py#L490 and `StableDiffusionXLImg2ImgPipelineMixin` https://github.com/huggingface/optimum/blob/7376c6ad7f0a852cb81dfbb9e9539eb6ed14fd36/optimum/pipelines/diffusers/pipeline_stable_diffusion_xl_img2img.py#L497
apply watermark to the output of `vae_decoder`. 

However, the default watermarker `StableDiffusionXLWatermarker` does not support `float16` images because `cv2.cvtColor` doesn't support it. 

Running the following code
```python
from optimum.pipelines.diffusers.watermark import StableDiffusionXLWatermarker
import numpy as np

watermarker = StableDiffusionXLWatermarker()
fp16_image = np.random.rand(1, 3, 1024, 1024).astype(np.float16)
watermarked_image = watermarker.apply_watermark(fp16_image)
```
gives the following error
```
error: OpenCV(4.8.1) ...
> Unsupported depth of input image:
>     'VDepth::contains(depth)'
> where
>     'depth' is 7 (CV_16F)
```

In this PR, we check whether `images` in `StableDiffusionXLWatermarker.apply_watermark` is `float16` and cast it to `float32` if so.
This enables the use of fp16 vae decoder in a pipeline loaded using `from_pretrained` (there is no option to disable the default watermark).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

