### PR TITLE
🐛 Fix model kwargs handling in pipeline function

### DIFF
--- a/optimum/pipelines/pipelines_base.py
+++ b/optimum/pipelines/pipelines_base.py
@@ -309,7 +309,7 @@ def pipeline(
     accelerator: Optional[str] = "ort",
     revision: Optional[str] = None,
     trust_remote_code: Optional[bool] = None,
-    *model_kwargs,
+    model_kwargs: Optional[Dict[str, Any]] = None,  # Changed to explicit kwarg
     **kwargs,
 ) -> Pipeline:
     targeted_task = "translation" if task.startswith("translation") else task
@@ -367,6 +367,9 @@ def pipeline(
     else:
         load_feature_extractor = True
 
+    if model_kwargs is None:
+        model_kwargs = {}
+
     model, model_id, tokenizer, feature_extractor = MAPPING_LOADING_FUNC[accelerator](
         model,
         targeted_task,
@@ -378,7 +381,7 @@ def pipeline(
         config=config,
         hub_kwargs=hub_kwargs,
         token=token,
-        *model_kwargs,
+        model_kwargs=model_kwargs,
         **kwargs,
     )
 


### PR DESCRIPTION
Fixes how model-specific arguments are handled in the `pipeline()` function by replacing the problematic `*model_kwargs` positional argument with a proper `model_kwargs` keyword argument.

- [x] Bug
- [ ] Feature

## Changes

- Changed `*model_kwargs` to `model_kwargs: Optional[Dict[str, Any]] = None`
- Added initialization of empty dict when `model_kwargs` is None
- Properly forwarded model kwargs to loading functions

## Why?

The previous implementation using `*model_kwargs` as positional arguments could silently drop model-specific arguments, leading to unexpected behavior. This change ensures model arguments are properly passed through and provides better type safety and API clarity.