### PR TITLE
Fix no space left on device in actions

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -57,10 +57,17 @@ jobs:
       - name: Free disk space
         run: |
           df -h
-          echo "Removing large packages"
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel
+          sudo apt-get update
+          sudo apt-get purge -y '^apache.*'
+          sudo apt-get purge -y '^imagemagick.*'
+          sudo apt-get purge -y '^dotnet.*'
+          sudo apt-get purge -y '^aspnetcore.*'
+          sudo apt-get purge -y 'php.*'
+          sudo apt-get purge -y '^temurin.*'
+          sudo apt-get purge -y '^mysql.*'
+          sudo apt-get purge -y '^java.*'
+          sudo apt-get purge -y '^openjdk.*'
+          sudo apt-get purge -y microsoft-edge-stable google-cloud-cli azure-cli google-chrome-stable firefox powershell mono-devel
           df -h
           sudo apt-get autoremove -y >/dev/null 2>&1
           sudo apt-get clean
@@ -72,9 +79,21 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
           df -h
+          echo "remove /usr/share leftovers"
           sudo rm -rf /usr/share/dotnet/sdk > /dev/null 2>&1
           sudo rm -rf /usr/share/dotnet/shared > /dev/null 2>&1
           sudo rm -rf /usr/share/swift > /dev/null 2>&1
