### PR TITLE
Add ability to specify a LoRA to fuse with Stable Diffusion models before export

### DIFF
--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -150,6 +150,12 @@ def parse_args_onnx(parser):
             "Also disable the use of position_ids for text-generation models that require it for batched generation. This argument is introduced for backward compatibility and will be removed in a future release of Optimum."
         ),
     )
+    optional_group.add_argument(
+        "--fuse_lora",
+        type=str,
+        default=None,
+        help=("For Stable Diffusion models only. LoRA to fuse before export."),
+    )
 
     input_group = parser.add_argument_group(
         "Input shapes (if necessary, this allows to override the shapes of the input given to the ONNX exporter, that requires an example input)."
@@ -258,6 +264,7 @@ class ONNXExportCommand(BaseOptimumCLICommand):
             cache_dir=self.args.cache_dir,
             trust_remote_code=self.args.trust_remote_code,
             pad_token_id=self.args.pad_token_id,
+            fuse_lora=self.args.fuse_lora,
             for_ort=self.args.for_ort,
             use_subprocess=True,
             _variant=self.args.variant,

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -68,6 +68,7 @@ def _get_submodels_and_onnx_configs(
     custom_onnx_configs: Dict,
     custom_architecture: bool,
     _variant: str,
+    fuse_lora: Optional[str] = None,
     int_dtype: str = "int64",
     float_dtype: str = "fp32",
     fn_get_submodels: Optional[Callable] = None,
@@ -81,7 +82,7 @@ def _get_submodels_and_onnx_configs(
         if is_stable_diffusion:
             onnx_config = None
             models_and_onnx_configs = get_stable_diffusion_models_for_export(
-                model, int_dtype=int_dtype, float_dtype=float_dtype
+                model, int_dtype=int_dtype, float_dtype=float_dtype, fuse_lora=fuse_lora
             )
         else:
             onnx_config_constructor = TasksManager.get_exporter_config_constructor(
@@ -176,6 +177,7 @@ def main_export(
     cache_dir: Optional[str] = None,
     trust_remote_code: bool = False,
     pad_token_id: Optional[int] = None,
+    fuse_lora: Optional[str] = None,
     subfolder: str = "",
     revision: str = "main",
     force_download: bool = False,
@@ -236,6 +238,8 @@ def main_export(
             model repository.
         pad_token_id (`Optional[int]`, defaults to `None`):
             This is needed by some models, for some tasks. If not provided, will attempt to use the tokenizer to guess it.
+        fuse_lora (`Optional[str]`, defaults to `None`):
+            For Stable Diffusion models only. LoRA to fuse before export.
         subfolder (`str`, defaults to `""`):
             In case the relevant files are located inside a subfolder of the model repo either locally or on huggingface.co, you can
             specify the folder name here.
@@ -468,6 +472,7 @@ def main_export(
         fn_get_submodels=fn_get_submodels,
         preprocessors=preprocessors,
         _variant=_variant,
+        fuse_lora=fuse_lora,
         legacy=legacy,
         library_name=library_name,
         model_kwargs=model_kwargs,

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -214,6 +214,7 @@ class OnnxConfig(ExportConfig, ABC):
         self._preprocessors = preprocessors
         self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
         self.variant = "default"
+        self.fuse_lora = None
         self.legacy = legacy
 
     def _create_dummy_input_generator_classes(self, **kwargs) -> List[DummyInputGenerator]:
@@ -260,6 +261,17 @@ class OnnxConfig(ExportConfig, ABC):
         different users would like to export the model differently (with different inputs/outputs, model splitted in several ONNX or not, etc.).
         """
         return self._variant
+
+    @property
+    def fuse_lora(self) -> str:
+        """
+        For Stable Diffusion models only. LoRA to fuse before export.
+        """
+        return self._fuse_lora
+
+    @fuse_lora.setter
+    def fuse_lora(self, value: str):
+        self._fuse_lora = value
 
     @variant.setter
     def variant(self, value: str):


### PR DESCRIPTION
# What does this PR do?

Adds the --fuse_lora command which can optionally fuse a specified LoRA with the ONNX model for Stable Diffusion. This allows easily exporting fine tuned versions of the model.