### PR TITLE
Add end-to-end Marlin benchmark

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -42,14 +42,58 @@ CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-c
 
 ### Batch size = 1
 
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |10         |1         |512          |1         |112.08       |98.89                 |10.11             |
+|gptq        |False    |4   |128       |cuda-old  |10         |1         |512          |1         |6.09         |374.60                |2.67              |
+|gptq        |False    |4   |128       |exllama   |10         |1         |512          |1         |5.99         |116.11                |8.61              |
+|gptq        |False    |4   |128       |exllama_v2|10         |1         |512          |1         |7.28         |115.05                |8.69              |
+|gptq        |False    |4   |128       |marlin    |10         |1         |512          |1         |32.26        |95.15                 |10.51             |
+|bitsandbytes|None     |None|None      |None      |10         |1         |512          |1         |10.18        |140.90                |7.10              |
+
 ### Batch size = 2
+
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|FIELD13|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|-------|
+|None        |None     |None|None      |None      |10         |2         |512          |1         |112.08       |183.41                |10.90             |       |
+|gptq        |False    |4   |128       |cuda-old  |10         |2         |512          |1         |6.09         |458.15                |4.37              |       |
+|gptq        |False    |4   |128       |exllama   |10         |2         |512          |1         |5.99         |196.50                |10.18             |       |
+|gptq        |False    |4   |128       |exllama_v2|10         |2         |512          |1         |7.28         |195.30                |10.24             |       |
+|gptq        |False    |4   |128       |marlin    |10         |2         |512          |1         |32.26        |192.18                |10.41             |       |
+|bitsandbytes|None     |None|None      |None      |10         |2         |512          |1         |10.18        |223.30                |8.96              |       |
 
 ### Batch size = 4
 
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |10         |4         |512          |1         |112.08       |332.39                |12.03             |
+|gptq        |False    |4   |128       |cuda-old  |10         |4         |512          |1         |6.09         |618.96                |6.46              |
+|gptq        |False    |4   |128       |exllama   |10         |4         |512          |1         |5.99         |353.67                |11.31             |
+|gptq        |False    |4   |128       |exllama_v2|10         |4         |512          |1         |7.28         |353.47                |11.32             |
+|gptq        |False    |4   |128       |marlin    |10         |4         |512          |1         |32.26        |384.47                |10.40             |
+|bitsandbytes|None     |None|None      |None      |10         |4         |512          |1         |10.18        |369.76                |10.82             |
+
 ### Batch size = 8
+
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |10         |8         |512          |1         |112.08       |655.58                |12.20             |
+|gptq        |False    |4   |128       |cuda-old  |10         |8         |512          |1         |6.09         |962.64                |8.31              |
+|gptq        |False    |4   |128       |exllama   |10         |8         |512          |1         |5.99         |687.99                |11.63             |
+|gptq        |False    |4   |128       |exllama_v2|10         |8         |512          |1         |7.28         |684.68                |11.68             |
+|gptq        |False    |4   |128       |marlin    |10         |8         |512          |1         |32.26        |760.58                |10.52             |
+|bitsandbytes|None     |None|None      |None      |10         |8         |512          |1         |10.18        |689.23                |11.61             |
 
 ### Batch size = 16
 
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |10         |16        |512          |1         |112.08       |1368.83               |11.69             |
+|gptq        |False    |4   |128       |cuda-old  |10         |16        |512          |1         |6.09         |1679.88               |9.52              |
+|gptq        |False    |4   |128       |exllama   |10         |16        |512          |1         |5.99         |1337.64               |11.96             |
+|gptq        |False    |4   |128       |exllama_v2|10         |16        |512          |1         |7.28         |1336.79               |11.97             |
+|gptq        |False    |4   |128       |marlin    |10         |16        |512          |1         |32.26        |1515.79               |10.56             |
+|bitsandbytes|None     |None|None      |None      |10         |16        |512          |1         |10.18        |1427.68               |11.21             |
 
 ## Decode benchmark
 
@@ -79,14 +123,58 @@ CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-c
 
 ### Batch size = 1
 
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |5          |1         |1            |512       |6.64         |30.43                 |32.86             |
+|gptq        |False    |4   |128       |cuda-old  |5          |1         |1            |512       |6.03         |42.91                 |23.30             |
+|gptq        |False    |4   |128       |exllama   |5          |1         |1            |512       |6.65         |31.68                 |31.57             |
+|gptq        |False    |4   |128       |exllama_v2|5          |1         |1            |512       |5.86         |31.60                 |31.64             |
+|gptq        |False    |4   |128       |marlin    |5          |1         |1            |512       |31.75        |28.96                 |34.53             |
+|bitsandbytes|None     |None|None      |None      |5          |1         |1            |512       |9.80         |45.06                 |22.19             |
+
 ### Batch size = 2
