### PR TITLE
Respect custom file_name in ORTModelForCausalLM.from_pretrained

### DIFF
--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -459,21 +459,24 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
             _file_name = model_files[0].name
             subfolder = model_files[0].parent
 
-            defaut_file_name = file_name or "model.onnx"
-            for file in model_files:
-                if file.name == defaut_file_name:
-                    _file_name = file.name
-                    subfolder = file.parent
-                    break
+            if file_name is not None:
+                _file_name = file_name
+            else:
+                _file_name = model_files[0].name
+                for file in model_files:
+                    if file.name == "model.onnx":
+                        _file_name = file.name
+                        subfolder = file.parent
+                        break
 
-            file_name = _file_name
+                file_name = _file_name
 
-            if len(model_files) > 1:
-                logger.warning(
-                    f"Too many ONNX model files were found in {' ,'.join(map(str, model_files))}. "
-                    "specify which one to load by using the `file_name` and/or the `subfolder` arguments. "
-                    f"Loading the file {file_name} in the subfolder {subfolder}."
-                )
+                if len(model_files) > 1:
+                    logger.warning(
+                        f"Too many ONNX model files were found in {' ,'.join(map(str, model_files))}. "
+                        "specify which one to load by using the `file_name` and/or the `subfolder` arguments. "
+                        f"Loading the file {file_name} in the subfolder {subfolder}."
+                    )
 
         if os.path.isdir(model_id):
             model_id = subfolder


### PR DESCRIPTION
Fixes an issue (#2246 ) in the `_from_pretrained` method where the `file_name` parameter was not being respected when multiple ONNX files were found. The main changes:

1. When a user explicitly provides a `file_name`, we now respect that choice rather than potentially overriding it with a discovered file
2. Only when `file_name` is `None` do we attempt to find a default file (first trying "model.onnx", then falling back to the first file found), and emit warning suggesting a file_name` be specified.
3. The discovered filename is only assigned to `file_name` if no value was initially provided

### Steps to verify correction
```python
from optimum.onnxruntime import ORTModelForCausalLM

# Load model with custom ONNX filename
model = ORTModelForCausalLM.from_pretrained(
    "HuggingFaceTB/SmolLM2-135M-Instruct",  # this model has multiple eligible ONNX files
    export=True,
    file_name="model_fp16.onnx", # previously would default to model_quantized.onnx instead of the specified file
    provider="CPUExecutionProvider"
)
```
