### PR TITLE
[RFC][WIP] Introduce PT2 dynamo onnx exporter

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -77,6 +77,7 @@ def main_export(
     legacy: bool = False,
     no_dynamic_axes: bool = False,
     do_constant_folding: bool = True,
+    dynamo: bool = False,
     **kwargs_shapes,
 ):
     """
@@ -163,6 +164,8 @@ def main_export(
             If True, disables the use of dynamic axes during ONNX export.
         do_constant_folding (bool, defaults to `True`):
             PyTorch-specific argument. If `True`, the PyTorch ONNX export will fold constants into adjacent nodes, if possible.
+        dynamo (bool, default to `False):
+            PyTorch-specific argument. If `True`, export with the new Dynamo ONNX Exporter introduced in PyTorch 2+.
         **kwargs_shapes (`Dict`):
             Shapes to use during inference. This argument allows to override the default shapes used during the ONNX export.
 
@@ -369,6 +372,7 @@ def main_export(
         task=task,
         use_subprocess=use_subprocess,
         do_constant_folding=do_constant_folding,
+        dynamo=dynamo,
         **kwargs_shapes,
     )
 
@@ -405,6 +409,7 @@ def main():
         library_name=args.library_name,
         legacy=args.legacy,
         do_constant_folding=not args.no_constant_folding,
+        dynamo=args.dynamo,
         **input_shapes,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ EXTRAS_REQUIRE = {
         "protobuf>=3.20.1",
         "accelerate",  # ORTTrainer requires it.
     ],
-    "exporters": ["onnx", "onnxruntime", "timm"],
-    "exporters-gpu": ["onnx", "onnxruntime-gpu", "timm"],
+    "exporters": ["onnx", "onnxruntime", "onnxscript", "timm"],
+    "exporters-gpu": ["onnx", "onnxruntime-gpu", "onnxscript", "timm"],
     "exporters-tf": [
         "tensorflow>=2.4,<=2.12.1",
         "tf2onnx",


### PR DESCRIPTION
Hello from PyTorch ONNX exporter team. Since the early announcement of PT2 we have been actively developing the next generation of PyTorch ONNX exporter based on Dynamo, the new Python level JIT compiler.

With the upcoming PyTorch 2.3 release ([targeting 4/24/24](https://dev-discuss.pytorch.org/t/pytorch-release-2-3-0-call-for-features/1872)), we hope to introduce the new exporter as an experimental feature for early beta adoption in Optimum.

This is an initial PR to introduce the code path of calling the new exporter, which is now hidden behind a flag that is by default turned off. The goal is to kick off the discussion and start gathering feedback from the community.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

