### PR TITLE
fix Unable to find data type for weight_name='/encoder/layer.0/attention/output/dense/MatMul_output_0'

### DIFF
--- a/optimum/onnxruntime/quantization.py
+++ b/optimum/onnxruntime/quantization.py
@@ -19,6 +19,7 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import onnx
 from datasets import Dataset, load_dataset
@@ -286,6 +287,7 @@ class ORTQuantizer(OptimumQuantizer):
         calibration_tensors_range: Optional[Dict[str, Tuple[float, float]]] = None,
         use_external_data_format: bool = False,
         preprocessor: Optional[QuantizationPreprocessor] = None,
+        extra_options: Optional[Dict[str, Any]] = {}
     ) -> Path:
         """
         Quantizes a model given the optimization specifications defined in `quantization_config`.
@@ -382,6 +384,7 @@ class ORTQuantizer(OptimumQuantizer):
                 "AddQDQPairToWeight": quantization_config.qdq_add_pair_to_weight,
                 "DedicatedQDQPair": quantization_config.qdq_dedicated_pair,
                 "QDQOpTypePerChannelSupportToAxis": quantization_config.qdq_op_type_per_channel_support_to_axis,
+                **extra_options,
             },
         }
 


### PR DESCRIPTION

# What does this PR do?
Adds a keyword argument to allow passing extra_options to ORTQuantizer.quantize()

To fix RuntimeError: 
> Unable to find data type for weight_name='/encoder/layer.0/attention/output/dense/MatMul_output_0'. shape_inference failed to return a type probably this node is from a different domain or using an input produced by such an operator. This may happen if you quantize a model already quantized. **You may use extra_options DefaultTensorType to indicate the default weight type, usually onnx.TensorProto.FLOAT**.

Maybe it can be added to `AutoQuantizationConfig`, but there any many `@staticmethod` for that, so maybe this quick fix is simpler.

## Who can review?
It's very simple. Anyone can review.

- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun

