### PR TITLE
Support transformers 4.43

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.26.0,<4.43.0",
+    "transformers[sentencepiece]>=4.26.0,<4.44",
     "torch>=1.11",
     "packaging",
     "numpy<2.0",  # transformers requires numpy<2.0 https://github.com/huggingface/transformers/pull/31569


### PR DESCRIPTION
# What does this PR do?
Allows `transformers<4.44` as a dependency, since with the release of 4.43.0 (and 4.43.1 today), then `optimum` can't be installed with these versions.

Looking at the release notes of 4.43.0, I didn't see anything that would obviously break here (the biggest standout was https://github.com/huggingface/transformers/pull/31696, but it seems that was handled in https://github.com/huggingface/optimum/pull/1929 already). If there are any that stand out to anyone else, I'd be happy to take a look at the necessary fixes.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@fxmarty @IlyasMoutawwakil @echarlaix 

based off of https://github.com/huggingface/optimum/pull/1929
