### PR TITLE
Fix forward bug in ORTModelForFeatureExtraction

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1091,11 +1091,11 @@ class ORTModelForFeatureExtraction(ORTModel):
             onnx_outputs = self.model.run(None, onnx_inputs)
             model_outputs = self._prepare_onnx_outputs(use_torch, *onnx_outputs)
 
-        if "last_hidden_state" in self.output_names:
-            last_hidden_state = model_outputs["last_hidden_state"]
-        else:
-            # TODO: This allows to support sentence-transformers models (sentence embedding), but is not validated.
-            last_hidden_state = next(iter(model_outputs.values()))
+            if "last_hidden_state" in self.output_names:
+                last_hidden_state = model_outputs["last_hidden_state"]
+            else:
+                # TODO: This allows to support sentence-transformers models (sentence embedding), but is not validated.
+                last_hidden_state = next(iter(model_outputs.values()))
 
         # converts output to namedtuple for pipelines post-processing
         return BaseModelOutput(last_hidden_state=last_hidden_state)


### PR DESCRIPTION
# What does this PR do?
Fix forward bug in ORTModelForFeatureExtraction when using CUDAExecutionProvider.
Current code will result in crash when using cuda.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
 @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime :
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
