### PR TITLE
Added support for quantizing models on IBM Power systems (ppc64le)

### DIFF
--- a/optimum/commands/onnxruntime/quantize.py
+++ b/optimum/commands/onnxruntime/quantize.py
@@ -54,6 +54,7 @@ def parse_args_onnxruntime_quantize(parser: "ArgumentParser"):
     level_group.add_argument(
         "--avx512_vnni", action="store_true", help="Quantization with AVX-512 and VNNI instructions."
     )
+    level_group.add_argument("--ppc64le", action="store_true", help="Quantization for the IBM PowerPC64 architecture.")
     level_group.add_argument("--tensorrt", action="store_true", help="Quantization for NVIDIA TensorRT optimizer.")
     level_group.add_argument(
         "-c",
@@ -91,6 +92,8 @@ class ONNXRuntimeQuantizeCommand(BaseOptimumCLICommand):
             qconfig = AutoQuantizationConfig.avx512(is_static=False, per_channel=self.args.per_channel)
         elif self.args.avx512_vnni:
             qconfig = AutoQuantizationConfig.avx512_vnni(is_static=False, per_channel=self.args.per_channel)
+        elif self.args.ppc64le:
+            qconfig = AutoQuantizationConfig.ppc64le(is_static=False, per_channel=self.args.per_channel)
         elif self.args.tensorrt:
             raise ValueError(
                 "TensorRT quantization relies on static quantization that requires calibration, which is currently not supported through optimum-cli. Please adapt Optimum static quantization examples to run static quantization for TensorRT: https://github.com/huggingface/optimum/tree/main/examples/onnxruntime/quantization"

--- a/optimum/onnxruntime/configuration.py
+++ b/optimum/onnxruntime/configuration.py
@@ -599,6 +599,55 @@ class AutoQuantizationConfig:
         )
 
     @staticmethod
+    def ppc64le(
+        is_static: bool,
+        use_symmetric_activations: bool = False,
+        use_symmetric_weights: bool = True,
+        per_channel: bool = True,
+        nodes_to_quantize: Optional[List[str]] = None,
+        nodes_to_exclude: Optional[List[str]] = None,
+        operators_to_quantize: Optional[List[str]] = None,
+    ):
+        """
+        Creates a [`~onnxruntime.QuantizationConfig`] fit for IBM Power CPU.
+        
+        Args:
+            is_static (`bool`):
+                Boolean flag to indicate whether we target static or dynamic quantization.
+            use_symmetric_activations (`bool`, defaults to `False`):
+                Whether to use symmetric quantization for activations.
+            use_symmetric_weights (`bool`, defaults to `True`):
+                Whether to use symmetric quantization for weights.
+            per_channel (`bool`, defaults to `True`):
+                Whether we should quantize per-channel (also known as "per-row"). Enabling this can
+                increase overall accuracy while making the quantized model heavier.
+            nodes_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Specific nodes to quantize. If `None`, all nodes being operators from `operators_to_quantize` will be quantized.
+            nodes_to_exclude (`Optional[List[str]]`, defaults to `None`):
+                Specific nodes to exclude from quantization. The list of nodes in a model can be found loading the ONNX model through onnx.load, or through visual inspection with [netron](https://github.com/lutzroeder/netron).
+            operators_to_quantize (`Optional[List[str]]`, defaults to `None`):
+                Type of nodes to perform quantization on. By default, all the quantizable operators will be quantized. Quantizable operators can be found at https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/quantization/registry.py.
+        """
+        format, mode, operators_to_quantize = default_quantization_parameters(
+            is_static, operators_to_quantize=operators_to_quantize
+        )
+
+        return QuantizationConfig(
+            is_static=is_static,
+            format=format,
+            mode=mode,
+            activations_dtype=QuantType.QUInt8,
+            activations_symmetric=use_symmetric_activations,
+            weights_dtype=QuantType.QInt8,
+            weights_symmetric=use_symmetric_weights,
+            per_channel=per_channel,
+            reduce_range=False,
+            nodes_to_quantize=nodes_to_quantize or [],
+            nodes_to_exclude=nodes_to_exclude or [],
+            operators_to_quantize=operators_to_quantize,
+        )
+
+    @staticmethod
     def tensorrt(
         per_channel: bool = True,
         nodes_to_quantize: Optional[List[str]] = None,


### PR DESCRIPTION
# What does this PR do?

This PR adds quantization support for IBM Power systems (ppc64le). This addition was made so that users running AI models on Power systems have the ability to quantize models in a standard format using optimum.

Authored by : mgiessing <[marvin.giessing@gmail.com](mailto:marvin.giessing@gmail.com)>

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

