### PR TITLE
Extend sentence-transformers ONNX test

### DIFF
--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -332,7 +332,10 @@ PYTORCH_TIMM_MODEL = {
 
 PYTORCH_SENTENCE_TRANSFORMERS_MODEL = {
     "clip": "sentence-transformers/clip-ViT-B-32",
-    "transformer": "sentence-transformers/all-MiniLM-L6-v2",
+    "transformer": {
+        "sentence-transformers/all-MiniLM-L6-v2": ["feature-extraction", "sentence-similarity"],
+        "fxmarty/tiny-dummy-mistral-sentence-transformer": ["feature-extraction", "sentence-similarity"],
+    },
 }
 
 


### PR DESCRIPTION
Test that would have catched https://github.com/huggingface/optimum/issues/1731 & https://github.com/UKPLab/sentence-transformers/pull/2510

This should be merged only by sentence_transformers 2.5.0 (or 2.4.1) release.