### PR TITLE
Read use_external_data_format from ORTConfig file

### DIFF
--- a/optimum/onnxruntime/subpackage/commands/quantize.py
+++ b/optimum/onnxruntime/subpackage/commands/quantize.py
@@ -77,6 +77,7 @@ class ONNXRuntimeQuantizeCommand(BaseOptimumCLICommand):
 
         save_dir = self.args.output
         quantizers = []
+        use_external_data_format = False
 
         quantizers = [
             ORTQuantizer.from_pretrained(self.args.onnx_model, file_name=model.name)
@@ -96,7 +97,11 @@ class ONNXRuntimeQuantizeCommand(BaseOptimumCLICommand):
                 "TensorRT quantization relies on static quantization that requires calibration, which is currently not supported through optimum-cli. Please adapt Optimum static quantization examples to run static quantization for TensorRT: https://github.com/huggingface/optimum/tree/main/examples/onnxruntime/quantization"
             )
         else:
-            qconfig = ORTConfig.from_pretrained(self.args.config).quantization
+            config = ORTConfig.from_pretrained(self.args.config)
+            qconfig = config.quantization
+            use_external_data_format = config.use_external_data_format
 
         for q in quantizers:
-            q.quantize(save_dir=save_dir, quantization_config=qconfig)
+            q.quantize(
+                save_dir=save_dir, quantization_config=qconfig, use_external_data_format=use_external_data_format
+            )


### PR DESCRIPTION
When quantizing the models >2Gb, it's important to set the flag use_external_data_format to 'true',
since otherwise the quantization will fail due to

`ValueError: Message onnx.ModelProto exceeds maximum protobuf size of 2GB`

However, currently there is no way to set the parameter when using optimum-cli because there is no such
command option. Theoretically, it could be set when using ORTConfig file with -c comman flag, because one of the configuration parameters in it is use_external_data_format. In fact, the optimum code ignores it and does not pass it in quantize() function.

The goal of this change is to close this gap.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #1916

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
-->