+
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |5          |2         |1            |512       |6.64         |30.11                 |66.42             |
+|gptq        |False    |4   |128       |cuda-old  |5          |2         |1            |512       |6.03         |42.68                 |46.86             |
+|gptq        |False    |4   |128       |exllama   |5          |2         |1            |512       |6.65         |37.00                 |54.05             |
+|gptq        |False    |4   |128       |exllama_v2|5          |2         |1            |512       |5.86         |31.74                 |63.02             |
+|gptq        |False    |4   |128       |marlin    |5          |2         |1            |512       |31.75        |29.19                 |68.53             |
+|bitsandbytes|None     |None|None      |None      |5          |2         |1            |512       |9.80         |68.00                 |29.41             |
 
 ### Batch size = 4
 
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |5          |4         |1            |512       |6.64         |29.76                 |134.41            |
+|gptq        |False    |4   |128       |cuda-old  |5          |4         |1            |512       |6.03         |51.43                 |77.78             |
+|gptq        |False    |4   |128       |exllama   |5          |4         |1            |512       |6.65         |55.15                 |72.53             |
+|gptq        |False    |4   |128       |exllama_v2|5          |4         |1            |512       |5.86         |31.58                 |126.68            |
+|gptq        |False    |4   |128       |marlin    |5          |4         |1            |512       |31.75        |29.08                 |137.56            |
+|bitsandbytes|None     |None|None      |None      |5          |4         |1            |512       |9.80         |70.25                 |56.94             |
+
 ### Batch size = 8
+
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |5          |8         |1            |512       |6.64         |32.98                 |242.60            |
+|gptq        |False    |4   |128       |cuda-old  |5          |8         |1            |512       |6.03         |91.74                 |87.20             |
+|gptq        |False    |4   |128       |exllama   |5          |8         |1            |512       |6.86         |58.61                 |136.49            |
+|gptq        |False    |4   |128       |exllama_v2|5          |8         |1            |512       |5.86         |32.59                 |245.48            |
+|gptq        |False    |4   |128       |marlin    |5          |8         |1            |512       |31.75        |29.02                 |275.70            |
+|bitsandbytes|None     |None|None      |None      |5          |8         |1            |512       |9.80         |74.20                 |107.81            |
 
 ### Batch size = 16
 
+|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
+|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
+|None        |None     |None|None      |None      |5          |16        |1            |512       |6.64         |40.24                 |397.61            |
+|gptq        |False    |4   |128       |cuda-old  |5          |16        |1            |512       |6.03         |171.90                |93.08             |
+|gptq        |False    |4   |128       |exllama   |5          |16        |1            |512       |6.86         |66.37                 |241.07            |
+|gptq        |False    |4   |128       |exllama_v2|5          |16        |1            |512       |5.86         |48.10                 |332.61            |
+|gptq        |False    |4   |128       |marlin    |5          |16        |1            |512       |31.75        |31.71                 |504.63            |
+|bitsandbytes|None     |None|None      |None      |5          |16        |1            |512       |9.80         |82.29                 |194.44            |
 
 ## Perplexity benchmark results
 

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -4,159 +4,89 @@ Please refer to https://medium.com/pytorch/bettertransformer-out-of-the-box-perf
 
 # GPTQ benchmark
 
-The results below are for AutoGPTQ 0.5.0, PyTorch 2.0.1, bitsandbytes 0.41.1, transformers 4.35.
+The results below are for AutoGPTQ 0.7.0, PyTorch 2.2.0, bitsandbytes 0.42.0, transformers 4.37.2.
 
-## Generation benchmark results
+Here are results obtained on a single NVIDIA A100-SXM4-80GB GPU **without act-order**. Additional benchmarks could be done in the act-order case.
 
-Run
-
-```shell
-# pytorch fp16
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --num-batches 4 --task text-generation --generate
-
-# GPTQ with exllamav2 kernel (int4/fp16)
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 4 --gptq --task text-generation --use-exllama --exllama-version 2 --generate 
-
-# GPTQ with exllama kernel (int4/fp16)
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 4 --gptq --task text-generation --use-exllama --generate
-
-# GPTQ without exllama kernel (int4/fp16)
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 4 --gptq --task text-generation --generate
-
-# using bitsandbytes fp4/fp16 scheme
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --num-batches 4 --task text-generation --bitsandbytes --generate
-```
-
-Here are results obtained on a single NVIDIA A100-SXM4-80GB GPU. We use a prompt length of 512, and generate exactly 512 new tokens. Each generation is repeated for 4 batches, and metrics are averaged over the number of batches and generation length.
-
-Additional benchmarks could be done in the act-order case.
-
-From the bencharmk, it appears that Exllama kernel is the best-in-class for GPTQ, although it is rather slow for larger batch sizes. The memory savings are not exactly of x4 although weights are in int4. This can be explained by the possible static buffers used by the kernels, the CUDA context (taken into account in the measurements), and the KV cache that is still in fp16.
+From the benchmark, it appears that Exllama kernel is the best-in-class for GPTQ, although it is rather slow for larger batch sizes. The memory savings are not exactly of x4 although weights are in int4. This can be explained by the possible static buffers used by the kernels, the CUDA context (taken into account in the measurements), and the KV cache that is still in fp16.
 
 Bitsandbytes uses the fp4 scheme, with the compute in fp16.
 
