### PR TITLE
remove upper transformers version limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except Exception as error:
 REQUIRED_PKGS = [
     "coloredlogs",
     "sympy",
-    "transformers[sentencepiece]>=4.29,<4.46.0",
+    "transformers[sentencepiece]>=4.29",
     "torch>=1.11",
     "packaging",
     "numpy",
@@ -54,6 +54,7 @@ EXTRAS_REQUIRE = {
         "datasets>=1.2.1",
         "evaluate",
         "protobuf>=3.20.1",
+        "transformers<4.46.0",
     ],
     "onnxruntime-gpu": [
         "onnx",
@@ -62,9 +63,10 @@ EXTRAS_REQUIRE = {
         "evaluate",
         "protobuf>=3.20.1",
         "accelerate",  # ORTTrainer requires it.
+        "transformers<4.46.0",
     ],
-    "exporters": ["onnx", "onnxruntime", "timm"],
-    "exporters-gpu": ["onnx", "onnxruntime-gpu", "timm"],
+    "exporters": ["onnx", "onnxruntime", "timm", "transformers<4.46.0"],
+    "exporters-gpu": ["onnx", "onnxruntime-gpu", "timm", "transformers<4.46.0"],
     "exporters-tf": [
         "tensorflow>=2.4,<=2.12.1",
         "tf2onnx",


### PR DESCRIPTION
To not block a release from optimum-intel, optimum-neuron, optimum-habana and others to support the latest transformers release (removing the need to dsync it with an optimum release)