### PR TITLE
fix falcon dummy input generator

### DIFF
--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -1090,11 +1090,12 @@ class FalconDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
             random_sequence_length_range=random_sequence_length_range,
             **kwargs,
         )
-        self.num_kv_heads = self.num_kv_heads = (
-            normalized_config.num_kv_heads
-            if (normalized_config.new_decoder_architecture or not normalized_config.multi_query)
-            else 1
-        )
+        if normalized_config.new_decoder_architecture and normalized_config.multi_query:
+            self.num_kv_heads = normalized_config.num_attention_heads
+        elif normalized_config.new_decoder_architecture and not normalized_config.multi_query:
+            self.num_kv_heads = normalized_config.num_kv_heads
+        else:
+            self.num_kv_heads = 1
         self.head_dim = self.hidden_size // self.num_attention_heads
 
     def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -1092,7 +1092,7 @@ class FalconDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
         )
         if normalized_config.new_decoder_architecture and normalized_config.multi_query:
             self.num_kv_heads = normalized_config.num_attention_heads
-        elif normalized_config.new_decoder_architecture and not normalized_config.multi_query:
+        elif normalized_config.new_decoder_architecture:
             self.num_kv_heads = normalized_config.num_kv_heads
         else:
             self.num_kv_heads = 1


### PR DESCRIPTION
# What does this PR do?

during enabling falcon40b export for openvino, I found that this model is not covered by dummy input generator configuration and failed with shape mismatch. This PR fixes that.

I propose these changed into optimum-intel, but the proper place for it here.


## Who can review?
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun

