### PR TITLE
Add support for Ernie model

### DIFF
--- a/docs/source/exporters/onnx/overview.mdx
+++ b/docs/source/exporters/onnx/overview.mdx
@@ -42,6 +42,7 @@ Supported architectures from [🤗 Transformers](https://huggingface.co/docs/tra
 - Donut-Swin
 - Electra
 - Encoder Decoder
+- Ernie
 - ESM
 - Falcon
 - Flaubert

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -137,6 +137,10 @@ class SplinterOnnxConfig(BertOnnxConfig):
     pass
 
 
+class ErnieOnnxConfig(BertOnnxConfig):
+    pass
+
+
 class DistilBertOnnxConfig(BertOnnxConfig):
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -576,6 +576,15 @@ class TasksManager:
             "text2text-generation-with-past",
             onnx="EncoderDecoderOnnxConfig",
         ),
+        "ernie": supported_tasks_mapping(
+            "feature-extraction",
+            "fill-mask",
+            "text-classification",
+            "multiple-choice",
+            "token-classification",
+            "question-answering",
+            onnx="ErnieOnnxConfig",
+        ),
         "esm": supported_tasks_mapping(
             "feature-extraction",
             "fill-mask",

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -229,6 +229,7 @@ class NormalizedConfigManager:
         "donut-swin": NormalizedVisionConfig,
         "electra": NormalizedTextConfig,
         "encoder-decoder": NormalizedEncoderDecoderConfig,
+        "ernie": NormalizedTextConfig,
         "gemma": NormalizedTextConfigWithGQA,
         "gpt2": GPT2LikeNormalizedTextConfig,
         "gpt-bigcode": GPTBigCodeNormalizedTextConfig,

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1983,6 +1983,7 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
         "camembert",
         "distilbert",
         "electra",
+        "ernie",
         "mpnet",
         "roberta",
         "xlm_roberta",

--- a/tests/onnxruntime/utils_onnxruntime_tests.py
+++ b/tests/onnxruntime/utils_onnxruntime_tests.py
@@ -89,7 +89,7 @@ MODEL_NAMES = {
     "detr": "hf-internal-testing/tiny-random-detr",
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
-    "ernie": "hf-internal-testing/tiny-random-ErnieMModel",
+    "ernie": "hf-internal-testing/tiny-random-ErnieModel",
     "encoder-decoder": {
         "hf-internal-testing/tiny-random-EncoderDecoderModel-bert-bert": [
             "text2text-generation",

--- a/tests/onnxruntime/utils_onnxruntime_tests.py
+++ b/tests/onnxruntime/utils_onnxruntime_tests.py
@@ -89,6 +89,7 @@ MODEL_NAMES = {
     "detr": "hf-internal-testing/tiny-random-detr",
     "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
     "electra": "hf-internal-testing/tiny-random-ElectraModel",
+    "ernie": "hf-internal-testing/tiny-random-ErnieMModel",
     "encoder-decoder": {
         "hf-internal-testing/tiny-random-EncoderDecoderModel-bert-bert": [
             "text2text-generation",


### PR DESCRIPTION
Solve #555 
This submission enables optimum to support the Ernie family model and support onnxruntime export of related models. The onnx code related to this model has been verified.

https://github.com/huggingface/transformers/tree/main/src/transformers/models/ernie

Before submitting
 - [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
 - [x] Did you make sure to update the documentation with your changes?
 - [x] Did you write any new necessary tests?