### PR TITLE
Make optimized ONNX external data files downloadable from Hugging Face Hub

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -873,21 +873,23 @@ class ORTModel(OptimizedModel):
                 force_download=force_download,
                 local_files_only=local_files_only,
             )
-            # try download external data
-            try:
-                hf_hub_download(
-                    repo_id=model_path.as_posix(),
-                    subfolder=subfolder,
-                    filename=file_name + "_data",
-                    use_auth_token=use_auth_token,
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    local_files_only=local_files_only,
-                )
-            except EntryNotFoundError:
-                # model doesn't use external data
-                pass
+            # The optimizer could have saved external data with the `.data` suffix.
+            for suffix in ["_data", ".data"]:
+                # try download external data
+                try:
+                    hf_hub_download(
+                        repo_id=model_path.as_posix(),
+                        subfolder=subfolder,
+                        filename=file_name + suffix,
+                        use_auth_token=use_auth_token,
+                        revision=revision,
+                        cache_dir=cache_dir,
+                        force_download=force_download,
+                        local_files_only=local_files_only,
+                    )
+                except EntryNotFoundError:
+                    # model doesn't use external data
+                    pass
 
             model_cache_path = Path(model_cache_path)
             preprocessors = maybe_load_preprocessors(model_path.as_posix(), subfolder=subfolder)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -878,7 +878,7 @@ class ORTModel(OptimizedModel):
                 hf_hub_download(
                     repo_id=model_path.as_posix(),
                     subfolder=subfolder,
-                    filename=file_name + "_data",
+                    filename=file_name + ".data",
                     use_auth_token=use_auth_token,
                     revision=revision,
                     cache_dir=cache_dir,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -878,7 +878,7 @@ class ORTModel(OptimizedModel):
                 hf_hub_download(
                     repo_id=model_path.as_posix(),
                     subfolder=subfolder,
-                    filename=file_name + ".data",
+                    filename=file_name + "_data",
                     use_auth_token=use_auth_token,
                     revision=revision,
                     cache_dir=cache_dir,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -937,21 +937,23 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
                     force_download=force_download,
                     local_files_only=local_files_only,
                 )
-                # try download external data
-                try:
-                    hf_hub_download(
-                        repo_id=model_id,
-                        subfolder=subfolder,
-                        filename=filename + "_data",
-                        use_auth_token=use_auth_token,
-                        revision=revision,
-                        cache_dir=cache_dir,
-                        force_download=force_download,
-                        local_files_only=local_files_only,
-                    )
-                except EntryNotFoundError:
-                    # model doesn't use external data
-                    pass
+                # The optimizer could have saved external data with the `.data` suffix.
+                for suffix in ["_data", ".data"]:
+                    # try download external data
+                    try:
+                        hf_hub_download(
+                            repo_id=model_id,
+                            subfolder=subfolder,
+                            filename=filename + suffix,
+                            use_auth_token=use_auth_token,
+                            revision=revision,
+                            cache_dir=cache_dir,
+                            force_download=force_download,
+                            local_files_only=local_files_only,
+                        )
+                    except EntryNotFoundError:
+                        # model doesn't use external data
+                        pass
 
                 paths[attr_name] = Path(model_cache_path).name
             new_model_save_dir = Path(model_cache_path).parent


### PR DESCRIPTION
# What does this PR do?

This PR adds `.data` to the external data file suffixes so that an optimized model can be downloaded from Hugging Face as the optimizer saves models with `.data` instead of `_data`. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

