### PR TITLE
Extend autocast check to cover more platforms like XPU

### DIFF
--- a/optimum/bettertransformer/models/encoder_models.py
+++ b/optimum/bettertransformer/models/encoder_models.py
@@ -289,7 +289,7 @@ class BertLayerBetterTransformer(BetterTransformerBaseLayer, nn.Module):
 
     def forward(self, hidden_states, attention_mask, *_):
         # No check on output_attentions here as roformer relies on BertLayerBetterTransformer but does not pass output_attentions as keyword argument.
-        if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
+        if not self.training and not torch._C._is_any_autocast_enabled():
             if hidden_states.is_nested:
                 attention_mask = None
 


### PR DESCRIPTION
# What does this PR do?

In the current code, the check for `BertLayerBetterTransformer.forward` only contains these conditions:
```
if not self.training and not torch.is_autocast_enabled() and not torch.is_autocast_cpu_enabled():
```
These conditions cannot return the correct result of `autocast_enabled` on the Intel xpu platform, causing the model to use the wrong optimization method. `torch._C._is_any_autocast_enabled` contains more detections and can be a better choice.

