### PR TITLE
fix infer task from model_name if model from sentence transformer

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -256,7 +256,7 @@ def main_export(
 
     if task == "auto":
         try:
-            task = TasksManager.infer_task_from_model(model_name_or_path)
+            task = TasksManager.infer_task_from_model(model_name_or_path, library_name=library_name)
         except KeyError as e:
             raise KeyError(
                 f"The task could not be automatically inferred. Please provide the argument --task with the relevant task from {', '.join(TasksManager.get_all_tasks())}. Detailed error: {e}"

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1856,6 +1856,7 @@ class TasksManager:
         revision: Optional[str] = None,
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         token: Optional[Union[bool, str]] = None,
+        library_name: Optional[str] = None,
     ) -> str:
         """
         Infers the task from the model repo, model instance, or model class.
@@ -1874,7 +1875,9 @@ class TasksManager:
             token (`Optional[Union[bool,str]]`, defaults to `None`):
                 The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
                 when running `huggingface-cli login` (stored in `huggingface_hub.constants.HF_TOKEN_PATH`).
-
+            library_name (`Optional[str]`, defaults to `None`):
+                The library name of the model. Can be any of "transformers", "timm", "diffusers", "sentence_transformers". See `TasksManager.infer_library_from_model` for the priority should
+                none be provided.
         Returns:
             `str`: The task name automatically detected from the HF hub repo, model instance, or model class.
         """
@@ -1887,6 +1890,7 @@ class TasksManager:
                 revision=revision,
                 cache_dir=cache_dir,
                 token=token,
+                library_name=library_name,
             )
         elif type(model) == type:
             inferred_task_name = cls._infer_task_from_model_or_model_class(model_class=model)
@@ -2162,6 +2166,9 @@ class TasksManager:
                 none be provided.
             model_kwargs (`Dict[str, Any]`, *optional*):
                 Keyword arguments to pass to the model `.from_pretrained()` method.
+            library_name (`Optional[str]`, defaults to `None`):
+                The library name of the model. Can be any of "transformers", "timm", "diffusers", "sentence_transformers". See `TasksManager.infer_library_from_model` for the priority should
+                none be provided.
 
         Returns:
             The instance of the model.
@@ -2181,7 +2188,12 @@ class TasksManager:
         original_task = task
         if task == "auto":
             task = TasksManager.infer_task_from_model(
-                model_name_or_path, subfolder=subfolder, revision=revision, cache_dir=cache_dir, token=token
+                model_name_or_path,
+                subfolder=subfolder,
+                revision=revision,
+                cache_dir=cache_dir,
+                token=token,
+                library_name=library_name,
             )
 
         model_type = None

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1770,6 +1770,7 @@ class TasksManager:
         revision: Optional[str] = None,
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         token: Optional[Union[bool, str]] = None,
+        library_name: Optional[str] = None,
     ) -> str:
         inferred_task_name = None
 
@@ -1791,13 +1792,14 @@ class TasksManager:
                 raise RuntimeError(
                     f"Hugging Face Hub is not reachable and we cannot infer the task from a cached model. Make sure you are not offline, or otherwise please specify the `task` (or `--task` in command-line) argument ({', '.join(TasksManager.get_all_tasks())})."
                 )
-            library_name = cls.infer_library_from_model(
-                model_name_or_path,
-                subfolder=subfolder,
-                revision=revision,
-                cache_dir=cache_dir,
-                token=token,
-            )
+            if library_name is None:
+                library_name = cls.infer_library_from_model(
+                    model_name_or_path,
+                    subfolder=subfolder,
+                    revision=revision,
+                    cache_dir=cache_dir,
+                    token=token,
+                )
 
             if library_name == "timm":
                 inferred_task_name = "image-classification"
@@ -1816,6 +1818,8 @@ class TasksManager:
                                     break
                             if inferred_task_name is not None:
                                 break
+            elif library_name == "sentence_transformers":
+                inferred_task_name = "feature-extraction"
             elif library_name == "transformers":
                 pipeline_tag = model_info.pipeline_tag
                 transformers_info = model_info.transformersInfo

--- a/optimum/exporters/tflite/__main__.py
+++ b/optimum/exporters/tflite/__main__.py
@@ -46,7 +46,7 @@ def main():
     task = args.task
     if task == "auto":
         try:
-            task = TasksManager.infer_task_from_model(args.model)
+            task = TasksManager.infer_task_from_model(args.model, library_name="transformers")
         except KeyError as e:
             raise KeyError(
                 "The task could not be automatically inferred. Please provide the argument --task with the task "
@@ -58,7 +58,12 @@ def main():
             )
 
     model = TasksManager.get_model_from_task(
-        task, args.model, framework="tf", cache_dir=args.cache_dir, trust_remote_code=args.trust_remote_code
+        task,
+        args.model,
+        framework="tf",
+        cache_dir=args.cache_dir,
+        trust_remote_code=args.trust_remote_code,
+        library_name="transformers",
     )
 
     tflite_config_constructor = TasksManager.get_exporter_config_constructor(

--- a/optimum/exporters/tflite/convert.py
+++ b/optimum/exporters/tflite/convert.py
@@ -194,7 +194,7 @@ def prepare_converter_for_quantization(
         if task is None:
             from ...exporters import TasksManager
 
-            task = TasksManager.infer_task_from_model(model)
+            task = TasksManager.infer_task_from_model(model, library_name="transformers")
 
         preprocessor_kwargs = {}
         if isinstance(preprocessor, PreTrainedTokenizerBase):


### PR DESCRIPTION
# What does this PR do?
issue found during attempt to export https://huggingface.co/BAAI/bge-small-zh-v1.5 via optimum-intel without --task specification
The root cause is infer_library_from_model detects task as sentence-transformers even if --library transformers selected in cli and there is no additional condition for specification task for sentence transformers, as the result method raises error
```
KeyError: "The task could not be automatically inferred. Please provide the argument --task with the relevant task from image-text-to-text, audio-classification, zero-shot-image-classification, masked-im, audio-xvector, image-to-text, audio-frame-classification, depth-estimation, visual-question-answering, semantic-segmentation, image-to-image, image-classification, feature-extraction, image-segmentation, inpainting, sentence-similarity, object-detection, automatic-speech-recognition, multiple-choice, text-classification, fill-mask, text-generation, zero-shot-object-detection, text-to-image, reinforcement-learning, text2text-generation, token-classification, question-answering, mask-generation, text-to-audio. Detailed error: 'Could not find the proper task name for the model BAAI/bge-small-zh-v1.5.'
```

provided default task for sentence-transformers and added mechanism to explicitly set library_name (in case if user force --library_name in cli, need additional changes for enabling this behaviour in optimum-intel and other integrations that allow to select library_name) for avoiding mismatch between auto-detected and selected library (sentence transformers model can be exported with both transformers and sentence transformers library name and export configuration and exported model may be different for this case)