### PR TITLE
Modify token classification processor default dataset args

### DIFF
--- a/optimum/utils/preprocessing/token_classification.py
+++ b/optimum/utils/preprocessing/token_classification.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 class TokenClassificationProcessing(TaskProcessor):
     ACCEPTED_PREPROCESSOR_CLASSES = (PreTrainedTokenizerBase,)
-    DEFAULT_DATASET_ARGS = {"path": "conll2003", "trust_remote_code": True}
+    DEFAULT_DATASET_ARGS = "conll2003"
     DEFAUL_DATASET_DATA_KEYS = {"primary": "tokens"}
     ALLOWED_DATA_KEY_NAMES = {"primary"}
     DEFAULT_REF_KEYS = ["ner_tags", "pos_tags", "chunk_tags"]


### PR DESCRIPTION
`trust_remote_code` shouldn't be set by default to True, reverting from 7cc57e40f84e00f8ebc2849da303e40575fb23b4, might make sense to change the dataset instead cc @IlyasMoutawwakil 