### PR TITLE
fix sdxl refiner export

### DIFF
--- a/optimum/exporters/utils.py
+++ b/optimum/exporters/utils.py
@@ -139,7 +139,11 @@ def _get_submodels_for_export_diffusion(
         # https://github.com/huggingface/diffusers/blob/v0.18.2/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py#L571
         unet.config.requires_aesthetics_score = getattr(pipeline.config, "requires_aesthetics_score", False)
         unet.config.time_cond_proj_dim = getattr(pipeline.unet.config, "time_cond_proj_dim", None)
-        unet.config.text_encoder_projection_dim = pipeline.text_encoder.config.projection_dim
+        unet.config.text_encoder_projection_dim = (
+            pipeline.text_encoder.config.projection_dim
+            if not is_sdxl
+            else pipeline.text_encoder_2.config.projection_dim
+        )
         unet.config.export_model_type = _get_diffusers_submodel_type(unet)
         models_for_export["unet"] = unet
 


### PR DESCRIPTION
# What does this PR do?

after some refactoring export part, sdxl-refiner model become broken for exporting.
https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0
This model does not have text_encoder and only text_encoder_2, now export failed with AtributeError: 'NoneType' object has no attribute 'config'

see for reference https://github.com/huggingface/optimum-intel/actions/runs/12426942003/job/34696091118?pr=1085