### PR TITLE
Add ONNX export optimization support for ModernBERT

### DIFF
--- a/optimum/onnxruntime/utils.py
+++ b/optimum/onnxruntime/utils.py
@@ -134,6 +134,7 @@ class ORTConfigManager:
         "marian": "bart",
         "mbart": "bart",
         "mistral": "gpt2",
+        "modernbert": "bert",
         "mpnet": "bert",
         "mt5": "bart",
         "m2m-100": "bart",

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -264,6 +264,7 @@ class NormalizedConfigManager:
         "mbart": BartLikeNormalizedTextConfig,
         "mistral": NormalizedTextConfigWithGQA,
         "mixtral": NormalizedTextConfigWithGQA,
+        "modernbert": NormalizedTextConfig,
         "mpnet": NormalizedTextConfig,
         "mpt": MPTNormalizedTextConfig,
         "mt5": T5LikeNormalizedTextConfig,

--- a/tests/onnxruntime/test_optimization.py
+++ b/tests/onnxruntime/test_optimization.py
@@ -96,6 +96,7 @@ class ORTOptimizerTest(unittest.TestCase):
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-distilbert"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-electra"),
         (ORTModelForCausalLM, "hf-internal-testing/tiny-random-gpt2"),
+        (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-ModernBertForSequenceClassification"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-random-roberta"),
         (ORTModelForSequenceClassification, "hf-internal-testing/tiny-xlm-roberta"),
     )


### PR DESCRIPTION
# What does this PR do?

Fixes #2177 where ModernBERT support for exporting to ONNX format was added but optimizations not fully enabled.  

Minor change that adds `modernbert` to necessary configuration management objects. In local tests, optimizations provided noticeable speedups with identical results to non-optimized model.

## Who can review?

@fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
