### PR TITLE
Fix compatibility with transformers v 4.39.0

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -252,6 +252,7 @@ class GemmaOnnxConfig(LlamaOnnxConfig):
 
 
 class PhiOnnxConfig(TextDecoderWithPositionIdsOnnxConfig):
+    DEFAULT_ONNX_OPSET = 14  # Phi now uses F.scaled_dot_product_attention by default for torch>=2.1.1.
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
 
 

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -676,10 +676,6 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
             for layer_past in past
         )
 
-    def can_generate(self):
-        """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
-        return True
-
 
 class ORTGPTBigCodeForCausalLM(ORTModelForCausalLM):
     # Adapted from transformers.models.gpt_bigcode.modeling_gpt_bigcode.GPTBigCodeForCausalLM.prepare_inputs_for_generation

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -43,6 +43,7 @@ from transformers.file_utils import add_end_docstrings, add_start_docstrings, ad
 from transformers.modeling_outputs import (
     BaseModelOutput,
     CausalLMOutput,
+    GenerationMixin,
     ImageClassifierOutput,
     MaskedLMOutput,
     ModelOutput,
@@ -52,7 +53,6 @@ from transformers.modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
     XVectorOutput,
-    GenerationMixin,
 )
 
 import onnxruntime as ort

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -52,6 +52,7 @@ from transformers.modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
     XVectorOutput,
+    GenerationMixin,
 )
 
 import onnxruntime as ort
@@ -893,6 +894,12 @@ class ORTModel(OptimizedModel):
             preprocessors = maybe_load_preprocessors(model_path.as_posix(), subfolder=subfolder)
 
         return model_cache_path, preprocessors
+
+    def can_generate(self) -> bool:
+        """
+        Returns whether this model can generate sequences with `.generate()`.
+        """
+        return isinstance(self, GenerationMixin)
 
 
 FEATURE_EXTRACTION_EXAMPLE = r"""

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -38,12 +38,12 @@ from transformers import (
     AutoModelForSemanticSegmentation,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
+    GenerationMixin,
 )
 from transformers.file_utils import add_end_docstrings, add_start_docstrings, add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import (
     BaseModelOutput,
     CausalLMOutput,
-    GenerationMixin,
     ImageClassifierOutput,
     MaskedLMOutput,
     ModelOutput,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -1111,12 +1111,6 @@ class ORTModelForConditionalGeneration(ORTModel, ABC):
 
         return self
 
-    def can_generate(self):
-        logger.warning(
-            "ORTModelForConditionalGeneration is an abstract class and is not meant to be used for generation. Please use ORTModelForSeq2SeqLM or ORTModelForSpeechSeq2Seq."
-        )
-        return False
-
 
 @add_end_docstrings(ONNX_MODEL_END_DOCSTRING)
 class ORTModelForSeq2SeqLM(ORTModelForConditionalGeneration, GenerationMixin):
@@ -1262,10 +1256,6 @@ class ORTModelForSeq2SeqLM(ORTModelForConditionalGeneration, GenerationMixin):
             )
         return reordered_past
 
-    def can_generate(self):
-        """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
-        return True
-
 
 @add_end_docstrings(ONNX_MODEL_END_DOCSTRING)
 class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin):
@@ -1396,10 +1386,6 @@ class ORTModelForSpeechSeq2Seq(ORTModelForConditionalGeneration, GenerationMixin
                 tuple(past_state.index_select(0, beam_idx) for past_state in layer_past[:2]) + layer_past[2:],
             )
         return reordered_past
-
-    def can_generate(self):
-        """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
-        return True
 
     @classmethod
     def _from_pretrained(
@@ -1986,10 +1972,6 @@ class ORTModelForVision2Seq(ORTModelForConditionalGeneration, GenerationMixin):
             )
         return reordered_past
 
-    def can_generate(self):
-        """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
-        return True
-
 
 @add_end_docstrings(ONNX_MODEL_END_DOCSTRING)
 class ORTModelForPix2Struct(ORTModelForConditionalGeneration, GenerationMixin):
@@ -2105,7 +2087,3 @@ class ORTModelForPix2Struct(ORTModelForConditionalGeneration, GenerationMixin):
     @staticmethod
     def _reorder_cache(past, beam_idx) -> Tuple[Tuple[torch.FloatTensor]]:
         ORTModelForSeq2SeqLM._reorder_cache(past, beam_idx)
-
-    def can_generate(self):
-        """Returns True to validate the check that the model using `GenerationMixin.generate()` can indeed generate."""
-        return True

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.26.0",
+    "transformers[sentencepiece]>=4.26.0,<4.40.0",
     "torch>=1.11",
     "packaging",
     "numpy",


### PR DESCRIPTION
Fix compatibility of ORTModels with transformers pipelines (broken since https://github.com/huggingface/transformers/commit/53d891247bd45f316d3d710c64b54964bea14a64)

Failing tests : https://github.com/huggingface/optimum/actions/runs/8377803444

Also update phi default opset (needed since https://github.com/huggingface/transformers/pull/29108)