### PR TITLE
`ORTDiffusionPipeline`s with IO Binding

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -1132,7 +1132,11 @@ class VaeEncoderOnnxConfig(VisionOnnxConfig):
     @property
     def outputs(self) -> Dict[str, Dict[int, str]]:
         return {
-            "latent_parameters": {0: "batch_size", 2: "sample_height / len_blocks", 3: "sample_width / len_blocks"},
+            "latent_parameters": {
+                0: "batch_size",
+                2: "sample_height / down_scaling_factor",
+                3: "sample_width / down_scaling_factor",
+            },
         }
 
 
@@ -1156,7 +1160,11 @@ class VaeDecoderOnnxConfig(VisionOnnxConfig):
     @property
     def outputs(self) -> Dict[str, Dict[int, str]]:
         return {
-            "sample": {0: "batch_size", 2: "latent_height * len_blocks", 3: "latent_width * len_blocks"},
+            "sample": {
+                0: "batch_size",
+                2: "latent_height * up_scaling_factor",
+                3: "latent_width * up_scaling_factor",
+            },
         }
 
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -1126,13 +1126,13 @@ class VaeEncoderOnnxConfig(VisionOnnxConfig):
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:
         return {
-            "sample": {0: "batch_size", 2: "height", 3: "width"},
+            "sample": {0: "batch_size", 2: "sample_height", 3: "sample_width"},
         }
 
     @property
     def outputs(self) -> Dict[str, Dict[int, str]]:
         return {
-            "latent_parameters": {0: "batch_size", 2: "height_latent", 3: "width_latent"},
+            "latent_parameters": {0: "batch_size", 2: "sample_height / len_blocks", 3: "sample_width / len_blocks"},
         }
 
 
@@ -1150,13 +1150,13 @@ class VaeDecoderOnnxConfig(VisionOnnxConfig):
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:
         return {
-            "latent_sample": {0: "batch_size", 2: "height_latent", 3: "width_latent"},
+            "latent_sample": {0: "batch_size", 2: "latent_height", 3: "latent_width"},
         }
 
     @property
     def outputs(self) -> Dict[str, Dict[int, str]]:
         return {
-            "sample": {0: "batch_size", 2: "height", 3: "width"},
+            "sample": {0: "batch_size", 2: "latent_height * len_blocks", 3: "latent_width * len_blocks"},
         }
 
 

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -1118,8 +1118,8 @@ class VaeEncoderOnnxConfig(VisionOnnxConfig):
     DEFAULT_ONNX_OPSET = 14
 
     NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        down_block_types="down_block_types",
         num_channels="in_channels",
-        image_size="sample_size",
         allow_new=True,
     )
 
@@ -1131,11 +1131,12 @@ class VaeEncoderOnnxConfig(VisionOnnxConfig):
 
     @property
     def outputs(self) -> Dict[str, Dict[int, str]]:
+        down_sampling_factor = 2 ** (len(self._normalized_config.down_block_types) - 1)
         return {
             "latent_parameters": {
                 0: "batch_size",
-                2: "sample_height / down_scaling_factor",
-                3: "sample_width / down_scaling_factor",
+                2: f"sample_height / {down_sampling_factor}",
+                3: f"sample_width / {down_sampling_factor}",
             },
         }
 
@@ -1147,6 +1148,7 @@ class VaeDecoderOnnxConfig(VisionOnnxConfig):
     DEFAULT_ONNX_OPSET = 14
 
     NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        up_block_types="up_block_types",
         num_channels="latent_channels",
         allow_new=True,
     )
@@ -1159,11 +1161,13 @@ class VaeDecoderOnnxConfig(VisionOnnxConfig):
 
     @property
     def outputs(self) -> Dict[str, Dict[int, str]]:
