### PR TITLE
Apply deprecated `evaluation_strategy`

### DIFF
--- a/examples/onnxruntime/training/image-classification/README.md
+++ b/examples/onnxruntime/training/image-classification/README.md
@@ -39,7 +39,7 @@ torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE run_image_classification.py \
     --per_device_eval_batch_size 32 \
     --logging_strategy steps \
     --logging_steps 10 \
-    --evaluation_strategy epoch \
+    --eval_strategy epoch \
     --seed 1337
 ```
 


### PR DESCRIPTION
# What does this PR do?

This PR applies the deprecated `evaluation_strategy` from https://github.com/huggingface/transformers/pull/30190.

TL;DR: `evaluation_strategy` -> `eval_strategy`

(Should go live in v4.41.0, but opening now so it's here when ready!)

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

- ONNX Runtime Training: @JingyaHuang