### PR TITLE
Don't hardcode the logger level to INFO; let users set TRANSFORMERS_VERBOSITY

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     from .base import OnnxConfig
 
 logger = logging.get_logger()
-logger.setLevel(logging.INFO)
 
 
 def main_export(

--- a/optimum/exporters/tflite/__main__.py
+++ b/optimum/exporters/tflite/__main__.py
@@ -28,7 +28,6 @@ from .convert import export, validate_model_outputs
 
 
 logger = logging.get_logger()
-logger.setLevel(logging.INFO)
 
 
 def main():

--- a/optimum/onnx/transformations_utils.py
+++ b/optimum/onnx/transformations_utils.py
@@ -29,7 +29,6 @@ from ..utils import logging, recurse_getattr
 
 
 logger = logging.get_logger()
-logger.setLevel(logging.INFO)
 
 
 def _find_duplicate_initializers(


### PR DESCRIPTION
# What does this PR do?

This PR stop the hardcoding of the logger level to INFO in various files. Currently, this hardcoding prevents `TRANSFORMERS_VERBOSITY` from working and unexpectedly sets the default logs as INFO rather than WARNING.
Beyond that, `optimum` is often used "behind the scenes" (or at least, it likely should be), and those modules should be very quiet apart from big warnings or errors, in my opinion. Otherwise, info logs such as 
```
config.json not found in the specified subfolder onnx. Using the top level config.json.
```
might confuse users into thinking that something is wrong with their `transformers`, RAG tool, etc., and logs such as 
```
Compiling the model to CPU ...
```
don't do anything more than spam the terminal. It's good that these logs exist, but people should opt into these by setting the logger level to INFO rather than having them enabled by default.

Fixes https://github.com/huggingface/optimum/pull/2044#discussion_r1794139083

Here's some scripts to help me make my case:

## Script 1
This script relies on an unreleased Sentence Transformers release, so it's a bit hard to reproduce, but it should paint a picture of the before vs after:

```python
from sentence_transformers import SentenceTransformer, export_optimized_onnx_model

onnx_model = SentenceTransformer("all-mpnet-base-v2", backend="onnx")
onnx_model.save_pretrained("all-mpnet-base-v2-local")
export_optimized_onnx_model(
    onnx_model,
    optimization_config="O3",
    model_name_or_path="all-mpnet-base-v2-local",
)
```

### Before
```
No 'model.onnx' found in 'sentence-transformers/all-mpnet-base-v2'. Exporting the model to ONNX.
Framework not specified. Using pt to export the model.
Using the export variant default. Available variants are:
    - default: The default ONNX variant.

***** Exporting submodel 1/1: MPNetModel *****
Using framework PyTorch: 2.5.0.dev20240807+cu121
2024-10-09 22:23:23.6534718 [W:onnxruntime:, session_state.cc:1166 onnxruntime::VerifyEachNodeIsAssignedToAnEp] Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
2024-10-09 22:23:23.6579083 [W:onnxruntime:, session_state.cc:1168 onnxruntime::VerifyEachNodeIsAssignedToAnEp] Rerunning with verbose output on a non-minimal build will show node assignments.
Saving the exported ONNX model is heavily recommended to avoid having to export it again. Do so with `model.push_to_hub('sentence-transformers/all-mpnet-base-v2', create_pr=True)`.
C:\Users\tom\.conda\envs\sentence-transformers\Lib\site-packages\optimum\onnxruntime\configuration.py:779: FutureWarning: disable_embed_layer_norm will be deprecated soon, use disable_embed_layer_norm_fusion instead, disable_embed_layer_norm_fusion is set to True.
  warnings.warn(
Optimizing model...
Configuration saved in C:\Users\tom\AppData\Local\Temp\tmpwxkm7dkn\ort_config.json
Optimized model saved at: C:\Users\tom\AppData\Local\Temp\tmpwxkm7dkn (external data format: False; saved all tensor to one file: True)
```

### After
```
No 'model.onnx' found in 'sentence-transformers/all-mpnet-base-v2'. Exporting the model to ONNX.
2024-10-09 22:24:27.2542599 [W:onnxruntime:, session_state.cc:1166 onnxruntime::VerifyEachNodeIsAssignedToAnEp] Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
2024-10-09 22:24:27.2585698 [W:onnxruntime:, session_state.cc:1168 onnxruntime::VerifyEachNodeIsAssignedToAnEp] Rerunning with verbose output on a non-minimal build will show node assignments.
Saving the exported ONNX model is heavily recommended to avoid having to export it again. Do so with `model.push_to_hub('sentence-transformers/all-mpnet-base-v2', create_pr=True)`.
C:\Users\tom\.conda\envs\sentence-transformers\Lib\site-packages\optimum\onnxruntime\configuration.py:779: FutureWarning: disable_embed_layer_norm will be deprecated soon, use disable_embed_layer_norm_fusion instead, disable_embed_layer_norm_fusion is set to True.
  warnings.warn(
```
We now have 2 warnings from Sentence Transformers (about that we're exporting & to recommend saving), 2 warnings from onnxruntime which make sense, and a warning from optimum regarding `disable_embed_layer_norm`. This is much more manageable, especially because a lot of the logs that we don't see here anymore don't matter to the average person. These are the removed logs:
```
Framework not specified. Using pt to export the model.
Using the export variant default. Available variants are:
    - default: The default ONNX variant.

***** Exporting submodel 1/1: MPNetModel *****
Using framework PyTorch: 2.5.0.dev20240807+cu121
Optimizing model...
Configuration saved in C:\Users\tom\AppData\Local\Temp\tmpwxkm7dkn\ort_config.json
Optimized model saved at: C:\Users\tom\AppData\Local\Temp\tmpwxkm7dkn (external data format: False; saved all tensor to one file: True)
```

## Script 2

```python
from sentence_transformers import SentenceTransformer

# Export & Save
SentenceTransformer("all-mpnet-base-v2", backend="openvino").save_pretrained("all-mpnet-base-v2-local")

# Load exported model
model = SentenceTransformer("all-mpnet-base-v2-local", backend="openvino")
print(model.encode(["Hello!"]).shape)
```

### Before

```
No 'openvino_model.xml' found in 'sentence-transformers/all-mpnet-base-v2'. Exporting the model to OpenVINO.
Framework not specified. Using pt to export the model.
Using framework PyTorch: 2.5.0.dev20240807+cu121
Compiling the model to CPU ...
Saving the exported OpenVINO model is heavily recommended to avoid having to export it again. Do so with `model.push_to_hub('sentence-transformers/all-mpnet-base-v2', create_pr=True)`.
config.json not found in the specified subfolder openvino. Using the top level config.json.
Compiling the model to CPU ...
(1, 768)
```

### After
```
No 'openvino_model.xml' found in 'sentence-transformers/all-mpnet-base-v2'. Exporting the model to OpenVINO.
Saving the exported OpenVINO model is heavily recommended to avoid having to export it again. Do so with `model.push_to_hub('sentence-transformers/all-mpnet-base-v2', create_pr=True)`.
(1, 768)
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
@echarlaix @JingyaHuang @regisss @xenova 

- Tom Aarsen