### PR TITLE
Remove "to ONNX" from info message when exporting model

### DIFF
--- a/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
+++ b/docs/source/exporters/onnx/usage_guides/export_a_model.mdx
@@ -118,7 +118,7 @@ You should see the following logs (along with potential logs from PyTorch / Tens
 
 ```bash
 Automatic task detection to question-answering.
-Framework not specified. Using pt to export to ONNX.
+Framework not specified. Using pt to export the model.
 Using framework PyTorch: 1.12.1
 
 Validating ONNX model...

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1402,7 +1402,7 @@ class TasksManager:
         else:
             raise EnvironmentError("Neither PyTorch nor TensorFlow found in environment. Cannot export model.")
 
-        logger.info(f"Framework not specified. Using {framework} to export to ONNX.")
+        logger.info(f"Framework not specified. Using {framework} to export the model.")
 
         return framework
 


### PR DESCRIPTION
This message is also shown when exporting models to OpenVINO format (in optimum-intel), which does not use ONNX. Replaced "Using pt to export to ONNX" with "Using pt to export the model".

@echarlaix