### PR TITLE
Update supported torch version for bettertransformer API

### DIFF
--- a/docs/source/bettertransformer/tutorials/convert.mdx
+++ b/docs/source/bettertransformer/tutorials/convert.mdx
@@ -19,7 +19,7 @@ You can easily use the `BetterTransformer` integration with 🤗 Optimum, first 
 pip install transformers accelerate optimum
 ```
 
-Also, make sure to install the latest version of PyTorch by following the guidelines on the [PyTorch official website](https://pytorch.org/get-started/locally/). Note that `BetterTransformer` API is only compatible with `torch>=1.13`, so make sure to have this version installed on your environement before starting.
+Also, make sure to install the latest version of PyTorch by following the guidelines on the [PyTorch official website](https://pytorch.org/get-started/locally/). Note that `BetterTransformer` API is only compatible with `torch>=2.0, so make sure to have this version installed on your environement before starting.
 If you want to benefit from the `scaled_dot_product_attention` function (for decoder-based models), make sure to use at least `torch>=2.0`.
 
 ## Step 1: Load your model


### PR DESCRIPTION
# What does this PR do?
As far as I can tell, [this line](https://github.com/huggingface/optimum/blob/v1.11.0-release/optimum/bettertransformer/transformation.py#L234C1-L237C14) of code is always run in `BetterTransformer.transform()` which effectively limits supported versions to just `>=2.0.0`. This PR just updates the documentation to match.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

