### PR TITLE
Fix wikitext2 processing

### DIFF
--- a/optimum/gptq/data.py
+++ b/optimum/gptq/data.py
@@ -117,7 +117,8 @@ def get_wikitext2(tokenizer: Any, seqlen: int, nsamples: int, split: str = "trai
         data = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
     elif split == "validation":
         data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
-    text = "".join([" \n" if s == "" else s for s in data["text"]])
+    # length of 288059 should be enough
+    text = "".join([" \n" if s == "" else s for s in data["text"][:1000]])
 
     enc = tokenizer(text, return_tensors="pt")
     dataset = []


### PR DESCRIPTION
# What does this PR do ?
This PR slices the wikitext2 dataset to only takes the first 1000 items (length of 288059). This is needed since tokenizing a big dataset for some tokenizer takes a long time. Fixes #1655.

