### PR TITLE
Add feature extraction support for image models

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1074,8 +1074,8 @@ class ORTModelForFeatureExtraction(ORTModel):
             input_features,
             input_values,
         ]
-        first_tensor = next((t for t in tensor_inputs if t is not None), None)
-        use_torch = isinstance(first_tensor, torch.Tensor) if first_tensor is not None else False
+        first_tensor = next(filter(lambda x: x is not None, tensor_inputs))
+        use_torch = isinstance(first_tensor, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
         if token_type_ids is None and "token_type_ids" in self.input_names:

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1059,11 +1059,20 @@ class ORTModelForFeatureExtraction(ORTModel):
         input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
-        **kwargs,
+        position_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        pixel_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        input_features: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
     ):
         # Determine the tensor type from any available tensor input
-        tensor_inputs = [input_ids, attention_mask, token_type_ids] + [
-            v for k, v in kwargs.items() if isinstance(v, (torch.Tensor, np.ndarray))
+        tensor_inputs = [
+            input_ids,
+            attention_mask,
+            token_type_ids,
+            position_ids,
+            pixel_values,
+            input_features,
+            input_values,
         ]
         first_tensor = next((t for t in tensor_inputs if t is not None), None)
         use_torch = isinstance(first_tensor, torch.Tensor) if first_tensor is not None else False
@@ -1074,20 +1083,14 @@ class ORTModelForFeatureExtraction(ORTModel):
 
         # Build model_inputs dictionary
         model_inputs = {
-            k: v
-            for k, v in {
-                "input_ids": input_ids,
-                "attention_mask": attention_mask,
-                "token_type_ids": token_type_ids,
-                **kwargs,
-            }.items()
-            if k in self.input_names and v is not None
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "token_type_ids": token_type_ids,
+            "position_ids": position_ids,
+            "pixel_values": pixel_values,
+            "input_features": input_features,
+            "input_values": input_values,
         }
-
-        # Validate that we have all required inputs
-        for input_name in self.input_names:
-            if input_name not in model_inputs:
-                raise ValueError(f"Input {input_name} is required by model but not provided.")
 
         if self.use_io_binding:
             io_binding, output_shapes, output_buffers = self._prepare_io_binding(self.model, model_inputs)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -2111,11 +2111,29 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
         "mpnet",
         "roberta",
         "xlm_roberta",
+        "vit",
     ]
 
     FULL_GRID = {"model_arch": SUPPORTED_ARCHITECTURES}
     ORTMODEL_CLASS = ORTModelForFeatureExtraction
     TASK = "feature-extraction"
+
+    def is_image_model(self, model_arch):
+        return model_arch == "vit"
+
+    def get_raw_input(self, model_arch):
+        if self.is_image_model(model_arch):
+            image_url = "https://picsum.photos/id/237/200/300"
+            return Image.open(requests.get(image_url, stream=True).raw)
+        else:
+            return "This is a sample output"
+
+    def get_input(self, model_arch, processor, return_tensors="pt"):
+        raw_input = self.get_raw_input(model_arch)
+        if self.is_image_model(model_arch):
+            return processor(images=raw_input, return_tensors=return_tensors)
+        else:
+            return processor(raw_input, return_tensors=return_tensors)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
@@ -2130,15 +2148,14 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
 
         set_seed(SEED)
         transformers_model = AutoModel.from_pretrained(model_id)
-        tokenizer = get_preprocessor(model_id)
-        text = "This is a sample output"
-        tokens = tokenizer(text, return_tensors="pt")
+        processor = get_preprocessor(model_id)
+        inputs = self.get_input(model_arch, processor, return_tensors="pt")
         with torch.no_grad():
-            transformers_outputs = transformers_model(**tokens)
+            transformers_outputs = transformers_model(**inputs)
 
         for input_type in ["pt", "np"]:
-            tokens = tokenizer(text, return_tensors=input_type)
-            onnx_outputs = onnx_model(**tokens)
+            inputs = self.get_input(model_arch, processor, return_tensors=input_type)
+            onnx_outputs = onnx_model(**inputs)
 
             self.assertIn("last_hidden_state", onnx_outputs)
             self.assertIsInstance(onnx_outputs.last_hidden_state, self.TENSOR_ALIAS_TO_TYPE[input_type])
@@ -2160,14 +2177,26 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
 
         model_id = MODEL_NAMES[model_arch]
         onnx_model = ORTModelForFeatureExtraction.from_pretrained(self.onnx_model_dirs[model_arch])
