### PR TITLE
fix device check

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -519,7 +519,7 @@ class GPTQQuantizer(object):
         blocks = recurse_getattr(model, self.block_name_to_quantize)
 
         cur_layer_device = get_device(blocks[0])
-        if not is_gptqmodel_available():
+        if not is_gptqmodel_available() and cur_layer_device.type == "cpu":
             cur_layer_device = 0
 
         if not has_device_map:
@@ -591,7 +591,7 @@ class GPTQQuantizer(object):
                 block = block.to(0)
             layers = get_layers(block)
             block_device = get_device(block)
-            if not is_gptqmodel_available():
+            if not is_gptqmodel_available() and block_device.type == "cpu":
                 block_device = 0
             if isinstance(self.modules_in_block_to_quantize, list) and len(self.modules_in_block_to_quantize) > 0:
                 if self.true_sequential:


### PR DESCRIPTION
A small fix for the device map. We should only assign the device to 0 when it detects the device is CPU. Otherwise, it will break the device_map="auto".
With this change, we could pass the device map check of transformers gptq test. See [here](https://github.com/huggingface/transformers/pull/35012/)

Hi @IlyasMoutawwakil . Please trigger the CI and review the tiny change. Thanks!