### PR TITLE
Initialize AcceleratorConfig in optimum TrainingArgs.

### DIFF
--- a/optimum/onnxruntime/training_args.py
+++ b/optimum/onnxruntime/training_args.py
@@ -51,6 +51,7 @@ if is_torch_available():
 if is_accelerate_available():
     from transformers.trainer_pt_utils import AcceleratorConfig
 
+
 class ORTOptimizerNames(ExplicitEnum):
     """
     Stores the acceptable string identifiers for optimizers in `onnxruntime.training.optim`.


### PR DESCRIPTION
# What does this PR do?
Transformers Introduced AccelerateConfigure dataclass https://github.com/huggingface/transformers/pull/28664
So we need to initialize it in Optimum Training Args.

Check this issue for reference: https://github.com/huggingface/optimum/issues/1749