+        upsampling_factor = 2 ** (len(self._normalized_config.up_block_types) - 1)
+
         return {
             "sample": {
                 0: "batch_size",
-                2: "latent_height * up_scaling_factor",
-                3: "latent_width * up_scaling_factor",
+                2: f"latent_height * {upsampling_factor}",
+                3: f"latent_width * {upsampling_factor}",
             },
         }
 

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -19,15 +19,15 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import onnx
 import torch
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
-from onnx.tools import update_model_dims
 from transformers import AutoModelForCausalLM, GenerationConfig
 from transformers.file_utils import add_end_docstrings, add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
+import onnx
 import onnxruntime
+from onnx.tools import update_model_dims
 
 from ..exporters.onnx import MODEL_TYPES_REQUIRING_POSITION_IDS, main_export
 from ..onnx.utils import check_model_uses_external_data

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -161,7 +161,6 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
                     setattr(self.generation_config, param_name, param_value)
                     setattr(self.config, param_name, None)
 
-        self.model_path = Path(model._model_path)
         self.use_merged = "use_cache_branch" in self.input_names
         self.model_type = self.config.model_type
 

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -19,15 +19,15 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import onnx
 import torch
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from onnx.tools import update_model_dims
 from transformers import AutoModelForCausalLM, GenerationConfig
 from transformers.file_utils import add_end_docstrings, add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-import onnx
 import onnxruntime
-from onnx.tools import update_model_dims
 
 from ..exporters.onnx import MODEL_TYPES_REQUIRING_POSITION_IDS, main_export
 from ..onnx.utils import check_model_uses_external_data

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -161,7 +161,6 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
                     setattr(self.generation_config, param_name, param_value)
                     setattr(self.config, param_name, None)
 
-        self.onnx_paths = [self.model_path]
         self.use_merged = "use_cache_branch" in self.input_names
         self.model_type = self.config.model_type
 

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -161,6 +161,7 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
                     setattr(self.generation_config, param_name, param_value)
                     setattr(self.config, param_name, None)
 
+        self.model_path = Path(model._model_path)
         self.use_merged = "use_cache_branch" in self.input_names
         self.model_type = self.config.model_type
 

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -603,8 +603,8 @@ class ORTPipelinePart(ConfigMixin):
 
             io_binding.bind_input(
                 name=input_name,
-                device_id=self.device.index,
                 device_type=model_inputs[input_name].device.type,
+                device_id=self.device.index if self.device.index is not None else -1,
                 element_type=TypeHelper.ort_type_to_numpy_type(self.input_dtypes[input_name]),
                 buffer_ptr=model_inputs[input_name].data_ptr(),
                 shape=tuple(model_inputs[input_name].size()),
@@ -623,8 +623,8 @@ class ORTPipelinePart(ConfigMixin):
             for output_name, output_tensor in model_outputs.items():
                 io_binding.bind_output(
                     name=output_name,
-                    device_id=self.device.index,
                     device_type=self.device.type,
+                    device_id=self.device.index if self.device.index is not None else -1,
                     element_type=TypeHelper.ort_type_to_numpy_type(self.output_dtypes[output_name]),
                     buffer_ptr=output_tensor.data_ptr(),
                     shape=tuple(output_tensor.size()),

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -70,7 +70,6 @@ from ..utils.save_utils import maybe_load_preprocessors, maybe_save_preprocessor
 from .io_binding import IOBindingHelper, TypeHelper
 from .utils import (
     ONNX_WEIGHTS_NAME,
-    check_io_binding,
     get_device_for_provider,
     get_ordered_input_names,
     get_provider_for_device,
@@ -231,7 +230,7 @@ class ORTModel(OptimizedModel):
                 f" Use `ort_model.to()` to send the outputs to the wanted device."
             )
 
-        self._use_io_binding = use_io_binding
+        self.use_io_binding = use_io_binding
 
         # Registers the ORTModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating
         # a pipeline https://github.com/huggingface/transformers/blob/cad61b68396a1a387287a8e2e2fef78a25b79383/src/transformers/pipelines/base.py#L863
@@ -308,14 +307,6 @@ class ORTModel(OptimizedModel):
     def device(self, **kwargs):
         raise AttributeError("The device attribute is read-only, please use the `to` method to change the device.")
 
-    @property
-    def use_io_binding(self):
-        return check_io_binding(self.providers, self._use_io_binding)
-
-    @use_io_binding.setter
-    def use_io_binding(self, value: bool):
-        self._use_io_binding = value
-
     def to(self, device: Union[torch.device, str, int]):
         """
         Changes the ONNX Runtime provider according to the device.
@@ -338,7 +329,7 @@ class ORTModel(OptimizedModel):
         validate_provider_availability(provider)  # raise error if the provider is not available
 
         # IOBinding is only supported for CPU and CUDA Execution Providers.
-        if device.type == "cuda" and self._use_io_binding is False and provider == "CUDAExecutionProvider":
+        if device.type == "cuda" and self.use_io_binding is False and provider == "CUDAExecutionProvider":
             self.use_io_binding = True
             logger.info(
                 "use_io_binding was set to False, setting it to True because it can provide a huge speedup on GPUs. "

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -247,6 +247,8 @@ class ORTModel(OptimizedModel):
     ):
         super().__init__(model, config)
 
+        self.model_path = Path(model._model_path)
+
         self.input_names = {input_key.name: idx for idx, input_key in enumerate(model.get_inputs())}
         self.input_dtypes = {input_key.name: input_key.type for input_key in model.get_inputs()}
 

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -104,7 +104,7 @@ class ORTOptimizer:
                     "Please re-export your model. This can be done by using the optimum-cli ONNX export tool or `ORTModelForCausalLM.from_pretrained(..., export=True, use_merged=False)`."
                 )
             else:
-                onnx_model_path.append(model_or_path.model._model_path)
+                onnx_model_path.append(model_or_path.model_path)
             config = model_or_path.config
         elif os.path.isdir(model_or_path):
             from_ortmodel = False

--- a/optimum/onnxruntime/optimization.py
+++ b/optimum/onnxruntime/optimization.py
@@ -104,7 +104,7 @@ class ORTOptimizer:
                     "Please re-export your model. This can be done by using the optimum-cli ONNX export tool or `ORTModelForCausalLM.from_pretrained(..., export=True, use_merged=False)`."
                 )
             else:
-                onnx_model_path.append(model_or_path.model_path)
+                onnx_model_path.append(model_or_path.model._model_path)
             config = model_or_path.config
         elif os.path.isdir(model_or_path):
             from_ortmodel = False

--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -199,7 +199,7 @@ def get_device_for_provider(provider: str, provider_options: Dict) -> torch.devi
     Gets the PyTorch device (CPU/CUDA) associated with an ONNX Runtime provider.
     """
     if provider in ["CUDAExecutionProvider", "TensorrtExecutionProvider", "ROCMExecutionProvider"]:
-        return torch.device(f"cuda:{provider_options['device_id']}")
+        return torch.device(f"cuda:{provider_options.get('device_id', 0)}")
     else:
         return torch.device("cpu")
 

--- a/optimum/subpackages.py
+++ b/optimum/subpackages.py
@@ -48,6 +48,8 @@ def load_namespace_modules(namespace: str, module: str):
         dist_name = dist.metadata["Name"]
         if not dist_name.startswith(f"{namespace}-"):
             continue
+        if dist_name == "optimum-benchmark":
+            continue
         package_import_name = dist_name.replace("-", ".")
         module_import_name = f"{package_import_name}.{module}"
         if module_import_name in sys.modules:

--- a/tests/onnxruntime/test_diffusion.py
+++ b/tests/onnxruntime/test_diffusion.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
 import torch
 from diffusers import (
     AutoPipelineForImage2Image,
@@ -272,22 +271,21 @@ class ORTPipelineForText2ImageTest(ORTModelTestMixin):
             }
         )
     )
-    @pytest.mark.rocm_ep_test
-    @pytest.mark.cuda_ep_test
-    @pytest.mark.trt_ep_test
     @require_torch_gpu
     @require_diffusers
     def test_pipeline_on_gpu(self, test_name: str, model_arch: str, provider: str):
         model_args = {"test_name": test_name, "model_arch": model_arch}
         self._setup(model_args)
 
-        height, width, batch_size = 32, 64, 1
+        height, width, batch_size = 32, 64, 2
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
 
-        pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[test_name], provider=provider)
+        pipeline = self.ORTMODEL_CLASS.from_pretrained(
+            self.onnx_model_dirs[test_name], provider=provider, use_io_binding=True
+        )
+        self.assertEqual(pipeline.device.type, "cuda")
 
         outputs = pipeline(**inputs).images
-
         self.assertIsInstance(outputs, np.ndarray)
         self.assertEqual(outputs.shape, (batch_size, height, width, 3))
 
@@ -486,19 +484,18 @@ class ORTPipelineForImage2ImageTest(ORTModelTestMixin):
             }
         )
     )
-    @pytest.mark.rocm_ep_test
-    @pytest.mark.cuda_ep_test
-    @pytest.mark.trt_ep_test
     @require_torch_gpu
     @require_diffusers
     def test_pipeline_on_gpu(self, test_name: str, model_arch: str, provider: str):
         model_args = {"test_name": test_name, "model_arch": model_arch}
         self._setup(model_args)
 
-        height, width, batch_size = 32, 64, 1
+        height, width, batch_size = 32, 64, 2
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
 
-        pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[test_name], provider=provider)
+        pipeline = self.ORTMODEL_CLASS.from_pretrained(
+            self.onnx_model_dirs[test_name], provider=provider, use_io_binding=True
+        )
         self.assertEqual(pipeline.device.type, "cuda")
 
         outputs = pipeline(**inputs).images
@@ -706,20 +703,19 @@ class ORTPipelineForInpaintingTest(ORTModelTestMixin):
             }
         )
     )
-    @pytest.mark.rocm_ep_test
-    @pytest.mark.cuda_ep_test
-    @pytest.mark.trt_ep_test
     @require_torch_gpu
     @require_diffusers
     def test_pipeline_on_gpu(self, test_name: str, model_arch: str, provider: str):
         model_args = {"test_name": test_name, "model_arch": model_arch}
         self._setup(model_args)
 
-        height, width, batch_size = 32, 64, 1
+        height, width, batch_size = 32, 64, 2
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
 
-        pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[test_name], provider=provider)
-        self.assertEqual(pipeline.device, "cuda")
+        pipeline = self.ORTMODEL_CLASS.from_pretrained(
+            self.onnx_model_dirs[test_name], provider=provider, use_io_binding=True
+        )
+        self.assertEqual(pipeline.device.type, "cuda")
 
         outputs = pipeline(**inputs).images
         self.assertIsInstance(outputs, np.ndarray)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -2354,14 +2354,14 @@ class ORTModelForCausalLMIntegrationTest(ORTModelTestMixin):
         self.assertFalse(model.use_merged)
         self.assertTrue(model.use_cache)
         self.assertIsInstance(model.model, onnxruntime.InferenceSession)
-        self.assertEqual(model.onnx_paths[0].name, ONNX_DECODER_WITH_PAST_NAME)
+        self.assertEqual(model.model_path.name, ONNX_DECODER_WITH_PAST_NAME)
 
         model = ORTModelForCausalLM.from_pretrained("fxmarty/onnx-tiny-random-gpt2-with-merge")
 
         self.assertTrue(model.use_merged)
         self.assertTrue(model.use_cache)
         self.assertIsInstance(model.model, onnxruntime.InferenceSession)
-        self.assertEqual(model.onnx_paths[0].name, ONNX_DECODER_MERGED_NAME)
+        self.assertEqual(model.model_path.name, ONNX_DECODER_MERGED_NAME)
 
     def test_load_vanilla_transformers_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This is also my attempt to create a generalizable io binding framework, the idea is to always have `output_shapes = fn(input_shapes, known_shapes)` where `known_shapes` is mostly stuff we find in the config, we the use this information at runtime with a simple symbolic resolver, keeping the shape inference time minimal, to create output tensors in torch and thus accelerate inference without the need to pass by ort values / cupy / numpy.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
