### PR TITLE
Export to ExecuTorch: Code Skeleton

### DIFF
--- a/optimum/commands/export/__init__.py
+++ b/optimum/commands/export/__init__.py
@@ -14,5 +14,6 @@
 
 
 from .base import ExportCommand
+from .executorch import ExecuTorchExportCommand
 from .onnx import ONNXExportCommand
 from .tflite import TFLiteExportCommand

--- a/optimum/commands/export/executorch.py
+++ b/optimum/commands/export/executorch.py
@@ -1,0 +1,54 @@
+"""Defines the command line for the export with ExecuTorch."""
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ...exporters import TasksManager
+from ..base import BaseOptimumCLICommand
+
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+def parse_args_executorch(parser):
+    required_group = parser.add_argument_group("Required arguments")
+    required_group.add_argument(
+        "-m", "--model", type=str, required=True, help="Model ID on huggingface.co or path on disk to load model from."
+    )
+    required_group.add_argument(
+        "output", type=Path, help="Path indicating the directory where to store the generated ExecuTorch model."
+    )
+
+    optional_group = parser.add_argument_group("Optional arguments")
+    optional_group.add_argument(
+        "--task",
+        default="auto",
+        help=(
+            "The task to export the model for. If not specified, the task will be auto-inferred based on the model. Available tasks depend on the model, but are among:"
+            f" {str(TasksManager.get_all_tasks())}. For decoder models, use `xxx-with-past` to export the model using past key values in the decoder."
+        ),
+    )
+    optional_group.add_argument(
+        "--recipe",
+        type=str,
+        default="xnnpack_fp32",
+        help='Pre-defined recipes for export to ExecuTorch. Defaults to "xnnpack_fp32".',
+    )
+
+
+class ExecuTorchExportCommand(BaseOptimumCLICommand):
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        return parse_args_executorch(parser)
+
+    def run(self):
+        from ...exporters.executorch import main_export
+
+        main_export(
+            model_name_or_path=self.args.model,
+            output=self.args.output,
+            task=self.args.task,
+            recipe=self.args.recipe,
+        )

--- a/optimum/executorchruntime/modeling_executorch.py
+++ b/optimum/executorchruntime/modeling_executorch.py
@@ -1,0 +1,158 @@
+"""ExecuTorchModelForXXX classes, allowing to run ExecuTorch Models with ExecuTorch Runtime using the same API as Transformers."""
+
+import logging
+import os
+import warnings
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+
+import torch
+from executorch.extension.pybindings.portable_lib import _load_for_executorch
+from huggingface_hub import hf_hub_download
+from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from huggingface_hub.utils import EntryNotFoundError
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    GenerationMixin,
+    AutoModelForCausalLM,
+    GenerationConfig,
+)
+from transformers.integrations.executorch import TorchExportableModuleWithStaticCache
+from transformers.modeling_outputs import (
+    BaseModelOutput,
+    CausalLMOutput,
+    CausalLMOutputWithPast,
+    ModelOutput,
+)
+
+from ..exporters import TasksManager
+from ..exporters.executorch import main_export
+from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExecuTorchModelForCausalLM(OptimizedModel):
+    """
+    ExecuTorch model with a causal language modeling head for ExecuTorch Runtime inference.
+    """
+
+    auto_model_class = AutoModelForCausalLM
+
+    def __init__(
+        self,
+        model: "ExecuTorchModule",  # Similar to ort.InferenceSession for ORTModel
+        config: "PretrainedConfig",
+    ):
+        super().__init__(model, config)
+        # TODO: Remove once figure out how make `ExecuTorchModule` inherit from `PreTrainedModel`
+        self.et_model = model
+
+    def forward(self, input_ids: torch.Tensor, cache_position: torch.Tensor) -> torch.Tensor:
+        return self.et_model.forward(input_ids, cache_position)[0]
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_dir_path: Union[str, Path],
+        task: str,
+        recipe: str,
+        config: "PretrainedConfig",
+        use_auth_token: Optional[Union[bool, str]] = None,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        subfolder: str = "",
+        local_files_only: bool = False,
+    ) -> "ExecuTorchModelForCausalLM":
+        if use_auth_token is not None:
+            warnings.warn(
+                "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
+                FutureWarning,
+            )
+            if token is not None:
+                raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
+            token = use_auth_token
+
+        full_path = os.path.join(f"{model_dir_path}", "model.pte")
+        model = _load_for_executorch(full_path)
+
+        return cls(
+            model=model,
+            config=config,
+        )
+
+    @classmethod
+    def _export(
+        cls,
+        model_id: str,
+        task: str,
+        recipe: str,
+        config: "PretrainedConfig",
+        use_auth_token: Optional[Union[bool, str]] = None,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        subfolder: str = "",
+        local_files_only: bool = False,
+        trust_remote_code: bool = False,
+    ):
+        if use_auth_token is not None:
+            warnings.warn(
+                "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
+                FutureWarning,
+            )
+            if token is not None:
+                raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
+            token = use_auth_token
+
+        save_dir = TemporaryDirectory()
+        save_dir_path = Path(save_dir.name)
+
+        # Export to ExecuTorch and save the pte file to the temporary directory
+        main_export(
+            model_name_or_path=model_id,
+            output=save_dir_path,
+            task=task,
+            recipe=recipe,
+            subfolder=subfolder,
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+            local_files_only=local_files_only,
+            force_download=force_download,
+            trust_remote_code=trust_remote_code,
+        )
+
+        return cls._from_pretrained(
+            model_dir_path=save_dir_path,
+            task=task,
+            recipe=recipe,
+            config=config,
+            use_auth_token=use_auth_token,
+            subfolder=subfolder,
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+            local_files_only=local_files_only,
+            force_download=force_download,
+        )
+
+    def generate(
+        self,
+        prompt_tokens: List[int],
+    ) -> List[int]:
+        """
+        Generate a sequence of token ids using the ExecuTorchModule.
+
+        `pipeline()` is where everything puts together. It consists of the tokenizer for encoding the inputs and decoding the model generated outputs.
+        """
+        pass

