### PR TITLE
Allow sending directly torch/tf/np dtype for generating dummy inputs

### DIFF
--- a/optimum/exporters/onnx/base.py
+++ b/optimum/exporters/onnx/base.py
@@ -73,6 +73,8 @@ GENERATE_DUMMY_DOCSTRING = r"""
         Generates the dummy inputs necessary for tracing the model. If not explicitely specified, default input shapes are used.
 
         Args:
+            framework (`str`, defaults to `"pt"`):
+                The framework for which to create the dummy inputs.
             batch_size (`int`, defaults to {batch_size}):
                 The batch size to use in the dummy inputs.
             sequence_length (`int`, defaults to {sequence_length}):

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1790,7 +1790,7 @@ class TasksManager:
                 cache_dir=cache_dir,
                 token=token,
             )
-        elif type(model) == type:
+        elif isinstance(model, type):
             inferred_task_name = cls._infer_task_from_model_or_model_class(model_class=model)
         else:
             inferred_task_name = cls._infer_task_from_model_or_model_class(model=model)
@@ -1944,7 +1944,7 @@ class TasksManager:
                 cache_dir=cache_dir,
                 token=token,
             )
-        elif type(model) == type:
+        elif isinstance(model, type):
             library_name = cls._infer_library_from_model_or_model_class(model_class=model)
         else:
             library_name = cls._infer_library_from_model_or_model_class(model=model)

--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -110,9 +110,9 @@ class OnnxRuntimeRun(Run):
         model_class = FeaturesManager.get_model_class_for_feature(get_autoclass_name(self.task))
         self.torch_model = model_class.from_pretrained(run_config["model_name_or_path"])
 
-        self.return_body[
-            "model_type"
-        ] = self.torch_model.config.model_type  # return_body is initialized in parent class
+        self.return_body["model_type"] = (
+            self.torch_model.config.model_type
+        )  # return_body is initialized in parent class
 
     def _launch_time(self, trial):
         batch_size = trial.suggest_categorical("batch_size", self.batch_sizes)

--- a/optimum/onnxruntime/runs/__init__.py
+++ b/optimum/onnxruntime/runs/__init__.py
@@ -110,9 +110,9 @@ class OnnxRuntimeRun(Run):
         model_class = FeaturesManager.get_model_class_for_feature(get_autoclass_name(self.task))
         self.torch_model = model_class.from_pretrained(run_config["model_name_or_path"])
 
-        self.return_body["model_type"] = (
-            self.torch_model.config.model_type
-        )  # return_body is initialized in parent class
+        self.return_body[
+            "model_type"
+        ] = self.torch_model.config.model_type  # return_body is initialized in parent class
 
     def _launch_time(self, trial):
         batch_size = trial.suggest_categorical("batch_size", self.batch_sizes)

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -672,7 +672,7 @@ class DummySeq2SeqDecoderTextInputGenerator(DummyDecoderTextInputGenerator):
                 None,
             )
 
-        return super().generate(input_name, framework=framework, int_dtype=int_dtype)
+        return super().generate(input_name, int_dtype=int_dtype, float_dtype=float_dtype, framework=framework)
 
 
 class DummyPastKeyValuesGenerator(DummyInputGenerator):
@@ -1670,7 +1670,7 @@ class DummyTransformerTimestepInputGenerator(DummyTimestepInputGenerator):
             shape = [self.batch_size]  # With transformer diffusers, timestep is a 1D tensor
             return self.random_float_tensor(shape, max_value=self.vocab_size, framework=framework, dtype=float_dtype)
 
-        return super().generate(input_name, framework, int_dtype, float_dtype)
+        return super().generate(input_name, int_dtype=int_dtype, float_dtype=float_dtype, framework=framework)
 
 
 class DummyTransformerVisionInputGenerator(DummyVisionInputGenerator):
@@ -1691,14 +1691,14 @@ class DummyTransformerTextInputGenerator(DummySeq2SeqDecoderTextInputGenerator):
         framework: Optional[str] = None,
     ):
         if input_name == "encoder_hidden_states":
-            return super().generate(input_name, framework, int_dtype, float_dtype)[0]
+            return super().generate(input_name, int_dtype=int_dtype, float_dtype=float_dtype, framework=framework)[0]
 
         elif input_name == "pooled_projections":
             return self.random_float_tensor(
                 [self.batch_size, self.normalized_config.projection_size], framework=framework, dtype=float_dtype
             )
 
-        return super().generate(input_name, framework, int_dtype, float_dtype)
+        return super().generate(input_name, int_dtype=int_dtype, float_dtype=float_dtype, framework=framework)
 
 
 class DummyFluxTransformerVisionInputGenerator(DummyTransformerVisionInputGenerator):
@@ -1725,7 +1725,7 @@ class DummyFluxTransformerVisionInputGenerator(DummyTransformerVisionInputGenera
             )
             return self.random_int_tensor(shape, max_value=1, framework=framework, dtype=int_dtype)
 
-        return super().generate(input_name, framework, int_dtype, float_dtype)
+        return super().generate(input_name, int_dtype=int_dtype, float_dtype=float_dtype, framework=framework)
 
 
 class DummyFluxTransformerTextInputGenerator(DummyTransformerTextInputGenerator):
@@ -1754,4 +1754,4 @@ class DummyFluxTransformerTextInputGenerator(DummyTransformerTextInputGenerator)
             shape = [self.batch_size]
             return self.random_float_tensor(shape, min_value=0, max_value=1, framework=framework, dtype=float_dtype)
 
-        return super().generate(input_name, framework, int_dtype, float_dtype)
+        return super().generate(input_name, int_dtype=int_dtype, float_dtype=float_dtype, framework=framework)

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -338,7 +338,8 @@ class DummyInputGenerator(ABC):
             raise RuntimeError(f"Could not infer the framework from {input_}")
         return framework
 
-    def _get_default_int_dtype(self):
+    @staticmethod
+    def _get_default_int_dtype():
         "Default to int64 of available framework."
         if is_torch_available():
             return torch.int64
@@ -347,7 +348,8 @@ class DummyInputGenerator(ABC):
         else:
             return np.int64
 
-    def _get_default_float_dtype(self):
+    @staticmethod
+    def _get_default_float_dtype():
         "Default to float32 of available framework."
         if is_torch_available():
             return torch.float32

--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -174,7 +174,7 @@ class DummyInputGenerator(ABC):
                 "The `framework` argument is deprecated and will be removed soon. Please use the `dtype` argument instead to indicate the framework.",
                 FutureWarning,
             )
-        dtype = DummyInputGenerator._set_default_int_dtype() if dtype is None else dtype
+        dtype = DummyInputGenerator._get_default_int_dtype() if dtype is None else dtype
         framework = DummyInputGenerator.infer_framework_from_dtype(dtype)
         if framework == "pt":
             return torch.randint(low=min_value, high=max_value, size=shape, dtype=dtype)
@@ -213,7 +213,7 @@ class DummyInputGenerator(ABC):
             )
         shape = tuple(shape)
         mask_length = random.randint(1, shape[-1] - 1)
-        dtype = DummyInputGenerator._set_default_int_dtype() if dtype is None else dtype
+        dtype = DummyInputGenerator._get_default_int_dtype() if dtype is None else dtype
         framework = DummyInputGenerator.infer_framework_from_dtype(dtype)
         if framework == "pt":
             mask_tensor = torch.cat(
@@ -278,7 +278,7 @@ class DummyInputGenerator(ABC):
                 "The `framework` argument is deprecated and will be removed soon. Please use the `dtype` argument instead to indicate the framework.",
                 FutureWarning,
             )
-        dtype = DummyInputGenerator._set_default_float_dtype() if dtype is None else dtype
+        dtype = DummyInputGenerator._get_default_float_dtype() if dtype is None else dtype
         framework = DummyInputGenerator.infer_framework_from_dtype(dtype)
         if framework == "pt":
             tensor = torch.empty(shape, dtype=dtype).uniform_(min_value, max_value)
@@ -316,7 +316,7 @@ class DummyInputGenerator(ABC):
                 "The `framework` argument is deprecated and will be removed soon. Please use the `dtype` argument instead to indicate the framework.",
                 FutureWarning,
             )
-        dtype = DummyInputGenerator._set_default_int_dtype() if dtype is None else dtype
+        dtype = DummyInputGenerator._get_default_int_dtype() if dtype is None else dtype
         framework = DummyInputGenerator.infer_framework_from_dtype(dtype) or framework
         if framework == "pt":
             return torch.full(shape, value, dtype=dtype)
@@ -338,8 +338,7 @@ class DummyInputGenerator(ABC):
             raise RuntimeError(f"Could not infer the framework from {input_}")
         return framework
 
-    @staticmethod
-    def _set_default_int_dtype():
+    def _get_default_int_dtype(self):
         "Default to int64 of available framework."
         if is_torch_available():
             return torch.int64
@@ -348,15 +347,14 @@ class DummyInputGenerator(ABC):
         else:
             return np.int64
 
-    @staticmethod
-    def _set_default_float_dtype():
+    def _get_default_float_dtype(self):
         "Default to float32 of available framework."
         if is_torch_available():
-            return torch.int64
+            return torch.float32
         elif is_tf_available():
-            return tf.int64
+            return tf.float32
         else:
-            return np.int64
+            return np.float32
 
     @staticmethod
     def infer_framework_from_dtype(dtype):


### PR DESCRIPTION
# What does this PR do?

Currently always via git push `DTYPE_MAPPER`:

https://github.com/huggingface/optimum/blob/4a7cb298140ee9bed968d98a780a950d15bb2935/optimum/utils/input_generators.py#L73

It would be nice to directly accept the different dtypes of frameworks. Eg. I could load a model in `torch.bfloat16` in this case, I would like to define the dummy inputs dtype with `model.dtype` instead of going through a reversed dict of the `DTYPE_MAPPER`. 

