### PR TITLE
Skip private model loading for external contributors

### DIFF
--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -974,7 +974,7 @@ class ORTModelIntegrationTest(unittest.TestCase):
     def test_load_model_from_hub_private(self):
         token = os.environ.get("HF_HUB_READ_TOKEN", None)
 
-        if token is None:
+        if not token:
             self.skipTest(
                 "Test requires a read access token for optimum-internal-testing in the environment variable `HF_HUB_READ_TOKEN`."
             )


### PR DESCRIPTION
https://github.com/huggingface/optimum/actions/runs/12406440330/job/34639615964?pr=2114

```
FAILED tests/onnxruntime/test_modeling.py::ORTModelIntegrationTest::test_load_model_from_hub_private - huggingface_hub.errors.RepositoryNotFoundError: 401 Client Error. (Request ID: Root=1-6763cff5-38ad3a1d75a3598d6b742f30;13c34049-a28a-43d1-a22b-e79829428ccf)

Repository Not Found for url: https://huggingface.co/api/models/optimum-internal-testing/tiny-random-phi-private/tree/onnx?recursive=True&expand=False.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
Invalid username or password.
```