### PR TITLE
Fix incorrect names for usage blenderbot for causallm

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -645,7 +645,10 @@ class M2M100OnnxConfig(TextSeq2SeqOnnxConfig):
             common_outputs = super(OnnxConfigWithPast, self).outputs
             if self.use_past:
                 # When exporting decoder models with use_cache=True, both the decoder without past and with past have the KV cache as an output.
-                for i in range(self._normalized_config.encoder_num_layers):
+                for i in range(
+                    self._normalized_config.encoder_num_layers 
+                    if self.task != "text-generation" else self._normalized_config.decoder_num_layers
+                ):
                     common_outputs[f"present.{i}.key"] = {0: "batch_size", 2: "past_sequence_length + sequence_length"}
                     common_outputs[f"present.{i}.value"] = {
                         0: "batch_size",

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -646,8 +646,9 @@ class M2M100OnnxConfig(TextSeq2SeqOnnxConfig):
             if self.use_past:
                 # When exporting decoder models with use_cache=True, both the decoder without past and with past have the KV cache as an output.
                 for i in range(
-                    self._normalized_config.encoder_num_layers 
-                    if self.task != "text-generation" else self._normalized_config.decoder_num_layers
+                    self._normalized_config.encoder_num_layers
+                    if self.task != "text-generation"
+                    else self._normalized_config.decoder_num_layers
                 ):
                     common_outputs[f"present.{i}.key"] = {0: "batch_size", 2: "past_sequence_length + sequence_length"}
                     common_outputs[f"present.{i}.value"] = {

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -600,7 +600,7 @@ class M2M100OnnxConfig(TextSeq2SeqOnnxConfig):
     def inputs_for_causal_lm(self):
         if self.use_past_in_inputs:
             common_inputs = {
-                "input_ids": {0: "batch_size"},
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
                 "attention_mask": {0: "batch_size", 1: "past_sequence_length + 1"},
             }
             for i in range(self._normalized_config.decoder_num_layers):


### PR DESCRIPTION
# What does this PR do?

in general case, number of encoder and decoder layers in seq2seq models like blenderbot, m2m, bart can be different from encoder.
As example blenderbot-3b - https://huggingface.co/facebook/blenderbot-3B/blob/main/config.json
If we use these models for causal lm case, where used only decoder, output names can be incorrect due to unequal number of layers in decoder and encoder (that is used for preparing inputs if model has past_key_values).

This PR fixes this issue


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
