### PR TITLE
Modify model id for test

### DIFF
--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1250,7 +1250,7 @@ class ORTModelForQuestionAnsweringIntegrationTest(ORTModelTestMixin):
         "roberta",
         "roformer",
         "squeezebert",
-        "xlm",
+        "xlm_qa",
         "xlm_roberta",
     ]
 

--- a/tests/onnxruntime/utils_onnxruntime_tests.py
+++ b/tests/onnxruntime/utils_onnxruntime_tests.py
@@ -149,7 +149,7 @@ MODEL_NAMES = {
     "wav2vec2-conformer": "hf-internal-testing/tiny-random-wav2vec2-conformer",
     "wavlm": "hf-internal-testing/tiny-random-WavlmModel",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
-    "xlm_qa": "hf-internal-testing/tiny-random-XLMForQuestionAnsweringSimple",  # issue with default hf-internal-testing in QA pipeline post-processing
+    "xlm_qa": "hf-internal-testing/tiny-random-XLMForQuestionAnsweringSimple",  # issue with default hf-internal-testing in transformers QA pipeline post-processing
     "xlm_roberta": "hf-internal-testing/tiny-xlm-roberta",
     "yolos": "hf-internal-testing/tiny-random-YolosModel",
 }

--- a/tests/onnxruntime/utils_onnxruntime_tests.py
+++ b/tests/onnxruntime/utils_onnxruntime_tests.py
@@ -149,6 +149,7 @@ MODEL_NAMES = {
     "wav2vec2-conformer": "hf-internal-testing/tiny-random-wav2vec2-conformer",
     "wavlm": "hf-internal-testing/tiny-random-WavlmModel",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
+    "xlm_qa": "hf-internal-testing/tiny-random-XLMForQuestionAnsweringSimple",
     "xlm_roberta": "hf-internal-testing/tiny-xlm-roberta",
     "yolos": "hf-internal-testing/tiny-random-YolosModel",
 }

--- a/tests/onnxruntime/utils_onnxruntime_tests.py
+++ b/tests/onnxruntime/utils_onnxruntime_tests.py
@@ -149,7 +149,7 @@ MODEL_NAMES = {
     "wav2vec2-conformer": "hf-internal-testing/tiny-random-wav2vec2-conformer",
     "wavlm": "hf-internal-testing/tiny-random-WavlmModel",
     "xlm": "hf-internal-testing/tiny-random-XLMModel",
-    "xlm_qa": "hf-internal-testing/tiny-random-XLMForQuestionAnsweringSimple",
+    "xlm_qa": "hf-internal-testing/tiny-random-XLMForQuestionAnsweringSimple",  # issue with default hf-internal-testing in QA pipeline post-processing
     "xlm_roberta": "hf-internal-testing/tiny-xlm-roberta",
     "yolos": "hf-internal-testing/tiny-random-YolosModel",
 }


### PR DESCRIPTION
QA pipeline post-processing is failing for models like https://huggingface.co/hf-internal-testing/tiny-random-XLMModel or https://huggingface.co/hf-internal-testing/tiny-random-xlm as described in https://github.com/huggingface/transformers/issues/28000