### PR TITLE
Reactivate BART Onnx Export

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -629,6 +629,7 @@ class M2M100OnnxConfig(TextSeq2SeqOnnxConfig):
 
 class BartOnnxConfig(M2M100OnnxConfig):
     DEFAULT_ONNX_OPSET = 14  # Bart now uses F.scaled_dot_product_attention by default for torch>=2.1.1.
+    MIN_TORCH_VERSION = version.parse("2.1.2")
     pass
 
 

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -317,10 +317,8 @@ class TasksManager:
             "text-generation-with-past",
             "text2text-generation",
             "text2text-generation-with-past",
-            # text-classification and question-answering can be supported, but the ONNX export is currently broken due to a regression in PyTorch 2.1.
-            # Reference: https://github.com/pytorch/pytorch/issues/110597.
-            # "text-classification",
-            # "question-answering",
+            "text-classification",
+            "question-answering",
             onnx="BartOnnxConfig",
         ),
         # BEiT cannot be used with the masked image modeling autoclass, so this task is excluded here

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1227,7 +1227,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
 class ORTModelForQuestionAnsweringIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        # "bart",  # see tasks.py
+        "bart",  # see tasks.py
         "bert",
         # "big_bird",
         # "bigbird_pegasus",
@@ -1592,7 +1592,7 @@ class ORTModelForMaskedLMIntegrationTest(ORTModelTestMixin):
 class ORTModelForSequenceClassificationIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        # "bart",  # see tasks.py
+        "bart",  # see tasks.py
         "bert",
         # "big_bird",
         # "bigbird_pegasus",

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1592,7 +1592,7 @@ class ORTModelForMaskedLMIntegrationTest(ORTModelTestMixin):
 class ORTModelForSequenceClassificationIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        "bart",  # see tasks.py
+        "bart", 
         "bert",
         # "big_bird",
         # "bigbird_pegasus",

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1227,7 +1227,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
 class ORTModelForQuestionAnsweringIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        "bart",  # see tasks.py
+        "bart", 
         "bert",
         # "big_bird",
         # "bigbird_pegasus",

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -89,6 +89,7 @@ class ORTOptimizerTestMixin(unittest.TestCase):
 class ORTOptimizerTest(unittest.TestCase):
     # Contribution note: Please add test models in alphabetical order. Find test models here: https://huggingface.co/hf-internal-testing.
     SUPPORTED_ARCHITECTURES_WITH_MODEL_ID = (
+        (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bart"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bert"),
         # (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-big_bird"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-distilbert"),

--- a/tests/onnxruntime/test_quantization.py
+++ b/tests/onnxruntime/test_quantization.py
@@ -76,6 +76,7 @@ class ORTDynamicQuantizationTest(unittest.TestCase):
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 30),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-roberta", 30),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-distilbert", 30),
+        (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-bart", 32),
     )
 
     SUPPORTED_DECODER_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (


### PR DESCRIPTION
# What does this PR do?

This PR reactivate the Bart Onnx Export which was disabled because of a Pytorch 2.1 regression. 
Since Pytorch 2.1.2 it is now fixed.
This [issue](https://github.com/huggingface/optimum/issues/1485) was the original issue of the export failure.

Question: To prevent this issue, hard constraints might be put under torch to make sure nobody gets optimum installed with torch 2.0 trying to export those models ? It should be above 1.11 but under 2.0 and could be above 2.1 as well. 

Tagging @fxmarty as he disabled the tests.



