### PR TITLE
Fix AutoModel can't load gptq model due to module prefix mismatch vs AutoModelForCausalLM

### DIFF
--- a/optimum/gptq/constants.py
+++ b/optimum/gptq/constants.py
@@ -18,7 +18,7 @@ BLOCK_PATTERNS = [
     "model.decoder.layers",
     "gpt_neox.layers",
     "model.layers",
-    # Models loaded by AutoModel have different block prefixes than models loaded by AutoModelForCausalLM, need to match it
+    # modules loaded by AutoModel vs AutoModelForCausalLM have different prefixes
     "h",
     "decoder.layers",
     "layers",

--- a/optimum/gptq/constants.py
+++ b/optimum/gptq/constants.py
@@ -18,7 +18,7 @@ BLOCK_PATTERNS = [
     "model.decoder.layers",
     "gpt_neox.layers",
     "model.layers",
-    # Models loaded by AutoModel have different prefixes than models loaded by AutoModelForCausalLM, need to match it
+    # Models loaded by AutoModel have different block prefixes than models loaded by AutoModelForCausalLM, need to match it
     "h",
     "decoder.layers",
     "layers",

--- a/optimum/gptq/constants.py
+++ b/optimum/gptq/constants.py
@@ -18,6 +18,10 @@ BLOCK_PATTERNS = [
     "model.decoder.layers",
     "gpt_neox.layers",
     "model.layers",
+    # Models loaded by AutoModel have different prefixes than models loaded by AutoModelForCausalLM, need to match it
+    "h",
+    "decoder.layers",
+    "layers",
 ]
 
 GPTQ_CONFIG = "quantize_config.json"

--- a/optimum/gptq/utils.py
+++ b/optimum/gptq/utils.py
@@ -72,7 +72,7 @@ def get_block_name_with_pattern(model: nn.Module):
     modules_names = [n for n, _ in model.named_modules()]
     for pattern_candidate in BLOCK_PATTERNS:
         pattern_candidate = pattern_candidate
-        if any(pattern_candidate in name for name in modules_names):
+        if any(name.startswith(pattern_candidate) for name in modules_names):
             return pattern_candidate
     raise ValueError("Block pattern could not be match. Pass `block_name_to_quantize` argument in `quantize_model`")
 


### PR DESCRIPTION
# What does this PR do?
This PR fixes the issue encountered when using AutoModel to load the GPTQ model, which caused this error:
```
Traceback (most recent call last):
  File "/root/GPTQModel/test_inf.py", line 5, in <module>
    model = AutoModel.from_pretrained(model_id, revision="main")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/auto/auto_factory.py", line 565, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/modeling_utils.py", line 4090, in from_pretrained
    hf_quantizer.preprocess_model(
  File "/root/transformers/src/transformers/quantizers/base.py", line 194, in preprocess_model
    return self._process_model_before_weight_loading(model, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/quantizers/quantizer_gptq.py", line 84, in _process_model_before_weight_loading
    model = self.optimum_quantizer.convert_model(model)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/optimum/optimum/gptq/quantizer.py", line 292, in convert_model
    self.block_name_to_quantize = get_block_name_with_pattern(model)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/optimum/optimum/gptq/utils.py", line 79, in get_block_name_with_pattern
    raise ValueError("Block pattern could not be match. Pass `block_name_to_quantize` argument in `quantize_model`")
ValueError: Block pattern could not be match. Pass `block_name_to_quantize` argument in `quantize_model`
```


The reason for this error is models loaded by AutoModel have different block prefixes than models loaded by AutoModelForCausalLM. For example, in the Llama model, the modules after loading with AutoModel are `'layers.0.self_attn.q_proj', 'layers.0.self_attn.k_proj', 'layers.0.self_attn.v_proj', etc`. In the AutoModelForCausalLM, the modules after loading are `'model.layers.0.self_attn.q_proj', 'model.layers.0.self_attn.k_proj', 'model.layers.0.self_attn.v_proj', etc`. They have different prefixes, but they correspond to the same module.

## Who can review?
@Qubitium  @SunMarc