-        tokenizer = get_preprocessor(model_id)
-        pipe = pipeline("feature-extraction", model=onnx_model, tokenizer=tokenizer)
-        text = "My Name is Philipp and i live in Germany."
-        outputs = pipe(text)
+        processor = get_preprocessor(model_id)
+        if self.is_image_model(model_arch):
+            # For image models, bypass the pipeline and test directly because feature extraction (in optimum/pipelines/pipelines_base.py) is only supported for text at the moment
+            # Change this once feature extraction pipelines is supported for image models
+            raw_input = self.get_raw_input(model_arch)
+            processed_inputs = processor(images=raw_input, return_tensors="pt")
+            outputs = onnx_model(**processed_inputs)
 
-        # compare model output class
-        self.assertEqual(pipe.device, onnx_model.device)
-        self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
+            # Check device and output format
+            assert onnx_model.device.type == "cpu"
+            assert isinstance(outputs.last_hidden_state, torch.Tensor)
+            features = outputs.last_hidden_state.detach().cpu().numpy().tolist()
+            assert all(isinstance(item, float) for row in features for inner in row for item in inner)
+        else:
+            # For text models, use the pipeline and check model device and compare model output class
+            pipe = pipeline("feature-extraction", model=onnx_model, tokenizer=processor)
+            raw_input = self.get_raw_input(model_arch)
+            outputs = pipe(raw_input)
+            assert pipe.device == onnx_model.device
+            assert all(all(isinstance(item, float) for item in row) for row in outputs[0])
 
         gc.collect()
 
@@ -2197,14 +2226,28 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
 
         model_id = MODEL_NAMES[model_arch]
         onnx_model = ORTModelForFeatureExtraction.from_pretrained(self.onnx_model_dirs[model_arch], provider=provider)
-        tokenizer = get_preprocessor(model_id)
-        pipe = pipeline("feature-extraction", model=onnx_model, tokenizer=tokenizer, device=0)
-        text = "My Name is Philipp and i live in Germany."
-        outputs = pipe(text)
-        # check model device
-        self.assertEqual(pipe.model.device.type.lower(), "cuda")
-        # compare model output class
-        self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
+        processor = get_preprocessor(model_id)
+
+        if self.is_image_model(model_arch):
+            # For image models, bypass the pipeline and test directly because feature extraction (in optimum/pipelines/pipelines_base.py) is only supported for text at the moment
+            # Change this once feature extraction pipelines is supported for image models
+            raw_input = self.get_raw_input(model_arch)
+            processed_inputs = processor(images=raw_input, return_tensors="pt").to("cuda")
+            outputs = onnx_model(**processed_inputs)
+
+            # Check device and output format
+            assert onnx_model.device.type == "cuda"
+            assert isinstance(outputs.last_hidden_state, torch.Tensor)
+            features = outputs.last_hidden_state.detach().cpu().numpy().tolist()
+            assert all(isinstance(item, float) for row in features for inner in row for item in inner)
+
+        else:
+            # For text models, use the pipeline, check model device and compare model output class
+            pipe = pipeline("feature-extraction", model=onnx_model, tokenizer=processor, device=0)
+            raw_input = self.get_raw_input(model_arch)
+            outputs = pipe(raw_input)
+            self.assertEqual(pipe.model.device.type.lower(), "cuda")
+            self.assertTrue(all(all(isinstance(item, float) for item in row) for row in outputs[0]))
 
         gc.collect()
 
@@ -2249,8 +2292,13 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
         self.assertFalse(onnx_model.use_io_binding)
         self.assertTrue(io_model.use_io_binding)
 
-        tokenizer = get_preprocessor(model_id)
-        tokens = tokenizer(["This is a sample output"] * 2, return_tensors="pt").to("cuda")
+        processor = get_preprocessor(model_id)
+
+        if self.is_image_model(model_arch):
+            raw_input = self.get_raw_input(model_arch)
+            tokens = processor(images=[raw_input, raw_input], return_tensors="pt").to("cuda")
+        else:
+            tokens = processor(["This is a sample output"] * 2, return_tensors="pt").to("cuda")
 
         onnx_outputs = onnx_model(**tokens)
         io_outputs = io_model(**tokens)


### PR DESCRIPTION
# What does this PR do?

This PR adds support for image models in ORTModelForFeatureExtraction, specifically addressing ViT and other visual models. The implementation modifies the forward method to dynamically handle both text and image inputs by detecting the presence of image-specific input keys like 'pixel_values'. This allows users to seamlessly use ORTModelForFeatureExtraction for both text and image feature extraction tasks without requiring a separate class structure. Tests have been updated to properly validate this functionality across all supported architectures, including Vision Transformer (ViT) models.


Fixes # (issue)
Fixes the issue : https://github.com/huggingface/optimum/issues/2226

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

