### PR TITLE
Add onnx export function for pix2struct model

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -132,6 +132,7 @@ class ORTConfigManager:
         "vit": "vit",
         "whisper": "bart",
         "xlm-roberta": "bert",
+        "pix2struct": "vit",
     }
 
     @classmethod


### PR DESCRIPTION
# What does this PR do?

This PR adds an export option to pix2struct model (document vision-language model) by optimizing its ViT encoder

## Before submitting

I have tested the export locally and have seen the model outputs the same captions as the original model (exported https://huggingface.co/google/pix2struct-screen2words-base and tested on https://github.com/google-research-datasets/screen2words dataset)
If there is more testing that I need to do or document the change somewhere please let me know

## Who can review?

@fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