-### Batch size = 1
+**Beware that exllama uses [fp16 accumulation](https://github.com/turboderp/exllamav2/blob/75f969a6d3efd28fcb521100669ba2594f3ba14c/exllamav2/exllamav2_ext/cuda/q_gemm.cu#L132-L138) for its fp16 x fp16 GEMM, while PyTorch and other kernels accumulate on fp32 for numerical accuracy purposees. This has latency implications and the comparison is therefore not apple-to-apple.**
 
-|quantization |act_order|bits|group_size|kernel|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Peak memory (MB)|
-|-----|---------|----|----------|------|-------------|----------------------|------------------|----------------|
-|None|None     |None|None      |None  |26.0         |36.958                |27.058            |29152.98        |
-| gptq | False | 4 | 128 | exllamav2 | 36.07 | 32.25 | 31.01 | 11313.75 |
-|gptq |False    |4   |128       |exllama|36.2         |33.711                |29.663            |10484.34        |
-|gptq |False    |4   |128       |autogptq-cuda-old|36.2         |46.44                 |21.53             |10344.62        |
-|bitsandbytes|None     |None|None      |None  |37.64        |52.00                 |19.23             |11018.36       |
+## Prefill benchmark
 
-### Batch size = 2
-
-|quantization |act_order|bits|group_size|kernel|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Peak memory (MB)|
-|-----|---------|----|----------|------|-------------|----------------------|------------------|----------------|
-|None|None     |None|None      |None  |26.0         |37.35                 |53.53             |30831.09        |
-| gptq | False | 4 | 128 | exllamav2 | 36.07 | 35.81 | 55.85  | 12112.42 |
-|gptq |False    |4   |128       |exllama|36.2         |37.25                 |53.68             |12162.43        |
-|gptq |False    |4   |128       |autogptq-cuda-old|36.2         |47.41                 |42.18             |12020.34        |
-|bitsandbytes|None     |None|None      |None  |37.64        |74.62                 |26.80             |12834.84       |
-
-### Batch size = 4
-
-|quantization |act_order|bits|group_size|kernel           |Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Peak memory (MB)|
-|-----|---------|----|----------|-----------------|-------------|----------------------|------------------|----------------|
-|None|None     |None|None      |None             |26.0         |37.89                 |105.55            |34187.22        |
-| gptq | False | 4 | 128 | exllamav2 | 36.07 | 36.04 | 110.98 | 16387.19 |
-|gptq |False    |4   |128       |exllama          |36.2         |54.14                 |73.87             |15518.55        |
-|gptq |False    |4   |128       |autogptq-cuda-old|36.2         |60.98                 |65.59             |15374.67        |
-|bitsandbytes|None     |None|None      |None  |37.64        |80.24                 |49.85             |16187.69       |
-
-### Batch size = 8
-
-|quantization |act_order|bits|group_size|kernel|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Peak memory (MB)|
-|-----|---------|----|----------|------|-------------|----------------------|------------------|----------------|
-|None|None     |None|None      |None  |26.0         |47.37                 |168.86            |40327.62        |
-| gptq | False | 4 | 128 | exllamav2 | 36.07 | 47.31 | 169.11 | 22463.02 |
-|gptq |False    |4   |128       |exllama|36.2         |73.57                 |108.73            |21864.56        |
-|gptq |False    |4   |128       |autogptq-cuda-old|36.2         |104.44                |76.59             |20987.68        |
-|bitsandbytes|None     |None|None      |None  |37.64        |91.29                 |87.63             |22894.02       |
-
-### Batch size = 16
-
-|quantization |act_order|bits|group_size|kernel|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Peak memory (MB)|
-|-----|---------|----|----------|------|-------------|----------------------|------------------|----------------|
-|None|None     |None|None      |None  |26.0         |69.94                 |228.76            |53986.51        |
-| gptq | False | 4 | 128 | exllamav2 | 36.07 | 83.09 | 192.55 | 35740.95 |
-|gptq |False    |4   |128       |exllama|36.2         |95.41                 |167.68            |34777.04        |
-|gptq |False    |4   |128       |autogptq-cuda-old|36.2         |192.48                |83.12             |35497.62        |
-|bitsandbytes|None     |None|None      |None  |37.64        |113.98                |140.38            |35532.37       |
-
-## Prefill-only benchmark results
+The benchmark below is for a prompt length of 512, measuring only the prefill step on a single NVIDIA A100-SXM4-80GB GPU. This benchmark typically corresponds to the forward during training (to the difference that here `generate` is called, which has some overhead).
 
 Run
 
 ```shell
 # pytorch fp16
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --num-batches 10 --task text-generation --prefill --generate
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --task text-generation --generate --prefill
 
 # GPTQ with exllamav2 kernel (int4/fp16)
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 10 --gptq --task text-generation --prefill --use-exllama --exllama-version 2 --generate 
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --gptq --task text-generation --use-exllama --exllama-version 2 --generate --prefill
 
-# GPTQ with exllamav kernel (int4/fp16)
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 10 --gptq --task text-generation --prefill --use-exllama --generate
+# GPTQ with exllama kernel (int4/fp16)
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep -gptq --task text-generation --use-exllama --generate --prefill
 
 # GPTQ without exllama kernel (int4/fp16)
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 10 --gptq --task text-generation --prefill --generate
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --gptq --task text-generation --generate --prefill
+
+# GPTQ with marlin kernel (int4/fp16)
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --gptq --task text-generation --use-marlin --generate --prefill
 
 # using bitsandbytes fp4/fp16 scheme
-CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --num-batches 10 --task text-generation --prefill --bitsandbytes --generate
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --bitsandbytes --task text-generation --generate --prefill
 ```
-
-The benchmark below is for a prompt length of 512, measuring only the prefill step on a single NVIDIA A100-SXM4-80GB GPU. The forward is repeated 10 times. This benchmark typically corresponds to the forward during training (to the difference that here `generate` is called, which has some overhead).
 
 ### Batch size = 1
 
-|quantization |act_order|bits|group_size|kernel           |prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Max memory (MB)|
-|-----|---------|----|----------|-----------------|-------------|----------|-------------|----------------------|------------------|---------------|
-|None|None     |None|None      |None             |512          |1         |27.22        |96.38                 |10.38             |27999.54       |
-| gptq | False | 4 | 128 | exllamav2 | 512 | 1 | 6.63 | 116.07  | 8.62  | 10260.35 |
-|gptq |False    |4   |128       |exllama          |512          |1         |38.35        |112.54                |8.89              |9330.89        |
-|gptq |False    |4   |128       |autogptq-cuda-old|512          |1         |43.94        |368.13                |2.72              |9474.19        |
-|bitsandbytes|None|None|None|None|512|1  |37.46|139.17 |7.19 |9952.65 |
-
 ### Batch size = 2
-
-|quantization |act_order|bits|group_size|kernel           |prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Max memory (MB)|
-|-----|---------|----|----------|-----------------|-------------|----------|-------------|----------------------|------------------|---------------|
-|None|None     |None|None      |None             |512          |1         |27.22        |169.95                |11.77             |28524.37       |
-| gptq | False | 4 | 128 | exllamav2 | 512 | 1 | 6.63 | 212.07  | 9.43  | 10783.60 |
-|gptq |False    |4   |128       |exllama          |512          |1         |38.35        |190.44                |10.50             |9855.71        |
-|gptq |False    |4   |128       |autogptq-cuda-old|512          |1         |43.94        |443.80                |4.51              |9928.23        |
-|bitsandbytes|None|None|None|None|512|1  |37.46|212.76 |9.40 |10421.89|
 
 ### Batch size = 4
 
-|quantization |act_order|bits|group_size|kernel           |prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Max memory (MB)|
-|-----|---------|----|----------|-----------------|-------------|----------|-------------|----------------------|------------------|---------------|
-|None|None     |None|None      |None             |512          |1         |27.22        |305.99                |13.07             |29574.01       |
-| gptq | False | 4 | 128 | exllamav2 | 512 | 1 | 6.63 | 385.58  | 10.37 | 11829.59 |
-|gptq |False    |4   |128       |exllama          |512          |1         |38.35        |345.54                |11.58             |10905.35       |
-|gptq |False    |4   |128       |autogptq-cuda-old|512          |1         |43.94        |597.24                |6.70              |10838.42       |
-|bitsandbytes|None|None|None|None|512|1  |37.46|349.18 |11.46|11440.08|
-
 ### Batch size = 8
-
-|quantization |act_order|bits|group_size|kernel           |prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Max memory (MB)|
-|-----|---------|----|----------|-----------------|-------------|----------|-------------|----------------------|------------------|---------------|
-|None|None     |None|None      |None             |512          |1         |27.22        |600.47                |13.32             |31673.30       |
-| gptq | False | 4 | 128 | exllamav2 | 512 | 1 | 6.63 | 753.06  | 10.62 | 13920.50 |
-|gptq |False    |4   |128       |exllama          |512          |1         |38.35        |659.61                |12.13             |13004.64       |
-|gptq |False    |4   |128       |autogptq-cuda-old|512          |1         |43.94        |909.09                |8.80              |12862.18       |
-|bitsandbytes|None|None|None|None|512|1  |37.46|643.42 |12.43|13539.37|
 
 ### Batch size = 16
 
-|quantization |act_order|bits|group_size|kernel    |prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|Max memory (MB)|
-|-----|---------|----|-----------|----------|-------------|----------|-------------|----------------------|------------------|---------------|
-|None|None     |None|None      |None        |512          |1         |27.22        |1209.07               |13.23             |35871.88       |
-| gptq | False | 4 | 128 | exllamav2 | 512 | 1 | 6.63 | 1467.36 | 10.90 | 18104.44 |
-|gptq |False    |4   |128       |exllama     |512          |1         |38.35        |1280.25               |12.50             |17203.22       |
-|gptq |False    |4   |128       |autogptq-cuda-old |512          |1         |43.94        |1533.54               |10.43             |17060.76       |
-|bitsandbytes|None|None|None|None|512|1  |37.46|1256.88|12.73|17737.95|
+
+## Decode benchmark
+
+The benchmark below is for a prefill length of 1, essentially measuring the decode step in text generation (512 tokens generated).
+
+Run
+
+```shell
+# pytorch fp16
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --num-batches 5 --task text-generation --generate --decode
+
+# GPTQ with exllamav2 kernel (int4/fp16)
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 5 --gptq --task text-generation --use-exllama --exllama-version 2 --generate --decode
+
+# GPTQ with exllama kernel (int4/fp16)
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 5 --gptq --task text-generation --use-exllama --exllama-version 1 --generate --decode
+
+# GPTQ with cuda-old kernel (int4/fp16)
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 5 --gptq --task text-generation --generate --decode
+
+# GPTQ with marlin kernel (int4/fp16)
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model TheBloke/Llama-2-13B-chat-GPTQ --sweep --num-batches 5 --gptq --task text-generation --use-marlin --generate --decode
+
+# using bitsandbytes fp4/fp16 scheme
+CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-chat-hf --sweep --num-batches 5 --bitsandbytes --task text-generation --generate --decode
+```
+
+### Batch size = 1
+
+### Batch size = 2
+
+### Batch size = 4
+
+### Batch size = 8
+
+### Batch size = 16
+
 
 ## Perplexity benchmark results
 

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -42,58 +42,57 @@ CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-c
 
 ### Batch size = 1
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |10         |1         |512          |1         |112.08       |98.89                 |10.11             |
-|gptq        |False    |4   |128       |cuda-old  |10         |1         |512          |1         |6.09         |374.60                |2.67              |
-|gptq        |False    |4   |128       |exllama   |10         |1         |512          |1         |5.99         |116.11                |8.61              |
-|gptq        |False    |4   |128       |exllama_v2|10         |1         |512          |1         |7.28         |115.05                |8.69              |
-|gptq        |False    |4   |128       |marlin    |10         |1         |512          |1         |32.26        |95.15                 |10.51             |
-|bitsandbytes|None     |None|None      |None      |10         |1         |512          |1         |10.18        |140.90                |7.10              |
-
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 112.08        | 98.89                  | 10.11              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.09          | 374.60                 | 2.67               |
+| gptq         | False     | 4    | 128        | exllama    | 5.99          | 116.11                 | 8.61               |
+| gptq         | False     | 4    | 128        | exllama_v2 | 7.28          | 115.05                 | 8.69               |
+| gptq         | False     | 4    | 128        | marlin     | 32.26         | 95.15                  | 10.51              |
+| bitsandbytes | None      | None | None       | None       | 10.18         | 140.90                 | 7.10               |
 ### Batch size = 2
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|FIELD13|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|-------|
-|None        |None     |None|None      |None      |10         |2         |512          |1         |112.08       |183.41                |10.90             |       |
-|gptq        |False    |4   |128       |cuda-old  |10         |2         |512          |1         |6.09         |458.15                |4.37              |       |
-|gptq        |False    |4   |128       |exllama   |10         |2         |512          |1         |5.99         |196.50                |10.18             |       |
-|gptq        |False    |4   |128       |exllama_v2|10         |2         |512          |1         |7.28         |195.30                |10.24             |       |
-|gptq        |False    |4   |128       |marlin    |10         |2         |512          |1         |32.26        |192.18                |10.41             |       |
-|bitsandbytes|None     |None|None      |None      |10         |2         |512          |1         |10.18        |223.30                |8.96              |       |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 112.08        | 183.41                 | 10.90              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.09          | 458.15                 | 4.37               |
+| gptq         | False     | 4    | 128        | exllama    | 5.99          | 196.50                 | 10.18              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 7.28          | 195.30                 | 10.24              |
+| gptq         | False     | 4    | 128        | marlin     | 32.26         | 192.18                 | 10.41              |
+| bitsandbytes | None      | None | None       | None       | 10.18         | 223.30                 | 8.96               |
 
 ### Batch size = 4
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |10         |4         |512          |1         |112.08       |332.39                |12.03             |
-|gptq        |False    |4   |128       |cuda-old  |10         |4         |512          |1         |6.09         |618.96                |6.46              |
-|gptq        |False    |4   |128       |exllama   |10         |4         |512          |1         |5.99         |353.67                |11.31             |
-|gptq        |False    |4   |128       |exllama_v2|10         |4         |512          |1         |7.28         |353.47                |11.32             |
-|gptq        |False    |4   |128       |marlin    |10         |4         |512          |1         |32.26        |384.47                |10.40             |
-|bitsandbytes|None     |None|None      |None      |10         |4         |512          |1         |10.18        |369.76                |10.82             |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 112.08        | 332.39                 | 12.03              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.09          | 618.96                 | 6.46               |
+| gptq         | False     | 4    | 128        | exllama    | 5.99          | 353.67                 | 11.31              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 7.28          | 353.47                 | 11.32              |
+| gptq         | False     | 4    | 128        | marlin     | 32.26         | 384.47                 | 10.40              |
+| bitsandbytes | None      | None | None       | None       | 10.18         | 369.76                 | 10.82              |
 
 ### Batch size = 8
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |10         |8         |512          |1         |112.08       |655.58                |12.20             |
-|gptq        |False    |4   |128       |cuda-old  |10         |8         |512          |1         |6.09         |962.64                |8.31              |
-|gptq        |False    |4   |128       |exllama   |10         |8         |512          |1         |5.99         |687.99                |11.63             |
-|gptq        |False    |4   |128       |exllama_v2|10         |8         |512          |1         |7.28         |684.68                |11.68             |
-|gptq        |False    |4   |128       |marlin    |10         |8         |512          |1         |32.26        |760.58                |10.52             |
-|bitsandbytes|None     |None|None      |None      |10         |8         |512          |1         |10.18        |689.23                |11.61             |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 112.08        | 655.58                 | 12.20              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.09          | 962.64                 | 8.31               |
+| gptq         | False     | 4    | 128        | exllama    | 5.99          | 687.99                 | 11.63              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 7.28          | 684.68                 | 11.68              |
+| gptq         | False     | 4    | 128        | marlin     | 32.26         | 760.58                 | 10.52              |
+| bitsandbytes | None      | None | None       | None       | 10.18         | 689.23                 | 11.61              |
 
 ### Batch size = 16
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |10         |16        |512          |1         |112.08       |1368.83               |11.69             |
-|gptq        |False    |4   |128       |cuda-old  |10         |16        |512          |1         |6.09         |1679.88               |9.52              |
-|gptq        |False    |4   |128       |exllama   |10         |16        |512          |1         |5.99         |1337.64               |11.96             |
-|gptq        |False    |4   |128       |exllama_v2|10         |16        |512          |1         |7.28         |1336.79               |11.97             |
-|gptq        |False    |4   |128       |marlin    |10         |16        |512          |1         |32.26        |1515.79               |10.56             |
-|bitsandbytes|None     |None|None      |None      |10         |16        |512          |1         |10.18        |1427.68               |11.21             |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 112.08        | 1368.83                | 11.69              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.09          | 1679.88                | 9.52               |
+| gptq         | False     | 4    | 128        | exllama    | 5.99          | 1337.64                | 11.96              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 7.28          | 1336.79                | 11.97              |
+| gptq         | False     | 4    | 128        | marlin     | 32.26         | 1515.79                | 10.56              |
+| bitsandbytes | None      | None | None       | None       | 10.18         | 1427.68                | 11.21              |
 
 ## Decode benchmark
 
@@ -123,58 +122,58 @@ CUDA_VISIBLE_DEVICES=0 python benchmark_gptq.py --model meta-llama/Llama-2-13b-c
 
 ### Batch size = 1
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |5          |1         |1            |512       |6.64         |30.43                 |32.86             |
-|gptq        |False    |4   |128       |cuda-old  |5          |1         |1            |512       |6.03         |42.91                 |23.30             |
-|gptq        |False    |4   |128       |exllama   |5          |1         |1            |512       |6.65         |31.68                 |31.57             |
-|gptq        |False    |4   |128       |exllama_v2|5          |1         |1            |512       |5.86         |31.60                 |31.64             |
-|gptq        |False    |4   |128       |marlin    |5          |1         |1            |512       |31.75        |28.96                 |34.53             |
-|bitsandbytes|None     |None|None      |None      |5          |1         |1            |512       |9.80         |45.06                 |22.19             |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 6.64          | 30.43                  | 32.86              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.03          | 42.91                  | 23.30              |
+| gptq         | False     | 4    | 128        | exllama    | 6.65          | 31.68                  | 31.57              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 5.86          | 31.60                  | 31.64              |
+| gptq         | False     | 4    | 128        | marlin     | 31.75         | 28.96                  | 34.53              |
+| bitsandbytes | None      | None | None       | None       | 9.80          | 45.06                  | 22.19              |
 
 ### Batch size = 2
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |5          |2         |1            |512       |6.64         |30.11                 |66.42             |
-|gptq        |False    |4   |128       |cuda-old  |5          |2         |1            |512       |6.03         |42.68                 |46.86             |
-|gptq        |False    |4   |128       |exllama   |5          |2         |1            |512       |6.65         |37.00                 |54.05             |
-|gptq        |False    |4   |128       |exllama_v2|5          |2         |1            |512       |5.86         |31.74                 |63.02             |
-|gptq        |False    |4   |128       |marlin    |5          |2         |1            |512       |31.75        |29.19                 |68.53             |
-|bitsandbytes|None     |None|None      |None      |5          |2         |1            |512       |9.80         |68.00                 |29.41             |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 6.64          | 30.11                  | 66.42              |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.03          | 42.68                  | 46.86              |
+| gptq         | False     | 4    | 128        | exllama    | 6.65          | 37.00                  | 54.05              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 5.86          | 31.74                  | 63.02              |
+| gptq         | False     | 4    | 128        | marlin     | 31.75         | 29.19                  | 68.53              |
+| bitsandbytes | None      | None | None       | None       | 9.80          | 68.00                  | 29.41              |
 
 ### Batch size = 4
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |5          |4         |1            |512       |6.64         |29.76                 |134.41            |
-|gptq        |False    |4   |128       |cuda-old  |5          |4         |1            |512       |6.03         |51.43                 |77.78             |
-|gptq        |False    |4   |128       |exllama   |5          |4         |1            |512       |6.65         |55.15                 |72.53             |
-|gptq        |False    |4   |128       |exllama_v2|5          |4         |1            |512       |5.86         |31.58                 |126.68            |
-|gptq        |False    |4   |128       |marlin    |5          |4         |1            |512       |31.75        |29.08                 |137.56            |
-|bitsandbytes|None     |None|None      |None      |5          |4         |1            |512       |9.80         |70.25                 |56.94             |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 6.64          | 29.76                  | 134.41             |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.03          | 51.43                  | 77.78              |
+| gptq         | False     | 4    | 128        | exllama    | 6.65          | 55.15                  | 72.53              |
+| gptq         | False     | 4    | 128        | exllama_v2 | 5.86          | 31.58                  | 126.68             |
+| gptq         | False     | 4    | 128        | marlin     | 31.75         | 29.08                  | 137.56             |
+| bitsandbytes | None      | None | None       | None       | 9.80          | 70.25                  | 56.94              |
 
 ### Batch size = 8
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |5          |8         |1            |512       |6.64         |32.98                 |242.60            |
-|gptq        |False    |4   |128       |cuda-old  |5          |8         |1            |512       |6.03         |91.74                 |87.20             |
-|gptq        |False    |4   |128       |exllama   |5          |8         |1            |512       |6.86         |58.61                 |136.49            |
-|gptq        |False    |4   |128       |exllama_v2|5          |8         |1            |512       |5.86         |32.59                 |245.48            |
-|gptq        |False    |4   |128       |marlin    |5          |8         |1            |512       |31.75        |29.02                 |275.70            |
-|bitsandbytes|None     |None|None      |None      |5          |8         |1            |512       |9.80         |74.20                 |107.81            |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 6.64          | 32.98                  | 242.60             |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.03          | 91.74                  | 87.20              |
+| gptq         | False     | 4    | 128        | exllama    | 6.86          | 58.61                  | 136.49             |
+| gptq         | False     | 4    | 128        | exllama_v2 | 5.86          | 32.59                  | 245.48             |
+| gptq         | False     | 4    | 128        | marlin     | 31.75         | 29.02                  | 275.70             |
+| bitsandbytes | None      | None | None       | None       | 9.80          | 74.20                  | 107.81             |
 
 ### Batch size = 16
 
-|quantization|act_order|bits|group_size|kernel    |num_batches|batch_size|prompt_length|new_tokens|Load time (s)|Per-token latency (ms)|Throughput (tok/s)|
-|------------|---------|----|----------|----------|-----------|----------|-------------|----------|-------------|----------------------|------------------|
-|None        |None     |None|None      |None      |5          |16        |1            |512       |6.64         |40.24                 |397.61            |
-|gptq        |False    |4   |128       |cuda-old  |5          |16        |1            |512       |6.03         |171.90                |93.08             |
-|gptq        |False    |4   |128       |exllama   |5          |16        |1            |512       |6.86         |66.37                 |241.07            |
-|gptq        |False    |4   |128       |exllama_v2|5          |16        |1            |512       |5.86         |48.10                 |332.61            |
-|gptq        |False    |4   |128       |marlin    |5          |16        |1            |512       |31.75        |31.71                 |504.63            |
-|bitsandbytes|None     |None|None      |None      |5          |16        |1            |512       |9.80         |82.29                 |194.44            |
+| quantization | act_order | bits | group_size | kernel     | Load time (s) | Per-token latency (ms) | Throughput (tok/s) |
+|--------------|-----------|------|------------|------------|---------------|------------------------|--------------------|
+| None         | None      | None | None       | None       | 6.64          | 40.24                  | 397.61             |
+| gptq         | False     | 4    | 128        | cuda-old   | 6.03          | 171.90                 | 93.08              |
+| gptq         | False     | 4    | 128        | exllama    | 6.86          | 66.37                  | 241.07             |
+| gptq         | False     | 4    | 128        | exllama_v2 | 5.86          | 48.10                  | 332.61             |
+| gptq         | False     | 4    | 128        | marlin     | 31.75         | 31.71                  | 504.63             |
+| bitsandbytes | None      | None | None       | None       | 9.80          | 82.29                  | 194.44             |
 
 ## Perplexity benchmark results
 

--- a/tests/benchmark/benchmark_gptq.py
+++ b/tests/benchmark/benchmark_gptq.py
@@ -15,10 +15,18 @@ from transformers import (
     AutoTokenizer,
     BitsAndBytesConfig,
     GenerationConfig,
-    GPTQConfig,
 )
 
+from auto_gptq import AutoGPTQForCausalLM
+from auto_gptq.modeling._base import BaseGPTQForCausalLM
+
 from optimum.exporters import TasksManager
+
+from auto_gptq.nn_modules.qlinear.qlinear_cuda import QuantLinear as CudaQuantLinear
+from auto_gptq.nn_modules.qlinear.qlinear_cuda_old import QuantLinear as CudaOldQuantLinear
+from auto_gptq.nn_modules.qlinear.qlinear_exllama import QuantLinear as ExllamaQuantLinear
+from auto_gptq.nn_modules.qlinear.qlinear_exllamav2 import QuantLinear as ExllamaV2QuantLinear
+from auto_gptq.nn_modules.qlinear.qlinear_marlin import QuantLinear as MarlinQuantLinear
 
 
 def get_parser():
@@ -58,11 +66,19 @@ def get_parser():
         default=256,
         help="",
     )
