### PR TITLE
Add authorization token to TaskManager determine_framework & infer_library_from_model

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -224,9 +224,9 @@ def main_export(
     original_task = task
     task = TasksManager.map_from_synonym(task)
 
-    framework = TasksManager.determine_framework(model_name_or_path, subfolder=subfolder, framework=framework)
+    framework = TasksManager.determine_framework(model_name_or_path, subfolder=subfolder, framework=framework, token=token)
     library_name = TasksManager.infer_library_from_model(
-        model_name_or_path, subfolder=subfolder, library_name=library_name
+        model_name_or_path, subfolder=subfolder, library_name=library_name, token=token
     )
 
     torch_dtype = None

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1457,6 +1457,7 @@ class TasksManager:
         subfolder: str = "",
         framework: Optional[str] = None,
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: str = None,
     ) -> str:
         """
         Determines the framework to use for the export.
@@ -1484,7 +1485,7 @@ class TasksManager:
         if framework is not None:
             return framework
 
-        all_files, request_exception = TasksManager.get_model_files(model_name_or_path, subfolder, cache_dir)
+        all_files, request_exception = TasksManager.get_model_files(model_name_or_path, subfolder, cache_dir, token=token)
 
         pt_weight_name = Path(WEIGHTS_NAME).stem
         pt_weight_extension = Path(WEIGHTS_NAME).suffix

--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -19,6 +19,7 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import onnx
 from datasets import Dataset, load_dataset
@@ -286,6 +287,7 @@ class ORTQuantizer(OptimumQuantizer):
         calibration_tensors_range: Optional[Dict[str, Tuple[float, float]]] = None,
         use_external_data_format: bool = False,
         preprocessor: Optional[QuantizationPreprocessor] = None,
+        extra_options: Optional[Dict[str, Any]] = {}
     ) -> Path:
         """
         Quantizes a model given the optimization specifications defined in `quantization_config`.
@@ -382,6 +384,7 @@ class ORTQuantizer(OptimumQuantizer):
                 "AddQDQPairToWeight": quantization_config.qdq_add_pair_to_weight,
                 "DedicatedQDQPair": quantization_config.qdq_dedicated_pair,
                 "QDQOpTypePerChannelSupportToAxis": quantization_config.qdq_op_type_per_channel_support_to_axis,
+                **extra_options,
             },
         }
 


### PR DESCRIPTION
# What does this PR do?

Fixes an issue I found myself while trying to access a private HuggingFace repository: the framework doesn't pass auth token down to necessary functions.

## Who can review?
Any one. It's a very simple fix.

- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun

