### PR TITLE
Fix IR version for merged ONNX decoders

### DIFF
--- a/optimum/onnx/graph_transformations.py
+++ b/optimum/onnx/graph_transformations.py
@@ -313,7 +313,10 @@ def merge_decoders(
             opset_imports.append(opset_import)
             opset_domains.add(opset_import.domain)
 
-    merged_model = onnx.helper.make_model(merged_graph, producer_name=producer_name, opset_imports=opset_imports)
+    # TODO: update IR version in the future.
+    merged_model = onnx.helper.make_model_gen_version(
+        merged_graph, producer_name=producer_name, opset_imports=opset_imports, ir_version=9
+    )
 
     check_and_save_model(merged_model, save_path=save_path)
 


### PR DESCRIPTION
Following onnx 1.16 release (https://github.com/onnx/onnx/releases/tag/v1.16.0) with the new IR version 10 not yet handled by ORT.

Making the CI green