### PR TITLE
Add Phi-3 mini to Optimum

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -358,7 +358,7 @@ class OptimizedModel(PreTrainedModel):
             if os.path.isdir(os.path.join(model_id, subfolder)) and cls.config_name == CONFIG_NAME:
                 if CONFIG_NAME in os.listdir(os.path.join(model_id, subfolder)):
                     config = AutoConfig.from_pretrained(
-                        os.path.join(model_id, subfolder, CONFIG_NAME), trust_remote_code=trust_remote_code
+                        os.path.join(model_id, subfolder), trust_remote_code=trust_remote_code
                     )
                 elif CONFIG_NAME in os.listdir(model_id):
                     config = AutoConfig.from_pretrained(

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -252,6 +252,7 @@ class NormalizedConfigManager:
         "pegasus": BartLikeNormalizedTextConfig,
         "pix2struct": Pix2StructNormalizedTextConfig,
         "phi": NormalizedTextConfig,
+        "phi3": NormalizedTextConfigWithGQA,
         "poolformer": NormalizedVisionConfig,
         "regnet": NormalizedVisionConfig,
         "resnet": NormalizedVisionConfig,


### PR DESCRIPTION
# What does this PR do?

This PR adds support for Phi-3 mini in Optimum. The optimized and quantized ONNX models for Phi-3 mini are uploaded as part of the [Phi-3 collection](https://huggingface.co/collections/microsoft/phi-3-6626e15e9585a200d2d761e3) for the [4K instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx) and [128K instruct](https://huggingface.co/microsoft/Phi-3-mini-128k-instruct-onnx) variants. 

Example usage:

```
# Download the ONNX models
git clone https://huggingface.co/microsoft/Phi-3-mini-128k-instruct-onnx
```

```
# Load ONNX model
from optimum.onnxruntime import ORTModelForCausalLM

model = ORTModelForCausalLM.from_pretrained(
    "./Phi-3-mini-128k-instruct-onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4",
    decoder_file_name="phi3-mini-128k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx",
    decoder_with_past_file_name="phi3-mini-128k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx",
    use_merged=True,
    provider="CPUExecutionProvider",
    trust_remote_code=True,
    local_files_only=True,
)
```

These PR changes are currently shown [here](https://huggingface.co/microsoft/Phi-3-mini-128k-instruct-onnx/discussions/1#662ff0e991587703a6866524).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
