### PR TITLE
Fix tests expected environment variable name

### DIFF
--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Test with pytest (in parallel)
         env:
-          FXMARTYCLONE_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+          HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
         working-directory: tests
         run: |
           pytest onnxruntime -m "not run_in_series" --durations=0 -vvvv -s -n auto

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -975,7 +975,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
 
         if token is None:
             self.skipTest(
-                "Test requires a read token for optimum-internal-testing in the environment variable `HF_HUB_READ_TOKEN`."
+                "Test requires a read access token for optimum-internal-testing in the environment variable `HF_HUB_READ_TOKEN`."
             )
 
         model = ORTModelForCustomTasks.from_pretrained(

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -979,7 +979,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
             )
 
         model = ORTModelForCustomTasks.from_pretrained(
-            "optimum-internal-testing/tiny-random-phi-private", token=token, export=True
+            "optimum-internal-testing/tiny-random-phi-private", revision="onnx", token=token
         )
 
         self.assertIsInstance(model.model, onnxruntime.InferenceSession)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -974,9 +974,13 @@ class ORTModelIntegrationTest(unittest.TestCase):
         token = os.environ.get("HF_HUB_READ_TOKEN", None)
 
         if token is None:
-            self.skipTest("Test requires a token for fxmartyclone in the environment variable `HF_HUB_READ_TOKEN`.")
+            self.skipTest(
+                "Test requires a read token for optimum-internal-testing in the environment variable `HF_HUB_READ_TOKEN`."
+            )
 
-        model = ORTModelForCustomTasks.from_pretrained("optimum-internal-testing/tiny-random-phi-private", token=token)
+        model = ORTModelForCustomTasks.from_pretrained(
+            "optimum-internal-testing/tiny-random-phi-private", token=token, export=True
+        )
 
         self.assertIsInstance(model.model, onnxruntime.InferenceSession)
         self.assertIsInstance(model.config, PretrainedConfig)


### PR DESCRIPTION
needed by `test_load_model_from_hub_private` which was previously always skipped https://github.com/huggingface/optimum/blob/9fd9ca5505e83f67c2a5e4c4f6f56d5fcf28442f/tests/onnxruntime/test_modeling.py#L974