### PR TITLE
Change `class_name` to `_class_name` to prevent `KeyError`

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1560,7 +1560,7 @@ class TasksManager:
             library_name = TasksManager.infer_library_from_model(model_name_or_path, subfolder, revision)
 
             if library_name == "diffusers":
-                class_name = model_info.config["diffusers"]["class_name"]
+                class_name = model_info.config["diffusers"]["_class_name"]
                 inferred_task_name = "stable-diffusion-xl" if "StableDiffusionXL" in class_name else "stable-diffusion"
             elif library_name == "timm":
                 inferred_task_name = "image-classification"


### PR DESCRIPTION
## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Description of issue
I tried to download several popular diffusion models with `optimum`, but they failed with a `KeyError` in `exporters/tasks.py`.

Here's an example using `runwayml/stable-diffusion-v1-5`:
```
(hf-optimum) % optimum-cli export onnx --framework pt  -m runwayml/stable-diffusion-v1-5 stable-diffusion-v1.5
Traceback (most recent call last):
  File " ... /optimum/exporters/onnx/__main__.py", line 224, in main_export
    task = TasksManager.infer_task_from_model(model_name_or_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "... /optimum/exporters/tasks.py", line 1655, in infer_task_from_model
    task = cls._infer_task_from_model_name_or_path(model, subfolder=subfolder, revision=revision)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File " ... /optimum/exporters/tasks.py", line 1592, in _infer_task_from_model_name_or_path
    class_name = model_info.config["diffusers"]["class_name"]
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
```

The correct key is `_class_name`, not `class_name`:
```
(Pdb) data["config"]
{'diffusers': {'_class_name': 'StableDiffusionPipeline'}}
```

I couldn't find a diffusion model on HF that used `class_name` in their `config.json` (although there were lots using `_class_name`), so I think `class_name` is just a typo.

After the fix, I was able to successfully download `runwayml/stable-diffusion-v1-5` using `optimum-cli`