### PR TITLE
Fix maximum seqlen for gptq quantization

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -354,7 +354,8 @@ class GPTQQuantizer(object):
             self.use_cuda_fp16 = model.dtype == torch.float16
 
         if self.model_seqlen is None:
-            self.model_seqlen = get_seqlen(model)
+            # We allow a max value of 4028 to avoid passing data with huge length to the model during the calibration step
+            self.model_seqlen = min(4028, get_seqlen(model))
 
         device = get_device(model)
 


### PR DESCRIPTION
# What does this PR do 
This PR set a maximum seqlen that we use to create our calibration dataset. For models like mistral, we have a seqlen of 32768 which results in issues when creating the calibration dataset. The dataset don't need to have data with a big seqlen too. 
Fixes https://github.com/huggingface/transformers/issues/29494