### PR TITLE
Add ONNX support for InternLM2

### DIFF
--- a/docs/source/exporters/onnx/overview.mdx
+++ b/docs/source/exporters/onnx/overview.mdx
@@ -57,6 +57,7 @@ Supported architectures from [🤗 Transformers](https://huggingface.co/docs/tra
 - Hiera
 - Hubert
 - IBert
+- InternLM2
 - LayoutLM
 - LayoutLM-v3
 - Lilt

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -404,6 +404,11 @@ class Phi3OnnxConfig(PhiOnnxConfig):
         super().__init__(*args, **kwargs)
 
 
+class InternLM2OnnxConfig(LlamaOnnxConfig):
+    ATOL_FOR_VALIDATION = 1e-4
+    MIN_TRANSFORMERS_VERSION = version.parse("4.41.0")
+
+
 class MistralOnnxConfig(TextDecoderWithPositionIdsOnnxConfig):
     # This is because of the patching of torch.triu in AttentionMaskConverter, that exists from transformers>=4.35
     MIN_TRANSFORMERS_VERSION = version.parse("4.34.99")

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -80,6 +80,7 @@ MODEL_TYPES_REQUIRING_POSITION_IDS = {
     "gpt-neox",
     "gptj",
     "imagegpt",
+    "internlm2",
     "llama",
     "mistral",
     "phi",

--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -772,6 +772,11 @@ class TasksManager:
             "image-classification",
             onnx="ImageGPTOnnxConfig",
         ),
+        "internlm2": supported_tasks_mapping(
+            "text-generation",
+            "text-generation-with-past",
+            onnx="InternLM2OnnxConfig",
+        ),
         "layoutlm": supported_tasks_mapping(
             "feature-extraction",
             "fill-mask",

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -257,6 +257,7 @@ class NormalizedConfigManager:
         "gpt-neox": NormalizedTextConfig,
         "gptj": GPT2LikeNormalizedTextConfig,
         "imagegpt": GPT2LikeNormalizedTextConfig,
+        "internlm2": NormalizedTextConfigWithGQA,
         "llama": NormalizedTextConfigWithGQA,
         "longt5": T5LikeNormalizedTextConfig,
         "marian": BartLikeNormalizedTextConfig,

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -2414,7 +2414,7 @@ class ORTModelForCausalLMIntegrationTest(ORTModelTestMixin):
 
     # TODO: fix "mpt" for which inference fails for transformers < v4.41
     if is_transformers_version(">=", "4.41"):
-        SUPPORTED_ARCHITECTURES.extend(["phi3", "mpt"])
+        SUPPORTED_ARCHITECTURES.extend(["phi3", "mpt", "internlm2"])
 
     if is_transformers_version(">=", "4.45"):
         SUPPORTED_ARCHITECTURES.append("granite")


### PR DESCRIPTION
# What does this PR do?

Adds support for ONNX export of InternLM2 model for text generation tasks (#2240).

Note: I checked the [ONNX contribution guide](https://huggingface.co/docs/optimum/exporters/onnx/usage_guides/contribute) and it seems I cannot find an updated version to add the tests, hence I haven't committed them yet. I would like to kindly ask what steps to take in order to add the tests correctly.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
