### PR TITLE
Add executorch documentation section

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Combine subpackage documentation
         run: |
           cd optimum
-          sudo python docs/combine_docs.py --subpackages nvidia amd intel neuron tpu habana furiosa --version ${{ env.VERSION }}
+          sudo python docs/combine_docs.py --subpackages nvidia amd intel neuron tpu habana furiosa executorch --version ${{ env.VERSION }}
           cd ..
 
       - name: Push to repositories

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Combine subpackage documentation
         run: |
           cd optimum
-          sudo python docs/combine_docs.py --subpackages nvidia amd intel neuron tpu habana furiosa --version pr_$PR_NUMBER
+          sudo python docs/combine_docs.py --subpackages nvidia amd intel neuron tpu habana furiosa executorch --version pr_$PR_NUMBER
           sudo mv optimum-doc-build ../
           cd ..
 

--- a/docs/combine_docs.py
+++ b/docs/combine_docs.py
@@ -133,6 +133,31 @@ def add_tpu_doc(base_toc: List):
     )
 
 
+def add_executorch_doc(base_toc: List):
+    """
+    Extends the table of content with a section about Optimum ExecuTorch.
+
+    Args:
+        base_toc (List): table of content for the doc of Optimum.
+    """
+    # Update optimum table of contents
+    base_toc.insert(
+        SUBPACKAGE_TOC_INSERT_INDEX,
+        {
+            "sections": [
+                {
+                    # Ideally this should directly point at https://huggingface.co/docs/optimum-executorch/index
+                    # Current hacky solution is to have a redirection in _redirects.yml
+                    "local": "docs/optimum-executorch/index",
+                    "title": "🤗 Optimum ExecuTorch",
+                }
+            ],
+            "title": "ExecuTorch",
+            "isExpanded": False,
+        },
+    )
+
+
 def main():
     args = parser.parse_args()
     optimum_path = Path("optimum-doc-build")
@@ -153,6 +178,9 @@ def main():
             # At the moment, Optimum Nvidia's doc is the README of the GitHub repo
             # It is linked to in optimum/docs/source/nvidia_overview.mdx
             continue
+        elif subpackage == "executorch":
+            # Optimum ExecuTorch has its own doc so it is managed differently
+            add_executorch_doc(base_toc)
         else:
             subpackage_path = Path(f"{subpackage}-doc-build")
 

--- a/docs/source/_redirects.yml
+++ b/docs/source/_redirects.yml
@@ -38,3 +38,6 @@ docs/optimum-neuron/index: /docs/optimum-neuron/index
 # Optimum TPU
 docs/optimum-tpu/index: /docs/optimum-tpu/index
 tpu/index: /docs/optimum-tpu/index
+
+# Optimum ExecuTorch
+docs/optimum-executorch/index: /docs/optimum-executorch/index


### PR DESCRIPTION
Can be merged once executorch documentation is generated https://github.com/huggingface/optimum-executorch/pull/21

Also a section can be added in https://github.com/huggingface/optimum/blob/v1.24.0/docs/source/index.mdx?plain=1#L60 after the first release of `optimum-executorch`

Fixes https://github.com/huggingface/optimum-executorch/issues/2