### PR TITLE
Remove unnecessary constants for > 2GB ONNX models

### DIFF
--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -29,7 +29,7 @@ import onnx
 from transformers.modeling_utils import get_parameter_dtype
 from transformers.utils import is_tf_available, is_torch_available
 
-from ...onnx.utils import _get_onnx_external_data_tensors, check_model_uses_external_data
+from ...onnx.utils import _get_onnx_external_constants, _get_onnx_external_data_tensors, check_model_uses_external_data
 from ...utils import (
     DEFAULT_DUMMY_SHAPES,
     ONNX_WEIGHTS_NAME,
@@ -583,6 +583,7 @@ def export_pytorch(
                 dynamic_axes=dynamix_axes,
                 do_constant_folding=do_constant_folding,
                 opset_version=opset,
+                keep_initializers_as_inputs=True,
             )
 
         # check if external data was exported
@@ -592,6 +593,7 @@ def export_pytorch(
 
         if model_uses_external_data or FORCE_ONNX_EXTERNAL_DATA:
             tensors_paths = _get_onnx_external_data_tensors(onnx_model)
+            constant_paths = _get_onnx_external_constants(onnx_model)
             logger.info("Saving external data to one file...")
 
             # try free model memory
@@ -617,6 +619,10 @@ def export_pytorch(
             # delete previous external data
             for tensor in tensors_paths:
                 os.remove(output.parent / tensor)
+
+            for tensor in constant_paths:
+                if os.path.isfile(output.parent / tensor):
+                    os.remove(output.parent / tensor)
 
     return input_names, output_names
 

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -583,7 +583,6 @@ def export_pytorch(
                 dynamic_axes=dynamix_axes,
                 do_constant_folding=do_constant_folding,
                 opset_version=opset,
-                keep_initializers_as_inputs=True,
             )
 
         # check if external data was exported

--- a/optimum/onnx/utils.py
+++ b/optimum/onnx/utils.py
@@ -19,6 +19,19 @@ import onnx
 from onnx.external_data_helper import ExternalDataInfo, _get_initializer_tensors
 
 
+def _get_onnx_external_constants(model: onnx.ModelProto) -> List[str]:
+    external_constants = []
+
+    for node in model.graph.node:
+        if node.op_type == "Constant":
+            for attribute in node.attribute:
+                external_datas = attribute.t.external_data
+                for external_data in external_datas:
+                    external_constants.append(external_data.value)
+
+    return external_constants
+
+
 def _get_onnx_external_data_tensors(model: onnx.ModelProto) -> List[str]:
     """
     Gets the paths of the external data tensors in the model.


### PR DESCRIPTION
e.g.
```
(hf-inf) fxmarty@huggingface:~/qwen_onnx$ ls
added_tokens.json       merges.txt                                                   model.onnx               tokenizer_config.json
config.json             _model_layers.0_self_attn_rotary_emb_Constant_5_attr__value  model.onnx_data          tokenizer.json
generation_config.json  _model_layers.0_self_attn_rotary_emb_Constant_attr__value    special_tokens_map.json  vocab.json
```

`_model_layers.0_self_attn_rotary_emb_Constant_5_attr__value` and `_model_layers.0_self_attn_rotary_emb_Constant_attr__value` are actually in `model.onnx_data` already.