### PR TITLE
Fix bug causing random initialization of bias when using GPTQ quantization with models without bias

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -278,7 +278,7 @@ class GPTQQuantizer(object):
                 elif isinstance(layer, Conv1D):
                     in_features = layer.weight.shape[0]
                     out_features = layer.weight.shape[1]
-                bias = True if layer.bias else False
+                bias = layer.bias is not None
                 if not (self.desc_act) or self.group_size == -1:
                     new_layer = QuantLinear(
                         self.bits,

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -278,19 +278,20 @@ class GPTQQuantizer(object):
                 elif isinstance(layer, Conv1D):
                     in_features = layer.weight.shape[0]
                     out_features = layer.weight.shape[1]
+                bias = True if layer.bias else False
                 if not (self.desc_act) or self.group_size == -1:
                     new_layer = QuantLinear(
                         self.bits,
                         self.group_size,
                         in_features,
                         out_features,
-                        True,
+                        bias,
                         use_cuda_fp16=self.use_cuda_fp16,
                         weight_dtype=layer.weight.dtype,
                     )
                 else:
                     new_layer = QuantLinear(
-                        self.bits, self.group_size, in_features, out_features, True, weight_dtype=layer.weight.dtype
+                        self.bits, self.group_size, in_features, out_features, bias, weight_dtype=layer.weight.dtype
                     )
                 new_layer.device = device
                 setattr(module, attr, new_layer.to(device))


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

For some GPTQ quantized models (e.g. TheBloke/Yi-34B-Chat-GPTQ), the Linear layers in the model do not include bias, but when using transformers to load these GPTQ quantized models, optimum randomly initializes bias in the Linear layers, causing a decrease in the model's accuracy. This PR fixes this issue.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->

- GPTQ, quantization: @fxmarty, @SunMarc
