### PR TITLE
Fix `is_torch_tpu_available` in ORT Trainer

### DIFF
--- a/optimum/onnxruntime/trainer.py
+++ b/optimum/onnxruntime/trainer.py
@@ -103,14 +103,14 @@ else:
     from transformers.deepspeed import deepspeed_init, deepspeed_load_checkpoint, is_deepspeed_zero3_enabled
 
 if check_if_transformers_greater("4.39"):
-    from transformers.utils import is_torch_xla_available
+    from transformers.utils import is_torch_xla_available as is_torch_tpu_xla_available
 
-    if is_torch_xla_available():
+    if is_torch_tpu_xla_available():
         import torch_xla.core.xla_model as xm
 else:
-    from transformers.utils import is_torch_tpu_available
+    from transformers.utils import is_torch_tpu_available as is_torch_tpu_xla_available
 
-    if is_torch_tpu_available(check_device=False):
+    if is_torch_tpu_xla_available(check_device=False):
         import torch_xla.core.xla_model as xm
 
 if TYPE_CHECKING:
@@ -735,7 +735,7 @@ class ORTTrainer(Trainer):
 
                 if (
                     args.logging_nan_inf_filter
-                    and not is_torch_tpu_available()
+                    and not is_torch_tpu_xla_available()
                     and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step))
                 ):
                     # if loss is nan or inf simply add the average of previous logged losses


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Following https://github.com/huggingface/optimum/pull/2012. There is one occurrence of `is_torch_tpu_available` in the code of the `ORTTrainer` class, which will fail for `transformers >= 4.39.0`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
