### PR TITLE
[Sentence Transformers] Complete the update of `model_type` 

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1682,9 +1682,11 @@ class TasksManager:
             if "Transformer" in model[0].__class__.__name__:
                 model.config = model[0].auto_model.config
                 model.config.model_type = "sentence-transformers-transformer"
+                model.config.__class__.model_type = "sentence-transformers-transformer"
             elif "CLIP" in model[0].__class__.__name__:
                 model.config = model[0].model.config
                 model.config.model_type = "sentence-transformers-clip"
+                model.config.__class__.model_type = "sentence-transformers-clip"
             else:
                 raise ValueError(
                     f"The export of a sentence-transformers model with the first module being {model[0].__class__.__name__} is currently not supported in Optimum. Please open an issue or submit a PR to add the support."


### PR DESCRIPTION
# What does this PR do?

Improve the update of `model_type`, with the previous update, the `model_type` remains as the previous one (eg. `bert`) when displaying the config (which is relatively ok):
![image](https://github.com/huggingface/optimum/assets/44135271/0da15aa4-a354-4285-96d6-817f9fc8b150)

But if we apply [`config.to_dict()`](https://github.com/huggingface/transformers/blob/c48787f347bd604f656c2cfff730e029c8f8c1fe/src/transformers/configuration_utils.py#L893), the `model_type` is not changed, so I would suggest to complete the change of `model_type` thoroughly.

