### PR TITLE
Fix main doc build

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -91,7 +91,6 @@ jobs:
           sudo rm -rf /etc/skel/.dotnet > /dev/null 2>&1
           sudo rm -rf /usr/local/.ghcup > /dev/null 2>&1
           sudo rm -rf /usr/local/aws-cli > /dev/null 2>&1
-          sudo rm -rf /usr/local/lib/node_modules > /dev/null 2>&1
           sudo rm -rf /usr/lib/heroku > /dev/null 2>&1
           sudo rm -rf /usr/local/share/chromium > /dev/null 2>&1
           df -h


### PR DESCRIPTION
As per title. Building Furiosa doc somehow uses npm.

Merging as non-critical.