### PR TITLE
Add quanto install and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,34 @@ You can find more examples in the [documentation](https://huggingface.co/docs/op
 ```
 
 You can find more examples in the [documentation](https://huggingface.co/docs/optimum/onnxruntime/usage_guides/trainer) and in the [examples](https://github.com/huggingface/optimum/tree/main/examples/onnxruntime/training).
+
+
+### Quanto
+
+[Quanto](https://github.com/huggingface/optimum-quanto) is a pytorch quantization backend.
+
+You can quantize a model either using the python API or the `optimum-cli`.
+
+```python
+from transformers import AutoModelForCausalLM
+from optimum.quanto import QuantizedModelForCausalLM, qint4
+
+model = AutoModelForCausalLM.from_pretrained('meta-llama/Meta-Llama-3.1-8B')
+qmodel = QuantizedModelForCausalLM.quantize(model, weights=qint4, exclude='lm_head')
+```
+
+The quantized model can be saved using save_pretrained:
+
+```python
+qmodel.save_pretrained('./Llama-3.1-8B-quantized')
+```
+
+It can later be reloaded using from_pretrained:
+
+```python
+from optimum.quanto import QuantizedModelForCausalLM
+
+qmodel = QuantizedModelForCausalLM.from_pretrained('Llama-3.1-8B-quantized')
+```
+
+You can see more details and [examples](https://github.com/huggingface/optimum-quanto/tree/main/examples) in the [Quanto](https://github.com/huggingface/optimum-quanto) repository.

--- a/README.md
+++ b/README.md
@@ -284,13 +284,13 @@ model = AutoModelForCausalLM.from_pretrained('meta-llama/Meta-Llama-3.1-8B')
 qmodel = QuantizedModelForCausalLM.quantize(model, weights=qint4, exclude='lm_head')
 ```
 
-The quantized model can be saved using save_pretrained:
+The quantized model can be saved using `save_pretrained`:
 
 ```python
 qmodel.save_pretrained('./Llama-3.1-8B-quantized')
 ```
 
-It can later be reloaded using from_pretrained:
+It can later be reloaded using `from_pretrained`:
 
 ```python
 from optimum.quanto import QuantizedModelForCausalLM

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ EXTRAS_REQUIRE = {
     "graphcore": "optimum-graphcore",
     "furiosa": "optimum-furiosa",
     "amd": "optimum-amd",
+    "quanto": ["optimum-quanto>=0.2.4"],
     "dev": TESTS_REQUIRE + QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
     "quality": QUALITY_REQUIRE,


### PR DESCRIPTION
# What does this PR do?

This simply adds an option to `setup.py` to install quanto, and some basic instructions to quantize, save and reload a model.