### PR TITLE
Follow up the diffusers task refactoring

### DIFF
--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -110,9 +110,9 @@ class OnnxRuntimeRun(Run):
         model_class = FeaturesManager.get_model_class_for_feature(get_autoclass_name(self.task))
         self.torch_model = model_class.from_pretrained(run_config["model_name_or_path"])
 
-        self.return_body[
-            "model_type"
-        ] = self.torch_model.config.model_type  # return_body is initialized in parent class
+        self.return_body["model_type"] = (
+            self.torch_model.config.model_type
+        )  # return_body is initialized in parent class
 
     def _launch_time(self, trial):
         batch_size = trial.suggest_categorical("batch_size", self.batch_sizes)

--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -110,9 +110,9 @@ class OnnxRuntimeRun(Run):
         model_class = FeaturesManager.get_model_class_for_feature(get_autoclass_name(self.task))
         self.torch_model = model_class.from_pretrained(run_config["model_name_or_path"])
 
-        self.return_body["model_type"] = (
-            self.torch_model.config.model_type
-        )  # return_body is initialized in parent class
+        self.return_body[
+            "model_type"
+        ] = self.torch_model.config.model_type  # return_body is initialized in parent class
 
     def _launch_time(self, trial):
         batch_size = trial.suggest_categorical("batch_size", self.batch_sizes)


### PR DESCRIPTION
# What does this PR do?

Some pipelines (eg. `StableDiffusionInstructPix2PixPipeline`) are not included in the auto pipelines of diffusers, we could previously still load these models for export. However, the refactoring #1947 limits the support to only pipelines included in those auto pipeline APIs.

Error I got with the refactoring:

```
======================================================================== test session starts ========================================================================
platform linux -- Python 3.8.10, pytest-8.0.0, pluggy-1.5.0
rootdir: /home/ubuntu/optimum-neuron
configfile: pyproject.toml
plugins: anyio-4.4.0
collected 14 items                                                                                                                                                  

tests/inference/test_stable_diffusion_pipeline.py .......F......                                                                                              [100%]

============================================================================= FAILURES ==============================================================================
__________________________ NeuronStableDiffusionPipelineIntegrationTest.test_instruct_pix2pix_export_and_inference_0_stable_diffusion_ip2p __________________________

a = (<tests.inference.test_stable_diffusion_pipeline.NeuronStableDiffusionPipelineIntegrationTest testMethod=test_instruct_pix2pix_export_and_inference_0_stable_diffusion_ip2p>,)
kw = {}

    @wraps(func)
    def standalone_func(*a, **kw):
>       return func(*(a + p.args), **p.kwargs, **kw)

../pyvenv/aws_neuron_venv_2.19.1/lib/python3.8/site-packages/parameterized/parameterized.py:620: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/inference/test_stable_diffusion_pipeline.py:138: in test_instruct_pix2pix_export_and_inference
    neuron_pipeline = NeuronStableDiffusionInstructPix2PixPipeline.from_pretrained(
../pyvenv/aws_neuron_venv_2.19.1/lib/python3.8/site-packages/optimum/modeling_base.py:424: in from_pretrained
    return from_pretrained_method(
optimum/neuron/utils/require_utils.py:51: in wrapper
    return func(*args, **kwargs)
optimum/neuron/modeling_diffusion.py:714: in _from_transformers
    return cls._export(*args, **kwargs)
optimum/neuron/utils/require_utils.py:51: in wrapper
    return func(*args, **kwargs)
optimum/neuron/modeling_diffusion.py:833: in _export
    pipe = TasksManager.get_model_from_task(
../pyvenv/aws_neuron_venv_2.19.1/lib/python3.8/site-packages/optimum/exporters/tasks.py:2116: in get_model_from_task
    model = model_class.from_pretrained(model_name_or_path, **kwargs).to(device)
../pyvenv/aws_neuron_venv_2.19.1/lib/python3.8/site-packages/huggingface_hub/utils/_validators.py:114: in _inner_fn
    return fn(*args, **kwargs)
../pyvenv/aws_neuron_venv_2.19.1/lib/python3.8/site-packages/diffusers/pipelines/auto_pipeline.py:336: in from_pretrained
    text_2_image_cls = _get_task_class(AUTO_TEXT2IMAGE_PIPELINES_MAPPING, orig_class_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

mapping = OrderedDict([('stable-diffusion', <class 'diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusi...haPipeline'>), ('pixart-sigma', <class 'diffusers.pipelines.pixart_alpha.pipeline_pixart_sigma.PixArtSigmaPipeline'>)])
pipeline_class_name = 'StableDiffusionInstructPix2PixPipeline', throw_error_if_not_exist = True

    def _get_task_class(mapping, pipeline_class_name, throw_error_if_not_exist: bool = True):
        def get_model(pipeline_class_name):
            for task_mapping in SUPPORTED_TASKS_MAPPINGS:
                for model_name, pipeline in task_mapping.items():
                    if pipeline.__name__ == pipeline_class_name:
                        return model_name
    
        model_name = get_model(pipeline_class_name)
    
        if model_name is not None:
            task_class = mapping.get(model_name, None)
            if task_class is not None:
                return task_class
    
        if throw_error_if_not_exist:
>           raise ValueError(f"AutoPipeline can't find a pipeline linked to {pipeline_class_name} for {model_name}")
E           ValueError: AutoPipeline can't find a pipeline linked to StableDiffusionInstructPix2PixPipeline for None
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
