### PR TITLE
Disable failing test & free space when building documentation

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -64,8 +64,6 @@ jobs:
           df -h
           sudo apt-get autoremove -y >/dev/null 2>&1
           sudo apt-get clean
-          sudo apt-get autoremove -y >/dev/null 2>&1
-          sudo apt-get autoclean -y >/dev/null 2>&1
           df -h
           echo "https://github.com/actions/virtual-environments/issues/709"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -54,6 +54,31 @@ jobs:
           repository: 'huggingface/optimum-amd'
           path: optimum-amd
 
+      - name: Free disk space
+        run: |
+          df -h
+          echo "Removing large packages"
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel
+          df -h
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get clean
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+          echo "https://github.com/actions/virtual-environments/issues/709"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+          echo "remove big /usr/local"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
+          df -h
+          sudo rm -rf /usr/share/dotnet/sdk > /dev/null 2>&1
+          sudo rm -rf /usr/share/dotnet/shared > /dev/null 2>&1
+          sudo rm -rf /usr/share/swift > /dev/null 2>&1
+          df -h
+
       - name: Set environment variables
         run: |
           cd optimum

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -95,7 +95,8 @@ class TestCLI(unittest.TestCase):
                 # f"optimum-cli onnxruntime quantize --onnx_model {tempdir}/encoder-decoder --avx2 -o {tempdir}/quantized_encoder_decoder",
             ]
 
-            if parse(ort_version) != Version("1.16.0"):
+            if parse(ort_version) != Version("1.16.0") and parse(ort_version) != Version("1.17.0"):
+                # Failing on onnxruntime==1.17.0, will be fixed on 1.17.1: https://github.com/microsoft/onnxruntime/pull/19421
                 export_commands.append(
                     f"optimum-cli export onnx --model hf-internal-testing/tiny-random-t5 {tempdir}/encoder-decoder"
                 )

--- a/tests/onnxruntime/test_quantization.py
+++ b/tests/onnxruntime/test_quantization.py
@@ -115,7 +115,8 @@ class ORTDynamicQuantizationTest(unittest.TestCase):
             self.assertEqual(expected_quantized_matmuls, num_quantized_matmul)
             gc.collect()
 
-    @unittest.skipIf(parse(ort_version) == Version("1.16.0"), "not supported with this onnxruntime version")
+    # NOTE: Will be fixed in 1.17.1, reference: https://github.com/microsoft/onnxruntime/pull/19421
+    @unittest.skipIf(parse(ort_version) == Version("1.17.0"), "not supported with this onnxruntime version")
     def test_dynamic_quantization_subgraphs(self):
         qconfig = AutoQuantizationConfig.avx512(is_static=False, per_channel=True)
         tmp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Skip failing tests due to a regression in ORT that will be fixed in its next patch release

Fix as well `ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device` on the build main doc workflow (https://github.com/huggingface/optimum/actions/runs/7899612672)