### PR TITLE
adds debug options to dump onnx graphs

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -459,7 +459,14 @@ class ORTTrainer(Trainer):
 
         # Wrap the model with `ORTModule`
         logger.info("Wrap ORTModule for ONNX Runtime training.")
-        model = ORTModule(self.model)
+        if self.args.save_onnx:
+            from torch_ort import DebugOptions
+
+            model = ORTModule(
+                self.model, DebugOptions(save_onnx=self.args.save_onnx, onnx_prefix=self.args.onnx_prefix)
+            )
+        else:
+            model = ORTModule(self.model)
         self.model_wrapped = model
         self.model = model
 


### PR DESCRIPTION
This PR adds functionality to dump onnx graphs via input arguments to ORTTrainer. This will assist in easier debugging processes for developers running into ONNX Runtime errors. [[docs](https://github.com/microsoft/onnxruntime/wiki/Performance-Investigation)]

Test Machine: 8xV100, cu118, python3.10
Test Environment: 
```docker 
FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch222
RUN pip install accelerate evaluate transformers scikit-learn
RUN git clone https://github.com/prathikr/optimum.git && cd optimum && git checkout prathikrao/add-debug-options && python setup.py install
```
Test Command: `torchrun --nproc_per_node 8 optimum/examples/onnxruntime/training/language-modelling/run_clm.py --model_name_or_path mistralai/Mistral-7B-v0.1 --dataset_name wikitext --dataset_config_name wikitext-2-raw-v1 --per_device_train_batch_size 4 --per_device_eval_batch_size 4 --do_train --max_steps 10 --fp16 --output_dir output_dir --overwrite_output_dir --seed 30 --dataloader_num_workers 1 --block_size 512 --deepspeed zero2.json --save_onnx True --onnx_prefix test --log_level VERBOSE`

[zero2.json](https://github.com/huggingface/optimum/files/14829611/zero2.json)
