### PR TITLE
Pin pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,10 @@ REQUIRED_PKGS = [
     "datasets",
 ]
 
+# TODO: unpin pytest once https://github.com/huggingface/transformers/pull/29154 is merged & released
 TESTS_REQUIRE = [
     "accelerate",
-    "pytest",
+    "pytest<=7.4.4",
     "requests",
     "parameterized",
     "pytest-xdist",


### PR DESCRIPTION
As per title, avoid the CI to fail due to a deprecated function that was removed in in pytest===8.0

see https://github.com/huggingface/transformers/pull/29154