+          df -h
+          echo "remove other leftovers"
+          sudo rm -rf /var/lib/mysql > /dev/null 2>&1
+          sudo rm -rf /home/runner/.dotnet > /dev/null 2>&1
+          sudo rm -rf /home/runneradmin/.dotnet > /dev/null 2>&1
+          sudo rm -rf /etc/skel/.dotnet > /dev/null 2>&1
+          sudo rm -rf /usr/local/.ghcup > /dev/null 2>&1
+          sudo rm -rf /usr/local/aws-cli > /dev/null 2>&1
+          sudo rm -rf /usr/local/lib/node_modules > /dev/null 2>&1
+          sudo rm -rf /usr/lib/heroku > /dev/null 2>&1
+          sudo rm -rf /usr/local/share/chromium > /dev/null 2>&1
           df -h
 
       - name: Set environment variables

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -25,46 +25,46 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Free disk space
-    run: |
-        df -h
-        sudo apt-get update
-        sudo apt-get purge -y '^apache.*'
-        sudo apt-get purge -y '^imagemagick.*'
-        sudo apt-get purge -y '^dotnet.*'
-        sudo apt-get purge -y '^aspnetcore.*'
-        sudo apt-get purge -y 'php.*'
-        sudo apt-get purge -y '^temurin.*'
-        sudo apt-get purge -y '^mysql.*'
-        sudo apt-get purge -y '^java.*'
-        sudo apt-get purge -y '^openjdk.*'
-        sudo apt-get purge -y microsoft-edge-stable google-cloud-cli azure-cli google-chrome-stable firefox powershell mono-devel
-        df -h
-        sudo apt-get autoremove -y >/dev/null 2>&1
-        sudo apt-get clean
-        df -h
-        echo "https://github.com/actions/virtual-environments/issues/709"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        df -h
-        echo "remove big /usr/local"
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
-        df -h
-        echo "remove /usr/share leftovers"
-        sudo rm -rf /usr/share/dotnet/sdk > /dev/null 2>&1
-        sudo rm -rf /usr/share/dotnet/shared > /dev/null 2>&1
-        sudo rm -rf /usr/share/swift > /dev/null 2>&1
-        df -h
-        echo "remove other leftovers"
-        sudo rm -rf /var/lib/mysql > /dev/null 2>&1
-        sudo rm -rf /home/runner/.dotnet > /dev/null 2>&1
-        sudo rm -rf /home/runneradmin/.dotnet > /dev/null 2>&1
-        sudo rm -rf /etc/skel/.dotnet > /dev/null 2>&1
-        sudo rm -rf /usr/local/.ghcup > /dev/null 2>&1
-        sudo rm -rf /usr/local/aws-cli > /dev/null 2>&1
-        sudo rm -rf /usr/local/lib/node_modules > /dev/null 2>&1
-        sudo rm -rf /usr/lib/heroku > /dev/null 2>&1
-        sudo rm -rf /usr/local/share/chromium > /dev/null 2>&1
-        df -h
+      run: |
+          df -h
+          sudo apt-get update
+          sudo apt-get purge -y '^apache.*'
+          sudo apt-get purge -y '^imagemagick.*'
+          sudo apt-get purge -y '^dotnet.*'
+          sudo apt-get purge -y '^aspnetcore.*'
+          sudo apt-get purge -y 'php.*'
+          sudo apt-get purge -y '^temurin.*'
+          sudo apt-get purge -y '^mysql.*'
+          sudo apt-get purge -y '^java.*'
+          sudo apt-get purge -y '^openjdk.*'
+          sudo apt-get purge -y microsoft-edge-stable google-cloud-cli azure-cli google-chrome-stable firefox powershell mono-devel
+          df -h
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get clean
+          df -h
+          echo "https://github.com/actions/virtual-environments/issues/709"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+          echo "remove big /usr/local"
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
+          df -h
+          echo "remove /usr/share leftovers"
+          sudo rm -rf /usr/share/dotnet/sdk > /dev/null 2>&1
+          sudo rm -rf /usr/share/dotnet/shared > /dev/null 2>&1
+          sudo rm -rf /usr/share/swift > /dev/null 2>&1
+          df -h
+          echo "remove other leftovers"
+          sudo rm -rf /var/lib/mysql > /dev/null 2>&1
+          sudo rm -rf /home/runner/.dotnet > /dev/null 2>&1
+          sudo rm -rf /home/runneradmin/.dotnet > /dev/null 2>&1
+          sudo rm -rf /etc/skel/.dotnet > /dev/null 2>&1
+          sudo rm -rf /usr/local/.ghcup > /dev/null 2>&1
+          sudo rm -rf /usr/local/aws-cli > /dev/null 2>&1
+          sudo rm -rf /usr/local/lib/node_modules > /dev/null 2>&1
+          sudo rm -rf /usr/lib/heroku > /dev/null 2>&1
+          sudo rm -rf /usr/local/share/chromium > /dev/null 2>&1
+          df -h
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -23,13 +23,58 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+
+    - name: Free disk space
+    run: |
+        df -h
+        sudo apt-get update
+        sudo apt-get purge -y '^apache.*'
+        sudo apt-get purge -y '^imagemagick.*'
+        sudo apt-get purge -y '^dotnet.*'
+        sudo apt-get purge -y '^aspnetcore.*'
+        sudo apt-get purge -y 'php.*'
+        sudo apt-get purge -y '^temurin.*'
+        sudo apt-get purge -y '^mysql.*'
+        sudo apt-get purge -y '^java.*'
+        sudo apt-get purge -y '^openjdk.*'
+        sudo apt-get purge -y microsoft-edge-stable google-cloud-cli azure-cli google-chrome-stable firefox powershell mono-devel
+        df -h
+        sudo apt-get autoremove -y >/dev/null 2>&1
+        sudo apt-get clean
+        df -h
+        echo "https://github.com/actions/virtual-environments/issues/709"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
+        echo "remove big /usr/local"
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
+        df -h
+        echo "remove /usr/share leftovers"
+        sudo rm -rf /usr/share/dotnet/sdk > /dev/null 2>&1
+        sudo rm -rf /usr/share/dotnet/shared > /dev/null 2>&1
+        sudo rm -rf /usr/share/swift > /dev/null 2>&1
+        df -h
+        echo "remove other leftovers"
+        sudo rm -rf /var/lib/mysql > /dev/null 2>&1
+        sudo rm -rf /home/runner/.dotnet > /dev/null 2>&1
+        sudo rm -rf /home/runneradmin/.dotnet > /dev/null 2>&1
+        sudo rm -rf /etc/skel/.dotnet > /dev/null 2>&1
+        sudo rm -rf /usr/local/.ghcup > /dev/null 2>&1
+        sudo rm -rf /usr/local/aws-cli > /dev/null 2>&1
+        sudo rm -rf /usr/local/lib/node_modules > /dev/null 2>&1
+        sudo rm -rf /usr/lib/heroku > /dev/null 2>&1
+        sudo rm -rf /usr/local/share/chromium > /dev/null 2>&1
+        df -h
+
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         pip install .[tests,onnxruntime]
+
     - name: Test with pytest
       working-directory: tests
       run: |

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Free disk space
+      if: matrix.os == 'ubuntu-20.04'
       run: |
           df -h
           sudo apt-get update


### PR DESCRIPTION
Github actions seem to have decreased the available space on its ubuntu runners, see https://github.com/actions/runner-images/discussions/9329 & https://github.com/actions/runner-images/pull/9251/files

Go from 19G to 54G free disk space in 3min.