### PR TITLE
move check_dummy_inputs_allowed to common export utils

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -27,16 +27,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
-import onnx
 from transformers.utils import is_accelerate_available, is_torch_available
-
-from ...onnx import remove_duplicate_weights_from_tied_info
 
 
 if is_torch_available():
     import torch.nn as nn
 
-from ...onnx import merge_decoders
 from ...utils import (
     DEFAULT_DUMMY_SHAPES,
     DummyInputGenerator,
@@ -315,6 +311,8 @@ class OnnxConfig(ExportConfig, ABC):
 
         # We branch here to avoid doing an unnecessary forward pass.
         if to_fix:
+            import onnx
+
             if input_shapes is None:
                 input_shapes = {}
             dummy_inputs = self.generate_dummy_inputs(framework="np", **input_shapes)
@@ -542,6 +540,10 @@ class OnnxConfig(ExportConfig, ABC):
         first_key = next(iter(models_and_onnx_configs))
         if is_torch_available() and isinstance(models_and_onnx_configs[first_key][0], nn.Module):
             if is_accelerate_available():
+                import onnx
+
+                from ...onnx import remove_duplicate_weights_from_tied_info
+
                 logger.info("Deduplicating shared (tied) weights...")
                 for subpath, key in zip(onnx_files_subpaths, models_and_onnx_configs):
                     torch_model = models_and_onnx_configs[key][0]
@@ -934,6 +936,8 @@ class OnnxSeq2SeqConfigWithPast(OnnxConfigWithPast):
             decoder_with_past_path = Path(path, onnx_files_subpaths[2])
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")
             try:
+                from ...onnx import merge_decoders
+
                 # The decoder with past does not output the cross attention past key values as they are constant,
                 # hence the need for strict=False
                 merge_decoders(

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -311,8 +311,6 @@ class OnnxConfig(ExportConfig, ABC):
 
         # We branch here to avoid doing an unnecessary forward pass.
         if to_fix:
-            import onnx
-
             if input_shapes is None:
                 input_shapes = {}
             dummy_inputs = self.generate_dummy_inputs(framework="np", **input_shapes)

--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -50,6 +50,8 @@ from .constants import ONNX_DECODER_MERGED_NAME, ONNX_DECODER_NAME, ONNX_DECODER
 from .model_patcher import ModelPatcher, Seq2SeqModelPatcher
 
 
+# TODO : moved back onnx imports applied in https://github.com/huggingface/optimum/pull/2114/files after refactorization
+
 if is_accelerate_available():
     from accelerate.utils import find_tied_parameters
 

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -19,8 +19,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from transformers.utils import is_tf_available
-
-from ...onnx import merge_decoders
 from ...utils import (
     DummyAudioInputGenerator,
     DummyBboxInputGenerator,
@@ -129,6 +127,7 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
 
         # Attempt to merge only if the decoder-only was exported separately without/with past
         if self.use_past is True and len(models_and_onnx_configs) == 2:
+            from ...onnx import merge_decoders
             decoder_path = Path(path, onnx_files_subpaths[0])
             decoder_with_past_path = Path(path, onnx_files_subpaths[1])
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from transformers.utils import is_tf_available
+
 from ...utils import (
     DummyAudioInputGenerator,
     DummyBboxInputGenerator,
@@ -128,6 +129,7 @@ class TextDecoderOnnxConfig(OnnxConfigWithPast):
         # Attempt to merge only if the decoder-only was exported separately without/with past
         if self.use_past is True and len(models_and_onnx_configs) == 2:
             from ...onnx import merge_decoders
+
             decoder_path = Path(path, onnx_files_subpaths[0])
             decoder_with_past_path = Path(path, onnx_files_subpaths[1])
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")

--- a/optimum/exporters/onnx/config.py
+++ b/optimum/exporters/onnx/config.py
@@ -37,6 +37,9 @@ from .constants import ONNX_DECODER_MERGED_NAME, ONNX_DECODER_NAME, ONNX_DECODER
 from .model_patcher import DecoderModelPatcher
 
 
+# TODO : moved back onnx imports applied in https://github.com/huggingface/optimum/pull/2114/files after refactorization
+
+
 if TYPE_CHECKING:
     from transformers import PretrainedConfig, PreTrainedModel
 

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -57,6 +57,8 @@ from .utils import (
 )
 
 
+# TODO : moved back onnx imports applied in https://github.com/huggingface/optimum/pull/2114/files after refactorization
+
 if is_torch_available():
     import torch
     import torch.nn as nn

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -22,7 +22,7 @@ import traceback
 from inspect import signature
 from itertools import chain
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import onnx
@@ -45,6 +45,7 @@ from ...utils.modeling_utils import MODEL_TO_PATCH_FOR_PAST
 from ...utils.save_utils import maybe_save_preprocessors
 from ..error_utils import AtolError, MinimumVersionError, OutputMatchError, ShapeError
 from ..tasks import TasksManager
+from ..utils import check_dummy_inputs_are_allowed
 from .base import OnnxConfig
 from .constants import UNPICKABLE_ARCHS
 from .model_configs import SpeechT5OnnxConfig
@@ -73,30 +74,6 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 class DynamicAxisNameError(ValueError):
     pass
-
-
-def check_dummy_inputs_are_allowed(
-    model: Union["PreTrainedModel", "TFPreTrainedModel", "ModelMixin"], dummy_input_names: Iterable[str]
-):
-    """
-    Checks that the dummy inputs from the ONNX config is a subset of the allowed inputs for `model`.
-    Args:
-        model (`Union[transformers.PreTrainedModel, transformers.TFPreTrainedModel`]):
-            The model instance.
-        model_inputs (`Iterable[str]`):
-            The model input names.
-    """
-
-    forward = model.forward if is_torch_available() and isinstance(model, nn.Module) else model.call
-    forward_parameters = signature(forward).parameters
-    forward_inputs_set = set(forward_parameters.keys())
-    dummy_input_names = set(dummy_input_names)
-
-    # We are fine if config_inputs has more keys than model_inputs
-    if not dummy_input_names.issubset(forward_inputs_set):
-        raise ValueError(
-            f"Config dummy inputs are not a subset of the model inputs: {dummy_input_names} vs {forward_inputs_set}"
-        )
 
 
 def validate_models_outputs(

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -1875,6 +1875,7 @@ class MusicgenOnnxConfig(OnnxSeq2SeqConfigWithPast):
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")
             try:
                 from ...onnx import merge_decoders
+
                 # The decoder with past does not output the cross attention past key values as they are constant,
                 # hence the need for strict=False
                 merge_decoders(

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Uni
 from packaging import version
 from transformers.utils import is_tf_available
 
-from ...onnx import merge_decoders
 from ...utils import (
     DEFAULT_DUMMY_SHAPES,
     BloomDummyPastKeyValuesGenerator,
@@ -1875,6 +1874,7 @@ class MusicgenOnnxConfig(OnnxSeq2SeqConfigWithPast):
             decoder_with_past_path = Path(path, onnx_files_subpaths[3])
             decoder_merged_path = Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")
             try:
+                from ...onnx import merge_decoders
                 # The decoder with past does not output the cross attention past key values as they are constant,
                 # hence the need for strict=False
                 merge_decoders(

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -92,6 +92,9 @@ from .model_patcher import (
 )
 
 
+# TODO : moved back onnx imports applied in https://github.com/huggingface/optimum/pull/2114/files after refactorization
+
+
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
     from transformers.modeling_utils import PreTrainedModel

--- a/optimum/exporters/utils.py
+++ b/optimum/exporters/utils.py
@@ -690,7 +690,7 @@ def check_dummy_inputs_are_allowed(
             The model input names.
     """
 
-    forward = model.forward if is_torch_available() and isinstance(model, nn.Module) else model.call
+    forward = model.forward if is_torch_available() and isinstance(model, torch.nn.Module) else model.call
     forward_parameters = signature(forward).parameters
     forward_inputs_set = set(forward_parameters.keys())
     dummy_input_names = set(dummy_input_names)


### PR DESCRIPTION
# What does this PR do?

`check_dummy_inputs_allowed` is helpful function for any optimum that involves pytorch models conversion (e.g. openvino). Current place of it import trigger initialization of full onnx configuration for other backends that wish to reuse it and it may lead to some troubles with resolving dependencies. I suggest to move it to common utilities for avoiding unexpected errors like represented bellow:

Example of logs (issue visible on windows with onnx>1.16.2 and related to https://github.com/onnx/onnx/issues/6267):
```
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\intel\openvino\__init__.py", line 51, in <module>
    from .quantization import OVQuantizer
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\intel\openvino\quantization.py", line 47, in <module>
    from optimum.exporters.onnx.convert import check_dummy_inputs_are_allowed
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\exporters\__init__.py", line 16, in <module>
    from .tasks import TasksManager  # noqa
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\exporters\tasks.py", line 173, in <module>
    class TasksManager:
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\exporters\tasks.py", line 338, in TasksManager
    "clip-text-model": supported_tasks_mapping(
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\exporters\tasks.py", line 117, in supported_tasks_mapping
    importlib.import_module(f"optimum.exporters.{backend}.model_configs"), config_cls_name
  File "C:\Users\chuquanc\packages\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\optimum\exporters\onnx\model_configs.py", line 23, in <module>
    from ...onnx import merge_decoders
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\transformers\utils\import_utils.py", line 1766, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "C:\Users\chuquanc\openvino\py310\lib\site-packages\transformers\utils\import_utils.py", line 1780, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import optimum.onnx.graph_transformations because of the following error (look up to see its traceback):
DLL load failed while importing onnx_cpp2py_export: A dynamic link library (DLL) initialization routine failed.
```
workaround for this problem also proposed on optimum-intel side https://github.com/huggingface/optimum-intel/pull/1048