--- a/optimum/exporters/executorch/__main__.py
+++ b/optimum/exporters/executorch/__main__.py
@@ -1,0 +1,138 @@
+"""Entry point to the optimum.exporters.executorch command line."""
+
+import argparse
+import warnings
+from pathlib import Path
+
+from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from transformers import AutoConfig, AutoTokenizer
+from transformers.utils import is_torch_available
+
+from ...commands.export.executorch import parse_args_executorch
+from ...utils import logging
+from ..tasks import TasksManager
+from .convert import export_to_executorch
+from .task_registry import task_registry
+
+if is_torch_available():
+    import torch
+
+from typing import Optional, Union
+
+
+logger = logging.get_logger()
+
+
+def main_export(
+    model_name_or_path: str,
+    output: Union[str, Path],
+    task: str,
+    recipe: str = "xnnpack",
+    cache_dir: str = HUGGINGFACE_HUB_CACHE,
+    trust_remote_code: bool = False,
+    pad_token_id: Optional[int] = None,
+    subfolder: str = "",
+    revision: str = "main",
+    force_download: bool = False,
+    local_files_only: bool = False,
+    use_auth_token: Optional[Union[bool, str]] = None,
+    token: Optional[Union[bool, str]] = None,
+    **kwargs,
+):
+    """
+    Full-suite ExecuTorch export function, exporting **from a model ID on Hugging Face Hub or a local model repository**.
+
+    Args:
+        > Required parameters
+
+        model_name_or_path (`str`):
+            Model ID on huggingface.co or path on disk to the model repository to export. Example: `model_name_or_path="google/gemma-2b"` or `mode_name_or_path="/path/to/model_folder`.
+        output (`Union[str, Path]`):
+            Path indicating the directory where to store the generated ExecuTorch model.
+
+        > Optional parameters
+
+        task (`Optional[str]`, defaults to `None`):
+            The task to export the model for. If not specified, the task will be auto-inferred based on the model. For decoder models,
+            use `xxx-with-past` to export the model using past key values in the decoder.
+        recipe (`str`, defaults to `"xnnpack"`):
+            The recipe to use to do the export. Defaults to "xnnpack".
+        cache_dir (`Optional[str]`, defaults to `None`):
+            Path indicating where to store cache. The default Hugging Face cache path will be used by default.
+        trust_remote_code (`bool`, defaults to `False`):
+            Allows to use custom code for the modeling hosted in the model repository. This option should only be set for repositories
+            you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the
+            model repository.
+        pad_token_id (`Optional[int]`, defaults to `None`):
+            This is needed by some models, for some tasks. If not provided, will attempt to use the tokenizer to guess it.
+        subfolder (`str`, defaults to `""`):
+            In case the relevant files are located inside a subfolder of the model repo either locally or on huggingface.co, you can
+            specify the folder name here.
+        revision (`str`, defaults to `"main"`):
+            Revision is the specific model version to use. It can be a branch name, a tag name, or a commit id.
+        force_download (`bool`, defaults to `False`):
+            Whether or not to force the (re-)download of the model weights and configuration files, overriding the
+            cached versions if they exist.
+        local_files_only (`Optional[bool]`, defaults to `False`):
+            Whether or not to only look at local files (i.e., do not try to download the model).
+        use_auth_token (`Optional[Union[bool,str]]`, defaults to `None`):
+            Deprecated. Please use the `token` argument instead.
+        token (`Optional[Union[bool,str]]`, defaults to `None`):
+            The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+            when running `huggingface-cli login` (stored in `huggingface_hub.constants.HF_TOKEN_PATH`).
+
+    Example usage:
+    ```python
+    >>> from optimum.exporters.executorch import main_export
+
+    >>> main_export("gemma-2b", output="gemma-2b_onnx/")
+    ```
+    """
+
+    if use_auth_token is not None:
+        warnings.warn(
+            "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
+            FutureWarning,
+        )
+        if token is not None:
+            raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
+        token = use_auth_token
+
+    model = task_registry.get(task)(model_name_or_path, kwargs)
+
+    if task == "text-generation":
+        from transformers.integrations.executorch import TorchExportableModuleWithStaticCache
+
+        model = TorchExportableModuleWithStaticCache(model)
+
+    return export_to_executorch(
+        model=model,
+        task=task,
+        recipe=recipe,
+        output=output,
+        **kwargs,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser("Hugging Face Optimum ExecuTorch exporter")
+
+    parse_args_executorch(parser)
+
+    # Retrieve CLI arguments
+    args = parser.parse_args()
+
+    main_export(
+        model_name_or_path=args.model,
+        output=args.output,
+        task=args.task,
+        recipe=args.recipe,
+        cache_dir=args.cache_dir,
+        trust_remote_code=args.trust_remote_code,
+        pad_token_id=args.pad_token_id,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/optimum/exporters/executorch/causal_lm.py
+++ b/optimum/exporters/executorch/causal_lm.py
@@ -1,0 +1,28 @@
+from transformers import AutoModelForCausalLM, GenerationConfig
+from .task_registry import register_task
+
+
+@register_task("text-generation")
+def load_causal_lm_model(model_name_or_path: str, **kwargs):
+    device = "cpu"
+    dtype = torch.float32
+    cache_implementation = "static"
+    attn_implementation = "sdpa"
+    batch_size = 1
+    max_generation_length = kwargs.get("max_length", 256)
+
+    return AutoModelForCausalLM.from_pretrained(
+        model_name_or_path,
+        device_map=device,
+        torch_dtype=dtype,
+        attn_implementation=attn_implementation,
+        generation_config=GenerationConfig(
+            use_cache=True,
+            cache_implementation=cache_implementation,
+            max_length=max_generation_length,
+            cache_config={
+                "batch_size": batch_size,
+                "max_cache_len": max_generation_length,
+            },
+        ),
+    )

--- a/optimum/exporters/executorch/convert.py
+++ b/optimum/exporters/executorch/convert.py
@@ -1,0 +1,54 @@
+"""ExecuTorch model check and export functions."""
+
+import os
+from pathlib import Path
+from typing import Union
+
+from transformers.utils import is_torch_available
+
+from ...utils import (
+    TORCH_MINIMUM_VERSION,
+    check_if_transformers_greater,
+    is_diffusers_available,
+    logging,
+)
+from ..tasks import TasksManager
+from .recipe_registry import recipe_registry
+
+
+if is_torch_available():
+    import torch
+    from transformers.modeling_utils import PreTrainedModel
+
+
+def export_to_executorch(
+    model: Union["PreTrainedModel", "TorchExportableModuleWithStaticCache"],
+    task: str,
+    recipe: str,
+    output_dir: Union[str, Path],
+    **kwargs,
+):
+    """
+    Full-suite ExecuTorch export function, exporting **from a pre-trained PyTorch model**. This function is especially useful in case one needs to do modifications on the model, as overriding a forward call, before exporting to ExecuTorch.
+
+    Args:
+        model (`Union["PreTrainedModel", "TorchExportableModuleWithStaticCache"]`):
+            PyTorch model to export to ExecuTorch.
+        recipe (`str`, defaults to `"xnnpack"`):
+            The recipe to use to do the export. Defaults to "xnnpack".
+        output (`Union[str, Path]`):
+            Path indicating the directory where to store the generated ExecuTorch model.
+    """
+    try:
+        recipe_func = recipe_registry.get(recipe)
+    except KeyError as e:
+        raise RuntimeError(f"The recipe '{recipe}' isn't registered. Detailed error: {e}")
+
+    executorch_prog = recipe_func(model, task, kwargs)
+
+    full_path = os.path.join(f"{output_dir}", "model.pte")
+    with open(full_path, "wb") as f:
+        executorch_prog.write_to_file(f)
+        print(f"Saved exported program to {full_path}")
+
+    return executorch_prog

--- a/optimum/exporters/executorch/recipe_registry.py
+++ b/optimum/exporters/executorch/recipe_registry.py
@@ -1,0 +1,9 @@
+recipe_registry = {}
+
+
+def register_recipe(recipe_name):
+    def decorator(func):
+        recipe_registry[recipe_name] = func
+        return func
+
+    return decorator

--- a/optimum/exporters/executorch/task_registry.py
+++ b/optimum/exporters/executorch/task_registry.py
@@ -1,0 +1,9 @@
+task_registry = {}
+
+
+def register_task(recipe_name):
+    def decorator(func):
+        task_registry[recipe_name] = func
+        return func
+
+    return decorator

--- a/optimum/exporters/executorch/xnnpack.py
+++ b/optimum/exporters/executorch/xnnpack.py
@@ -1,0 +1,43 @@
+from typing import Union
+
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+import torch
+import torch.export._trace
+
+from .recipe_registry import register_recipe
+
+
+@register_recipe("xnnpack")
+def export_to_executorch_with_xnnpack(
+    model,
+    task: str,
+    **kwargs,
+):
+    if task == "text-generation":
+        example_input_ids = torch.tensor([[1]], dtype=torch.long)
+        example_cache_position = torch.tensor([0], dtype=torch.long)
+    else:
+        # TODO: Prepare model inputs for other tasks
+        raise ValueError(f"Unsupported task {task}.")
+
+    with torch.no_grad():
+        exported_program = torch.export._trace._export(
+            model,
+            args=(example_input_ids,),
+            kwargs={"cache_position": example_cache_position},
+            pre_dispatch=False,
+            strict=True,
+        )
+
+        return to_edge_transform_and_lower(
+            exported_program,
+            partitioner=[XnnpackPartitioner()],
+            compile_config=EdgeCompileConfig(
+                _skip_dim_order=True,
+            ),
+        ).to_executorch(config=ExecutorchBackendConfig(extract_delegate_segments=False))

--- a/optimum/pipelines/pipelines_base.py
+++ b/optimum/pipelines/pipelines_base.py
@@ -293,9 +293,28 @@ def load_ort_pipeline(
     return model, model_id, tokenizer, feature_extractor
 
 
+def load_executorch_pipeline(
+    model,
+    targeted_task,
+    load_tokenizer,
+    tokenizer,
+    feature_extractor,
+    load_feature_extractor,
+    SUPPORTED_TASKS,
+    subfolder: str = "",
+    token: Optional[Union[bool, str]] = None,
+    revision: str = "main",
+    model_kwargs: Optional[Dict[str, Any]] = None,
+    config: AutoConfig = None,
+    **kwargs,
+):
+    raise NotImplementedError("Executorch pipeline is not implemented yet.")
+
+
 MAPPING_LOADING_FUNC = {
     "ort": load_ort_pipeline,
     "bettertransformer": load_bettertransformer,
+    "executorch": load_executorch_pipeline,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,10 @@ EXTRAS_REQUIRE = {
         "datasets<=2.16",
         "transformers>=4.26,<4.38",
     ],
+    "exporters-executorch": [
+        "executorch>=0.4.0",
+        "transformers>=4.46",
+    ],
     "diffusers": ["diffusers"],
     "intel": "optimum-intel>=1.18.0",
     "openvino": "optimum-intel[openvino]>=1.18.0",


### PR DESCRIPTION
# What does this PR do?

This PR is the first initiative to create an e2e path for ["Export to ExecuTorch"](https://github.com/huggingface/transformers/issues/32253). 

In this very first revision, I'm focusing outline the skeleton of the integration work:

`./setup.py`: Specify new dependency in order to "Export to ExecuTorch". In this case, it's adding a new pip package `executorch`(Beta version) and require the latest released `transformfers` (models from older versions may not work with ExecuTorch)

### Env setup
`./optimum/commands/export/executorch.py|__init__.py`: To support running export with ExecuTorch backend via cli.

### Export AOT(Ahead-of-time)
`./optimum/exporters/executorch/`: Main entry point to export via ExecuTorch. 
```
optimum/exporters/executorch/
├── __main__.py
├── causal_lm.py
├── convert.py
├── recipe_registry.py
├── task_registry.py
└── xnnpack.py
```
 - It contains the `coverter.py` which defines the common workflow to export a `transformers` model from 🤗 to ExecuTorch. 
 - The export workflow can be called with different recipes (e.g. quantize and delegate to XNNPACK, Core ML, QNN, MPS, etc.). 
 - For each model that performs different tasks may require different patches, this is handled via registered tasks. For example, `CausalLM` w/ cache must be loaded with `generation_config` and exported via `transformers.integrations.executorch`.

### Run with exported ExecuTorch model
`optimum/executorchruntime/modeling_executorch.py` defines the python class that wrap the Transformers `AutoModelForXXX` classes. We start with `ExecuTorchModelForCausalLM` in this file, which inherits the base `OptimizedModel` and overrides all abstract methods. This is where the ExecuTorch pybinding and the runtime gets integrated. 

`optimum/pipelines/pipelines_base.py` defines a pipeline for ExecuTorch where everything is put together, deciding which model/task/recipe to load and run. It also consists of tokenizers that paired with the model for encoding/decoding.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@michaelbenayoun @echarlaix 

