### PR TITLE
avoid library_name guessing if it is known in parameters standartization

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -2067,7 +2067,11 @@ class TasksManager:
         return library_name
 
     @classmethod
-    def standardize_model_attributes(cls, model: Union["PreTrainedModel", "TFPreTrainedModel", "DiffusionPipeline"]):
+    def standardize_model_attributes(
+        cls,
+        model: Union["PreTrainedModel", "TFPreTrainedModel", "DiffusionPipeline"],
+        library_name: Optional[str] = None,
+    ):
         """
         Updates the model for export. This function is suitable to make required changes to the models from different
         libraries to follow transformers style.
@@ -2078,7 +2082,8 @@ class TasksManager:
 
         """
 
-        library_name = TasksManager.infer_library_from_model(model)
+        if library_name is None:
+            library_name = TasksManager.infer_library_from_model(model)
 
         if library_name == "diffusers":
             inferred_model_type = None
@@ -2295,7 +2300,7 @@ class TasksManager:
                     kwargs["from_pt"] = True
                     model = model_class.from_pretrained(model_name_or_path, **kwargs)
 
-        TasksManager.standardize_model_attributes(model)
+        TasksManager.standardize_model_attributes(model, library_name=library_name)
 
         return model
 

--- a/optimum/subpackages.py
+++ b/optimum/subpackages.py
@@ -46,7 +46,7 @@ def load_namespace_modules(namespace: str, module: str):
     """
     for dist in importlib_metadata.distributions():
         dist_name = dist.metadata["Name"]
-        if not dist_name.startswith(f"{namespace}-"):
+        if dist_name is None or not dist_name.startswith(f"{namespace}-"):
             continue
         if dist_name == f"{namespace}-benchmark":
             continue

--- a/optimum/subpackages.py
+++ b/optimum/subpackages.py
@@ -46,9 +46,11 @@ def load_namespace_modules(namespace: str, module: str):
     """
     for dist in importlib_metadata.distributions():
         dist_name = dist.metadata["Name"]
-        if dist_name is None or not dist_name.startswith(f"{namespace}-"):
+        if dist_name is None:
             continue
         if dist_name == f"{namespace}-benchmark":
+            continue
+        if not dist_name.startswith(f"{namespace}-"):
             continue
         package_import_name = dist_name.replace("-", ".")
         module_import_name = f"{package_import_name}.{module}"


### PR DESCRIPTION
# What does this PR do?

in case if library_name detection has additional logic on optimum-integration path and not defined inside standard task manager approach to find library (e.g. open_clip integration),  parameters standardization may fail as the library will not be detected properly.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
