### PR TITLE
Update CI runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dev_test_benckmark.yml
+++ b/.github/workflows/dev_test_benckmark.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.11']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/dev_test_bettertransformer.yml
+++ b/.github/workflows/dev_test_bettertransformer.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - macos-13
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dev_test_dummy_inputs.yml
+++ b/.github/workflows/dev_test_dummy_inputs.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - macos-13
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dev_test_exporters.yml
+++ b/.github/workflows/dev_test_exporters.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.11']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/dev_test_fx.yml
+++ b/.github/workflows/dev_test_fx.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - macos-13
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dev_test_onnx.yml
+++ b/.github/workflows/dev_test_onnx.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - macos-13
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dev_test_onnxruntime.yml
+++ b/.github/workflows/dev_test_onnxruntime.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - windows-2019
         - macos-13
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dev_test_optimum_common.yml
+++ b/.github/workflows/dev_test_optimum_common.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
         os:
-        - ubuntu-20.04
+        - ubuntu-22.04
         - windows-2019
         - macos-13
     runs-on: ${{ matrix.os }}
@@ -38,5 +38,5 @@ jobs:
         # Setting HUGGINGFACE_CO_STAGING to true for only one job of the matrix
         as the staging tests cannot run in parallel.
         export HUGGINGFACE_CO_STAGING=${{ matrix.python-version == 3.8 && matrix.os
-        == ubuntu-20.04 }}
+        == ubuntu-22.04 }}
         python -m unittest discover -s tests -p test_*.py

--- a/.github/workflows/test_benckmark.yml
+++ b/.github/workflows/test_benckmark.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_bettertransformer.yml
+++ b/.github/workflows/test_bettertransformer.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_export_onnx.yml
+++ b/.github/workflows/test_export_onnx.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_export_onnx_cli.yml
+++ b/.github/workflows/test_export_onnx_cli.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_export_onnx_cli_timm.yml
+++ b/.github/workflows/test_export_onnx_cli_timm.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_export_onnx_timm.yml
+++ b/.github/workflows/test_export_onnx_timm.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_export_tflite.yml
+++ b/.github/workflows/test_export_tflite.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli.yml
+++ b/.github/workflows/test_export_tflite_cli.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli_dynamic_quantization_int8.yml
+++ b/.github/workflows/test_export_tflite_cli_dynamic_quantization_int8.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli_quantization_fp16.yml
+++ b/.github/workflows/test_export_tflite_cli_quantization_fp16.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli_quantization_full_int8.yml
+++ b/.github/workflows/test_export_tflite_cli_quantization_full_int8.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli_quantization_int8_custom_dataset.yml
+++ b/.github/workflows/test_export_tflite_cli_quantization_int8_custom_dataset.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli_quantization_int8_default_dataset.yml
+++ b/.github/workflows/test_export_tflite_cli_quantization_int8_default_dataset.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_export_tflite_cli_quantization_int8x16.yml
+++ b/.github/workflows/test_export_tflite_cli_quantization_int8x16.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_exporters_common.yml
+++ b/.github/workflows/test_exporters_common.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_exporters_slow.yml
+++ b/.github/workflows/test_exporters_slow.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: ["3.9"]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/test_fx.yml
+++ b/.github/workflows/test_fx.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_offline.yml
+++ b/.github/workflows/test_offline.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ['3.9']
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test_onnx.yml
+++ b/.github/workflows/test_onnx.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
-        os: [ubuntu-20.04, macos-14]
+        os: [ubuntu-22.04, macos-14]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_onnxruntime.yml
+++ b/.github/workflows/test_onnxruntime.yml
@@ -18,18 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         transformers-version: ["latest"]
-        os: [ubuntu-20.04, windows-2019] # TODO : add macos-15 after mps fix
+        os: [ubuntu-22.04, windows-2019] # TODO : add macos-15 after mps fix
         include:
           - transformers-version: "4.36.*"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - transformers-version: "4.45.*"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         uses: jlumbroso/free-disk-space@main
 
       - name: Checkout code

--- a/.github/workflows/test_optimum_common.yml
+++ b/.github/workflows/test_optimum_common.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-22.04, windows-2019, macos-13]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,5 +36,5 @@ jobs:
         shell: bash
         run: |
           # Setting HUGGINGFACE_CO_STAGING to true for only one job of the matrix as the staging tests cannot run in parallel.
-          export HUGGINGFACE_CO_STAGING=${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-20.04' }}
+          export HUGGINGFACE_CO_STAGING=${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-22.04' }}
           pytest tests/test_*.py

--- a/.github/workflows/test_utils.yml
+++ b/.github/workflows/test_utils.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
         python-version: ['3.9']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

ubuntu 20.04 actions runner image is deprecated https://github.com/actions/runner-images/issues/11101