### PR TITLE
Add Onnx support for Canine Model

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -153,6 +153,9 @@ class XLMOnnxConfig(BertOnnxConfig):
 class SplinterOnnxConfig(BertOnnxConfig):
     DEFAULT_ONNX_OPSET = 11
 
+class CanineOnnxConfig(BertOnnxConfig):
+    DEFAULT_ONNX_OPSET = 13
+
 
 class DistilBertOnnxConfig(BertOnnxConfig):
     DEFAULT_ONNX_OPSET = 11

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -482,6 +482,14 @@ class TasksManager:
             onnx="CamembertOnnxConfig",
             tflite="CamembertTFLiteConfig",
         ),
+        "canine": supported_tasks_mapping(
+            "text-classification",
+            "masked-lm",
+            "multiple-choice",
+            "token-classification",
+            "question-answering",
+            onnx="CanineOnnxConfig",
+        ),
         "clip": supported_tasks_mapping(
             "feature-extraction",
             "zero-shot-image-classification",

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -232,6 +232,7 @@ class NormalizedConfigManager:
         "bloom": NormalizedTextConfig.with_args(num_layers="n_layer"),
         "falcon": NormalizedTextConfig,
         "camembert": NormalizedTextConfig,
+        "canine": NormalizedTextConfig,
         "codegen": GPT2LikeNormalizedTextConfig,
         "cvt": NormalizedVisionConfig,
         "deberta": NormalizedTextConfig,

--- a/tests/exporters/exporters_utils.py
+++ b/tests/exporters/exporters_utils.py
@@ -55,6 +55,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "blenderbot": "hf-internal-testing/tiny-random-BlenderbotModel",
     "bloom": "hf-internal-testing/tiny-random-BloomModel",
     "camembert": "hf-internal-testing/tiny-random-camembert",
+    "canine": "google/canine-s",
     "clip": "hf-internal-testing/tiny-random-CLIPModel",
     "clip-vision-model": "fxmarty/clip-vision-model-tiny",
     "convbert": "hf-internal-testing/tiny-random-ConvBertModel",


### PR DESCRIPTION
# What does this PR do?
Add support for `Canine`.

To run model for `Sequence Classification` or `Token Classification`, make a temporary change [here](https://github.com/RaghavPrabhakar66/optimum/blob/f8f9707b4995f526d48e5376d0886b054a816cbd/optimum/utils/normalized_config.py#L81) from
```python
VOCAB_SIZE = "vocab_size"
```
to
```python
TYPE_VOCAB_SIZE = "vocab_size"
```

<!-- Remove if not applicable -->

Fixes #555 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
@ozancaglayan
<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
