### PR TITLE
better handle noninstalled libs error during model loading

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1384,7 +1384,6 @@ class TasksManager:
             except ModuleNotFoundError:
                 raise ValueError(f"`{library}` selected as model source, but `{library}` is not installed. Please install it.")
 
-
             return getattr(loaded_library, class_name)
         else:
             if framework == "pt":
@@ -2230,4 +2229,3 @@ class TasksManager:
             exporter_config_constructor = partial(exporter_config_constructor, **exporter_config_kwargs)
 
         return exporter_config_constructor
-


### PR DESCRIPTION
# What does this PR do?

I found an issue with loading models from extra-packages libraries (e.g. diffusers). TaskManager select and trying to load model even library is not installed in user environment and error message can be confusing for that case. This PR provides small improvement for this case.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@echarlaix, @IlyasMoutawwakil 