### PR TITLE
Fix infer task fo stable diffusion

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1560,7 +1560,9 @@ class TasksManager:
             library_name = TasksManager.infer_library_from_model(model_name_or_path, subfolder, revision)
 
             if library_name == "diffusers":
-                class_name = model_info.config["diffusers"]["class_name"]
+                class_name = model_info.config["diffusers"].get("class_name", None) or model_info.config[
+                    "diffusers"
+                ].get("_class_name", None)
                 inferred_task_name = "stable-diffusion-xl" if "StableDiffusionXL" in class_name else "stable-diffusion"
             elif library_name == "timm":
                 inferred_task_name = "image-classification"


### PR DESCRIPTION
# What does this PR do?

The current task inference is not working for stable diffusion checkpoints, eg. [`runwayml/stable-diffusion-v1-5`](https://huggingface.co/runwayml/stable-diffusion-v1-5/blob/1d0c4ebf6ff58a5caecab40fa1406526bca4b5b9/model_index.json#L2)

p.s. why did we use `class_name` I did not see any checkpoint using it instead of `_class_name`, if there is not we should remove it (keep it for now).

```python
from optimum.exporters import TasksManager

task = TasksManager.infer_task_from_model("runwayml/stable-diffusion-v1-5")

# KeyError: 'class_name'
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

