### PR TITLE
Fix training args transformers compatibility

### DIFF
--- a/optimum/onnxruntime/training_args.py
+++ b/optimum/onnxruntime/training_args.py
@@ -43,12 +43,12 @@ from transformers.utils import (
     logging,
 )
 from transformers.utils.generic import strtobool
-
+from ..utils.import_utils import check_if_transformers_greater
 
 if is_torch_available():
     import torch
 
-if is_accelerate_available():
+if is_accelerate_available() and check_if_transformers_greater("4.38.0"):
     from transformers.trainer_pt_utils import AcceleratorConfig
 
 
@@ -449,7 +449,7 @@ class ORTTrainingArguments(TrainingArguments):
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = self.fsdp_config.get("sync_module_states", "true")
             os.environ[f"{prefix}USE_ORIG_PARAMS"] = self.fsdp_config.get("use_orig_params", "false")
 
-        if is_accelerate_available():
+        if is_accelerate_available() and check_if_transformers_greater("4.38.0"):
             if not isinstance(self.accelerator_config, (AcceleratorConfig)):
                 if self.accelerator_config is None:
                     self.accelerator_config = AcceleratorConfig()

--- a/optimum/onnxruntime/training_args.py
+++ b/optimum/onnxruntime/training_args.py
@@ -43,7 +43,9 @@ from transformers.utils import (
     logging,
 )
 from transformers.utils.generic import strtobool
+
 from ..utils.import_utils import check_if_transformers_greater
+
 
 if is_torch_available():
     import torch


### PR DESCRIPTION
Following https://github.com/huggingface/optimum/pull/1750 which breaks compatibility for transformers < `v4.38.0`