### PR TITLE
Add Param Cache For Recompilation

### DIFF
--- a/optimum/fx/parallelization/core.py
+++ b/optimum/fx/parallelization/core.py
@@ -125,6 +125,11 @@ class ParallelExecutionCtx:
             because we have to make sure we don't initiate new parameters and replace original ones when
             recompilation happens in training process.
 
+        - param_cache (`Dict[str, nn.Parameter]`):
+            Cache which keeps record of newly created parameters. Similar to `parallel_layer_cache`, we
+            need to make sure all the newly created parameters in the first compilation will still be used
+            when recompilation happens.
+
         - weight_map (`Dict[str, str]`):
             Mapping between parameter names and their locations on disk, useful when loading weights
             from disk.
@@ -140,6 +145,7 @@ class ParallelExecutionCtx:
     current_device: torch.device
     example_inputs: List[Any] = field(default_factory=list)
     parallel_layer_cache: Dict[str, nn.Module] = field(default_factory=dict)
+    param_cache: Dict[str, nn.Parameter] = field(default_factory=dict)
     weight_map: Dict[str, str] = field(default_factory=dict)
     last_optimized_graph_module: Optional[GraphModule] = None
     compile_times: int = 0


### PR DESCRIPTION
The parameter cache instance is needed to handle recompilation where we need to make sure the parameters we created in the first run are used, currently the use case does not fall into error even without param cache because we directly replace layers in layer cache in recompilation(parameters are replaced automatically because layers are replaced), but there are still some parameters which is not traced within a standalone module(like layernorm weight), it still works fine for now because we directly use the original parameter instead of creating new ones for initialization and weights loading if it is already on the current rank device, however, in cases where we need to support third-party backends like nanotron which has its own implementation of `NanotronParameter`, we do need to track all the newly created parameters so that no new parameter is created in recompilation.