### PR TITLE
Remove CI macos runners

### DIFF
--- a/.github/workflows/test_bettertransformer.yml
+++ b/.github/workflows/test_bettertransformer.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04, macos-14]
+        os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         transformers-version: ["latest"]
-        os: [ubuntu-20.04, windows-2019, macos-15]
+        os: [ubuntu-20.04, windows-2019] # TODO : add macos-15 after mps fix
         include:
           - transformers-version: "4.36.*"
             os: ubuntu-20.04


### PR DESCRIPTION
https://github.com/huggingface/optimum/pull/2119#issuecomment-2538755578

Tests failing coming from mps not supported by arm64 macOS runners https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#limitations-for-arm64-macos-runners and from mps being now set default when device not specified and mps backend available since transformers v4.47 and [huggingface/transformers#34026](https://github.com/huggingface/transformers/pull/34026/files). Issue not related to optimum so merging to not block transformers v4.47 support