### PR TITLE
Fix gptq device_map = "cpu"

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -332,20 +332,23 @@ class GPTQQuantizer(object):
             use_cache = model.config.use_cache
             model.config.use_cache = False
 
+        # If the model has a device_map, we don't move to model. We have already dispatched the hook that will do the work
         if hasattr(model, "hf_device_map"):
             devices = list(model.hf_device_map.values())
+            has_device_map = True
             if "disk" in devices:
                 raise ValueError("disk offload is not supported with GPTQ quantization")
-            if "cpu" in devices and len(model.hf_device_map) > 1:
-                logger.info("Cpu offload is not recommended. There might be some issues with the memory")
-                hook = None
-                for name, device in model.hf_device_map.items():
-                    if device == "cpu":
-                        module = recurse_getattr(model, name)
-                        remove_hook_from_module(module, recurse=True)
-                        module, hook = cpu_offload_with_hook(module, prev_module_hook=hook)
-            # If the model has a device_map, we don't move to model. We have already dispatched the hook that will do the work
-            has_device_map = True
+            if "cpu" in devices or torch.device("cpu") in devices:
+                if len(model.hf_device_map) > 1:
+                    logger.info("Cpu offload is not recommended. There might be some issues with the memory")
+                    hook = None
+                    for name, device in model.hf_device_map.items():
+                        if device == "cpu":
+                            module = recurse_getattr(model, name)
+                            remove_hook_from_module(module, recurse=True)
+                            module, hook = cpu_offload_with_hook(module, prev_module_hook=hook)
+                else:
+                    has_device_map = False
 
         if hasattr(model, "dtype"):
             self.use_cuda_fp16 = model.dtype == torch.float16

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -54,7 +54,7 @@ class GPTQTest(unittest.TestCase):
     exllama_config = None
     cache_block_outputs = True
     modules_to_quantize_inside_block = None
-
+    device_map_for_quantization = {"": 0}
     dataset = [
         "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm."
     ]
@@ -66,7 +66,7 @@ class GPTQTest(unittest.TestCase):
         Setup quantized model
         """
         cls.model_fp16 = AutoModelForCausalLM.from_pretrained(
-            cls.model_name, torch_dtype=torch.float16, device_map={"": 0}
+            cls.model_name, torch_dtype=torch.float16, device_map=cls.device_map_for_quantization
         )
         cls.mem_fp16 = cls.model_fp16.get_memory_footprint()
 
@@ -166,6 +166,10 @@ class GPTQTest(unittest.TestCase):
             _ = AutoGPTQForCausalLM.from_quantized(tmpdirname)
 
             self.check_inference_correctness(quantized_model_from_saved)
+
+
+class GPTQTestCPUInit(GPTQTest):
+    device_map_for_quantization = "cpu"
 
 
 class GPTQTestExllama(GPTQTest):

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -54,7 +54,7 @@ class GPTQTest(unittest.TestCase):
     exllama_config = None
     cache_block_outputs = True
     modules_to_quantize_inside_block = None
-    device_map_for_quantization = {"": 0}
+    device_map_for_quantization = "cuda"
     dataset = [
         "auto-gptq is an easy-to-use model quantization library with user-friendly apis, based on GPTQ algorithm."
     ]
@@ -173,6 +173,7 @@ class GPTQTestCPUInit(GPTQTest):
 
     def test_generate_quality(self):
         self.check_inference_correctness(self.quantized_model.to(0))
+
 
 class GPTQTestExllama(GPTQTest):
     disable_exllama = False

--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -171,6 +171,8 @@ class GPTQTest(unittest.TestCase):
 class GPTQTestCPUInit(GPTQTest):
     device_map_for_quantization = "cpu"
 
+    def test_generate_quality(self):
+        self.check_inference_correctness(self.quantized_model.to(0))
 
 class GPTQTestExllama(GPTQTest):
     disable_exllama = False


### PR DESCRIPTION
# What does this do ? 
This PR fixes the case where the user passes device_map = "cpu". In that case, we still need to move each block to the gpu 0 on our own since we didn't add hooks. 
Fixes [28632](https://github.com/huggingface/transformers/issues/28632)