### PR TITLE
Switch back to `pull_request` event for PR doc build

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -4,9 +4,8 @@ name: Build PR documentation
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, reopened, labeled ]
     paths:
       - "optimum/**.py"
       - "docs/**.mdx"
@@ -17,14 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  authorize:
-    if: (github.event.action == 'labeled' && github.event.label.name == 'build-pr-doc') || github.event_name != 'pull_request_target' || (! github.event.pull_request.head.repo.fork)
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
   build_documentation:
-    needs: authorize
     runs-on: ubuntu-latest
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -42,7 +34,6 @@ jobs:
         with:
           repository: 'huggingface/optimum'
           path: optimum
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - uses: actions/checkout@v2
         with:
@@ -96,27 +87,10 @@ jobs:
           sudo mv intel-doc-build ../optimum
           cd ..
 
+      # TODO: enable Furiosa doc build in PRs once archive.furiosa.ai is public
       - name: Make Furiosa documentation
         run: |
-          cd optimum-furiosa
-          pip install .
-          sudo apt update
-          sudo apt install -y ca-certificates apt-transport-https gnupg
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 5F03AFA423A751913F249259814F888B20B09A7E
-            # TODO: remove secrets and pull_request_target once archive.furiosa.ai is public
-          sudo tee -a /etc/apt/auth.conf.d/furiosa.conf > /dev/null <<EOT
-            machine archive.furiosa.ai
-            login ${{ secrets.FURIOSA_ACCESS_KEY }}
-            password ${{ secrets.FURIOSA_SECRET_ACCESS_KEY }}
-          EOT
-          sudo chmod 400 /etc/apt/auth.conf.d/furiosa.conf
-          sudo tee -a /etc/apt/sources.list.d/furiosa.list <<EOT
-            deb [arch=amd64] https://archive.furiosa.ai/ubuntu jammy restricted
-          EOT
-          sudo apt update && sudo apt install -y furiosa-libnux
-          doc-builder build optimum.furiosa docs/source/ --build_dir furiosa-doc-build --version pr_$PR_NUMBER --version_tag_suffix "" --html --clean
-          mv furiosa-doc-build ../optimum
-          cd ..
+          echo "For PRs we don't build Furiosa doc"
 
       - name: Make Optimum documentation
         run: |

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -1,7 +1,5 @@
 name: Build PR documentation
 
-# WARNING: As this workflow supports the pull_request_target event, please exercise extra care when editing it.
-
 on:
   workflow_dispatch:
   pull_request:

--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -122,7 +122,9 @@ def main():
             subpackage_path = Path(f"{subpackage}-doc-build")
 
             # The doc of Furiosa will be missing for PRs
+            print("111", subpackage_path == "furiosa", subpackage_path.is_dir())
             if subpackage_path == "furiosa" and not subpackage_path.is_dir():
+                print("AAA")
                 continue
 
             # Copy all HTML files from subpackage into optimum

--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -121,6 +121,10 @@ def main():
         else:
             subpackage_path = Path(f"{subpackage}-doc-build")
 
+            # The doc of Furiosa will be missing for PRs
+            if subpackage_path == "furiosa" and not subpackage_path.is_dir():
+                continue
+
             # Copy all HTML files from subpackage into optimum
             rename_copy_subpackage_html_paths(
                 subpackage,

--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -122,9 +122,7 @@ def main():
             subpackage_path = Path(f"{subpackage}-doc-build")
 
             # The doc of Furiosa will be missing for PRs
-            print("111", subpackage_path == "furiosa", subpackage_path.is_dir())
-            if subpackage_path == "furiosa" and not subpackage_path.is_dir():
-                print("AAA")
+            if subpackage == "furiosa" and not subpackage_path.is_dir():
                 continue
 
             # Copy all HTML files from subpackage into optimum
@@ -136,7 +134,6 @@ def main():
             )
 
             # Load subpackage table of contents
-            print("HERE", subpackage_path)
             subpackage_toc_path = next(subpackage_path.rglob("_toctree.yml"))
             with open(subpackage_toc_path, "r") as f:
                 subpackage_toc = yaml.safe_load(f)

--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -134,6 +134,7 @@ def main():
             )
 
             # Load subpackage table of contents
+            print("HERE", subpackage_path)
             subpackage_toc_path = next(subpackage_path.rglob("_toctree.yml"))
             with open(subpackage_toc_path, "r") as f:
                 subpackage_toc = yaml.safe_load(f)

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -12,6 +12,8 @@ specific language governing permissions and limitations under the License.
 
 # 🤗 Optimum
 
+TEST
+
 🤗 Optimum is an extension of [Transformers](https://huggingface.co/docs/transformers) that provides a set of performance optimization tools to train and run models on targeted hardware with maximum efficiency.
 
 The AI ecosystem evolves quickly, and more and more specialized hardware along with their own optimizations are emerging every day.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -12,8 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # 🤗 Optimum
 
-TEST
-
 🤗 Optimum is an extension of [Transformers](https://huggingface.co/docs/transformers) that provides a set of performance optimization tools to train and run models on targeted hardware with maximum efficiency.
 
 The AI ecosystem evolves quickly, and more and more specialized hardware along with their own optimizations are emerging every day.


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR triggers the PR doc build for the `pull_request` event instead of `pull_request_target`. `pull_request_target` was used so that the secrets needed to build Furiosa's doc can be accessed from forks (after authorization). However, this event always triggers the associated workflow from main in PRs, which is not convenient when modifying this specific workflow because we cannot see the changes.
As a workaround, this PR switches back to `pull_request` and the doc of Furiosa is not built for PRs.
Needed for #1624.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

