### PR TITLE
CI: Avoid iterating over a mutated iterable

### DIFF
--- a/optimum/exporters/onnx/model_patcher.py
+++ b/optimum/exporters/onnx/model_patcher.py
@@ -62,7 +62,9 @@ def patch_everywhere(attribute_name: str, patch: Any, module_name_prefix: Option
         module_name_prefix (`Optional[str]`, defaults to `None`):
             If set, only module names starting with this prefix will be considered for patching.
     """
-    for name, module in sys.modules.items():
+    # sys.modules may be updated while being iterated over, hence the list copy.
+    for name in list(sys.modules):
+        module = sys.modules[name]
         if module_name_prefix is not None and not name.startswith(module_name_prefix):
             continue
         if hasattr(module, attribute_name):

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1227,7 +1227,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
 class ORTModelForQuestionAnsweringIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        "bart", 
+        "bart",
         "bert",
         # "big_bird",
         # "bigbird_pegasus",
@@ -1592,7 +1592,7 @@ class ORTModelForMaskedLMIntegrationTest(ORTModelTestMixin):
 class ORTModelForSequenceClassificationIntegrationTest(ORTModelTestMixin):
     SUPPORTED_ARCHITECTURES = [
         "albert",
-        "bart", 
+        "bart",
         "bert",
         # "big_bird",
         # "bigbird_pegasus",


### PR DESCRIPTION
As per title, fixes `RuntimeError: dictionary changed size during iteration`