-    parser.add_argument(
+
+    inference_phase_group = parser.add_argument_group("Inference phase")
+    inference_phase_group.add_argument(
         "--prefill",
         action="store_true",
         help="For decoder models, benchmark only the prefill step with `prompt_length`.",
     )
+    inference_phase_group.add_argument(
+        "--decode",
+        action="store_true",
+        help="For decoder models, benchmark only the decode step (simulated using a prompt length of 1 & KV cache).",
+    )
+
     parser.add_argument(
         "--gptq",
         action="store_true",
@@ -82,6 +98,11 @@ def get_parser():
         "--use-exllama",
         action="store_true",
         help="Use Exllama kernel, to rather use the AutoGPTQ CUDA (act-order case) or CUDA-old (no act-order case) kernels.",
+    )
+    parser.add_argument(
+        "--use-marlin",
+        action="store_true",
+        help="Use Marlin kernel.",
     )
     parser.add_argument(
         "--exllama-version",
@@ -125,7 +146,10 @@ def timing_cuda(
         start_event.record()
 
         if is_decoder:
-            _ = model.generate(input_ids, attention_mask=masks, generation_config=generation_config)
+            if isinstance(model, BaseGPTQForCausalLM):
+                _ = model.model.generate(input_ids, attention_mask=masks, generation_config=generation_config)
+            else:
+                _ = model.generate(input_ids, attention_mask=masks, generation_config=generation_config)
         else:
             _ = model(input_ids, masks)
         end_event.record()
@@ -158,7 +182,11 @@ def warmup(
             eos_token_id=None,  # This is required for min_new_tokens to actually have an effect.
         )
         model.generation_config.eos_token_id = None  # greedy_search falls back on this eos_token_id that we need to set to None as well for min_new_tokens to have an effect.
-        res = model.generate(input_ids, attention_mask=masks, generation_config=gen_config)
+        if isinstance(model, BaseGPTQForCausalLM):
+            res = model.model.generate(input_ids, attention_mask=masks, generation_config=gen_config)
+        else:
+            res = model.generate(input_ids, attention_mask=masks, generation_config=gen_config)
+
         assert res.shape[1] == new_tokens + input_ids.shape[1]
         del res
     else:
@@ -222,7 +250,11 @@ def benchmark_memory(
         )
 
         if is_decoder:
-            _ = model.generate(input_ids, attention_mask=masks, generation_config=gen_config)
+            if isinstance(model, BaseGPTQForCausalLM):
+                _ = model.model.generate(input_ids, attention_mask=masks, generation_config=gen_config)
+            else:
+                _ = model.generate(input_ids, attention_mask=masks, generation_config=gen_config)
+
         else:
             _ = model(input_ids, masks)
 
@@ -270,6 +302,10 @@ else:
 if args.prefill:
     print("Running the prefill benchmark: generating only one new token.")
     new_tokens = [1]
+else:
+    assert args.decode
+    print("Running the decode benchmark: setting the prompt length to 1.")
+    prompt_lengths = [1]
 
 if not torch.cuda.is_available():
     raise ValueError("A cuda device is necessary to benchmark GPTQ.")
@@ -305,16 +341,25 @@ else:
 
 load_start = time.time_ns()
 if args.gptq:
-    quantization_config = GPTQConfig(
-        bits=4, use_exllama=args.use_exllama, exllama_config={"version": args.exllama_version}
-    )
-    model = autoclass.from_pretrained(
+    use_exllama = args.use_exllama and args.exllama_version == 1
+    use_exllama_v2 = args.use_exllama and args.exllama_version == 2
+    use_marlin = args.use_marlin
+
+    print("use_exllama:", use_exllama)
+    print("use_exllama_v2:", use_exllama_v2)
+    print("use_marlin:", use_marlin)
+
+    model = AutoGPTQForCausalLM.from_quantized(
         args.model,
-        revision=args.revision,
-        quantization_config=quantization_config,
         torch_dtype=torch.float16,
-        device_map="auto",
+        device="cuda:0",
+        disable_exllama=not use_exllama,
+        disable_exllamav2=not use_exllama_v2,
+        use_marlin=use_marlin,
+        inject_fused_attention=False,
+        inject_fused_mlp=False
     )
+
 elif args.bitsandbytes:
     quantization_config = BitsAndBytesConfig(
         load_in_4bit=True, bnb_4bit_quant_type="fp4", bnb_4bit_compute_dtype=torch.float16
@@ -333,23 +378,34 @@ bits = None
 group_size = None
 kernel = None
 
+def raise_if_module_not_found(model: torch.nn.Module, layer_class, layer_name):
+        for _, module in model.named_modules():
+            if isinstance(module, layer_class):
+                break
+        else:
+            raise ValueError(f"{layer_name} layer not found")
+
+
 if args.gptq:
-    quantization_config_dict = model.config.quantization_config.to_dict()
-    act_order = quantization_config_dict["desc_act"]
-    bits = quantization_config_dict["bits"]
-    group_size = quantization_config_dict["group_size"]
-    use_exllama = quantization_config_dict["use_exllama"]
-    exllama_version = quantization_config_dict["exllama_config"]["version"]
+    act_order = model.quantize_config.desc_act
+    group_size = model.quantize_config.group_size
+    bits = model.quantize_config.bits
 
     if use_exllama:
-        if exllama_version == 2:
-            kernel = "exllamav2"
-        else:
-            kernel = "exllama"
+        kernel = "exllama"
+        raise_if_module_not_found(model, ExllamaQuantLinear, "exllama")
+    elif use_exllama_v2:
+        kernel = "exllama_v2"
+        raise_if_module_not_found(model, ExllamaV2QuantLinear, "exllamav2")
+    elif use_marlin:
+        kernel = "marlin"
+        raise_if_module_not_found(model, MarlinQuantLinear, "marlin")
     elif act_order:
-        kernel = "autotogptq-cuda"
+        kernel = "cuda"
+        raise_if_module_not_found(model, CudaQuantLinear, "cuda")
     else:
-        kernel = "autogptq-cuda-old"
+        kernel = "cuda-old"
+        raise_if_module_not_found(model, CudaOldQuantLinear, "cuda")
 
 load_time = (load_end - load_start) * 1e-9
 print(f"Model load time: {load_time:.1f} s")
@@ -421,16 +477,17 @@ if args.generate:
                 masks = torch.ones(batch_size, prompt_length, dtype=torch.int32).to(device)
 
                 with torch.no_grad():
-                    max_mem = benchmark_memory(
-                        model,
-                        input_ids,
-                        masks,
-                        args.num_batches,
-                        is_decoder,
-                        new_token,
-                        tokenizer.pad_token_id,
-                        memory_tracker=memory_tracker,
-                    )
+                    # max_mem = benchmark_memory(
+                    #     model,
+                    #     input_ids,
+                    #     masks,
+                    #     args.num_batches,
+                    #     is_decoder,
+                    #     new_token,
+                    #     tokenizer.pad_token_id,
+                    #     memory_tracker=memory_tracker,
+                    # )
+                    max_mem = 0
 
                     mean_latency = benchmark_latency(
                         model,


### PR DESCRIPTION
As per title. Reran the whole benchmark with more recent torch / AutoGPTQ / transformers versions.