### PR TITLE
Fix bug ORTModelForFeatureExtraction

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1072,7 +1072,8 @@ class ORTModelForFeatureExtraction(ORTModel):
         if kwargs:
             logger.warning(
                 f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes arbitrary or custom tensor arguments."
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
             )
 
         # Determine the tensor type from any available tensor input

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1076,11 +1076,10 @@ class ORTModelForFeatureExtraction(ORTModel):
         pixel_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
         input_features: Optional[Union[torch.Tensor, np.ndarray]] = None,
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1136,7 +1135,7 @@ class ORTModelForFeatureExtraction(ORTModel):
                 last_hidden_state = next(iter(model_outputs.values()))
 
         if return_dict:
-            return model_outputs
+            return {"last_hidden_state": last_hidden_state}
 
         # converts output to namedtuple for pipelines post-processing
         return BaseModelOutput(last_hidden_state=last_hidden_state)
@@ -1251,11 +1250,10 @@ class ORTModelForMaskedLM(ORTModel):
         input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1291,7 +1289,7 @@ class ORTModelForMaskedLM(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return MaskedLMOutput(logits=logits)
@@ -1354,11 +1352,10 @@ class ORTModelForQuestionAnswering(ORTModel):
         input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1392,7 +1389,7 @@ class ORTModelForQuestionAnswering(ORTModel):
             end_logits = model_outputs["end_logits"]
 
         if return_dict:
-            return model_outputs
+            return {"start_logits": start_logits, "end_logits": end_logits}
 
         # converts output to namedtuple for pipelines post-processing
         return QuestionAnsweringModelOutput(start_logits=start_logits, end_logits=end_logits)
@@ -1470,11 +1467,10 @@ class ORTModelForSequenceClassification(ORTModel):
         input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1510,7 +1506,7 @@ class ORTModelForSequenceClassification(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return SequenceClassifierOutput(logits=logits)
@@ -1574,11 +1570,10 @@ class ORTModelForTokenClassification(ORTModel):
         input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1614,7 +1609,7 @@ class ORTModelForTokenClassification(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         return TokenClassifierOutput(logits=logits)
 
@@ -1671,11 +1666,10 @@ class ORTModelForMultipleChoice(ORTModel):
         input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1711,7 +1705,7 @@ class ORTModelForMultipleChoice(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return MultipleChoiceModelOutput(logits=logits)
@@ -1775,11 +1769,10 @@ class ORTModelForImageClassification(ORTModel):
     def forward(
         self,
         pixel_values: Union[torch.Tensor, np.ndarray],
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1810,7 +1803,7 @@ class ORTModelForImageClassification(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return ImageClassifierOutput(logits=logits)
@@ -1874,11 +1867,10 @@ class ORTModelForSemanticSegmentation(ORTModel):
     def forward(
         self,
         pixel_values: Union[torch.Tensor, np.ndarray],
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -1909,7 +1901,7 @@ class ORTModelForSemanticSegmentation(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return SemanticSegmenterOutput(logits=logits)
@@ -2003,11 +1995,10 @@ class ORTModelForAudioClassification(ORTModel):
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
         attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
         input_features: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -2048,7 +2039,7 @@ class ORTModelForAudioClassification(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return SequenceClassifierOutput(logits=logits)
@@ -2100,11 +2091,10 @@ class ORTModelForCTC(ORTModel):
     def forward(
         self,
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -2145,7 +2135,7 @@ class ORTModelForCTC(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return CausalLMOutput(logits=logits)
@@ -2205,11 +2195,10 @@ class ORTModelForAudioXVector(ORTModel):
     def forward(
         self,
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -2243,7 +2232,7 @@ class ORTModelForAudioXVector(ORTModel):
             embeddings = model_outputs["embeddings"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits, "embeddings": embeddings}
 
         # converts output to namedtuple for pipelines post-processing
         return XVectorOutput(logits=logits, embeddings=embeddings)
@@ -2295,11 +2284,10 @@ class ORTModelForAudioFrameClassification(ORTModel):
     def forward(
         self,
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False# Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -2318,7 +2306,7 @@ class ORTModelForAudioFrameClassification(ORTModel):
             logits = model_outputs["logits"]
 
         if return_dict:
-            return model_outputs
+            return {"logits": logits}
 
         # converts output to namedtuple for pipelines post-processing
         return TokenClassifierOutput(logits=logits)
@@ -2364,11 +2352,10 @@ class ORTModelForImageToImage(ORTModel):
     def forward(
         self,
         pixel_values: Union[torch.Tensor, np.ndarray],
+        *,
+        return_dict: bool = False,
         **kwargs,
     ):
-        # Handle return_dict from kwargs with default value False
-        return_dict = kwargs.pop("return_dict", False)
-
         # Warn about any unexpected kwargs using the helper method
         self._warn_on_unhandled_inputs(kwargs)
 
@@ -2404,7 +2391,7 @@ class ORTModelForImageToImage(ORTModel):
             reconstruction = model_outputs["reconstruction"]
 
         if return_dict:
-            return model_outputs
+            return {"reconstruction": reconstruction}
 
         return ImageSuperResolutionOutput(reconstruction=reconstruction)
 

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1070,8 +1070,9 @@ class ORTModelForFeatureExtraction(ORTModel):
 
         # Raise error for any unexpected kwargs
         if kwargs:
-            raise ValueError(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes arbitrary or custom tensor arguments."
             )
 
         # Determine the tensor type from any available tensor input

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1002,6 +1002,19 @@ class ORTModel(OptimizedModel):
         """
         return isinstance(self, GenerationMixin)
 
+    def _warn_on_unhandled_inputs(self, kwargs: Dict[str, Any]) -> None:
+        """Warn about unhandled input arguments.
+
+        Args:
+            kwargs: Dictionary of unhandled input arguments.
+        """
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
 
 FEATURE_EXTRACTION_EXAMPLE = r"""
     Example of feature extraction:
@@ -1068,13 +1081,8 @@ class ORTModelForFeatureExtraction(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         # Determine the tensor type from any available tensor input
         tensor_inputs = [
@@ -1248,13 +1256,8 @@ class ORTModelForMaskedLM(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -1356,13 +1359,8 @@ class ORTModelForQuestionAnswering(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -1477,13 +1475,8 @@ class ORTModelForSequenceClassification(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -1586,13 +1579,8 @@ class ORTModelForTokenClassification(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -1688,13 +1676,8 @@ class ORTModelForMultipleChoice(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -1797,13 +1780,8 @@ class ORTModelForImageClassification(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(pixel_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -1901,13 +1879,8 @@ class ORTModelForSemanticSegmentation(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(pixel_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -2035,13 +2008,8 @@ class ORTModelForAudioClassification(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         if self.input_name == "input_features":
             assert input_features is not None, "input_features must be provided for this model"
@@ -2137,13 +2105,8 @@ class ORTModelForCTC(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -2247,13 +2210,8 @@ class ORTModelForAudioXVector(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -2342,13 +2300,8 @@ class ORTModelForAudioFrameClassification(ORTModel):
         # Handle return_dict from kwargs with default value False# Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(input_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
@@ -2416,13 +2369,8 @@ class ORTModelForImageToImage(ORTModel):
         # Handle return_dict from kwargs with default value False
         return_dict = kwargs.pop("return_dict", False)
 
-        # Raise error for any unexpected kwargs
-        if kwargs:
-            logger.warning(
-                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
-                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
-                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
-            )
+        # Warn about any unexpected kwargs using the helper method
+        self._warn_on_unhandled_inputs(kwargs)
 
         use_torch = isinstance(pixel_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1063,7 +1063,17 @@ class ORTModelForFeatureExtraction(ORTModel):
         pixel_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
         input_features: Optional[Union[torch.Tensor, np.ndarray]] = None,
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            raise ValueError(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
+            )
+
         # Determine the tensor type from any available tensor input
         tensor_inputs = [
             input_ids,
@@ -1114,6 +1124,9 @@ class ORTModelForFeatureExtraction(ORTModel):
             else:
                 # TODO: This allows to support sentence-transformers models (sentence embedding), but is not validated.
                 last_hidden_state = next(iter(model_outputs.values()))
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return BaseModelOutput(last_hidden_state=last_hidden_state)

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -1245,6 +1245,17 @@ class ORTModelForMaskedLM(ORTModel):
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1275,6 +1286,9 @@ class ORTModelForMaskedLM(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return MaskedLMOutput(logits=logits)
@@ -1339,6 +1353,17 @@ class ORTModelForQuestionAnswering(ORTModel):
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1367,6 +1392,9 @@ class ORTModelForQuestionAnswering(ORTModel):
 
             start_logits = model_outputs["start_logits"]
             end_logits = model_outputs["end_logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return QuestionAnsweringModelOutput(start_logits=start_logits, end_logits=end_logits)
@@ -1446,6 +1474,17 @@ class ORTModelForSequenceClassification(ORTModel):
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1476,6 +1515,9 @@ class ORTModelForSequenceClassification(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return SequenceClassifierOutput(logits=logits)
@@ -1541,6 +1583,17 @@ class ORTModelForTokenClassification(ORTModel):
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1571,6 +1624,9 @@ class ORTModelForTokenClassification(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         return TokenClassifierOutput(logits=logits)
 
@@ -1629,6 +1685,17 @@ class ORTModelForMultipleChoice(ORTModel):
         token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_ids, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1659,6 +1726,9 @@ class ORTModelForMultipleChoice(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return MultipleChoiceModelOutput(logits=logits)
@@ -1724,6 +1794,17 @@ class ORTModelForImageClassification(ORTModel):
         pixel_values: Union[torch.Tensor, np.ndarray],
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(pixel_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1749,6 +1830,9 @@ class ORTModelForImageClassification(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return ImageClassifierOutput(logits=logits)
@@ -1814,6 +1898,17 @@ class ORTModelForSemanticSegmentation(ORTModel):
         pixel_values: Union[torch.Tensor, np.ndarray],
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(pixel_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -1839,6 +1934,9 @@ class ORTModelForSemanticSegmentation(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return SemanticSegmenterOutput(logits=logits)
@@ -1934,6 +2032,17 @@ class ORTModelForAudioClassification(ORTModel):
         input_features: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         if self.input_name == "input_features":
             assert input_features is not None, "input_features must be provided for this model"
             model_input = input_features
@@ -1969,6 +2078,9 @@ class ORTModelForAudioClassification(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return SequenceClassifierOutput(logits=logits)
@@ -2022,6 +2134,17 @@ class ORTModelForCTC(ORTModel):
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -2057,6 +2180,9 @@ class ORTModelForCTC(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return CausalLMOutput(logits=logits)
@@ -2118,6 +2244,17 @@ class ORTModelForAudioXVector(ORTModel):
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -2146,6 +2283,9 @@ class ORTModelForAudioXVector(ORTModel):
 
             logits = model_outputs["logits"]
             embeddings = model_outputs["embeddings"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return XVectorOutput(logits=logits, embeddings=embeddings)
@@ -2199,6 +2339,17 @@ class ORTModelForAudioFrameClassification(ORTModel):
         input_values: Optional[Union[torch.Tensor, np.ndarray]] = None,
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False# Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(input_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -2212,6 +2363,9 @@ class ORTModelForAudioFrameClassification(ORTModel):
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
 
             logits = model_outputs["logits"]
+
+        if return_dict:
+            return model_outputs
 
         # converts output to namedtuple for pipelines post-processing
         return TokenClassifierOutput(logits=logits)
@@ -2259,6 +2413,17 @@ class ORTModelForImageToImage(ORTModel):
         pixel_values: Union[torch.Tensor, np.ndarray],
         **kwargs,
     ):
+        # Handle return_dict from kwargs with default value False
+        return_dict = kwargs.pop("return_dict", False)
+
+        # Raise error for any unexpected kwargs
+        if kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not handle those arguments. "
+                "Please use `ORTModelForCustomTasks` if your model takes/returns arbitrary or custom tensor inputs/outputs. "
+                "Or open an issue/PR in optimum repository (https://github.com/huggingface/optimum) if this argument needs to be supported in this class."
+            )
+
         use_torch = isinstance(pixel_values, torch.Tensor)
         self.raise_on_numpy_input_io_binding(use_torch)
 
@@ -2289,6 +2454,10 @@ class ORTModelForImageToImage(ORTModel):
             onnx_outputs = self.model.run(None, onnx_inputs)
             model_outputs = self._prepare_onnx_outputs(use_torch, onnx_outputs)
             reconstruction = model_outputs["reconstruction"]
+
+        if return_dict:
+            return model_outputs
+
         return ImageSuperResolutionOutput(reconstruction=reconstruction)
 
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -59,7 +59,7 @@ from transformers import (
     PretrainedConfig,
     set_seed,
 )
-from transformers.modeling_outputs import ImageSuperResolutionOutput
+from transformers.modeling_outputs import ImageSuperResolutionOutput, BaseModelOutput
 from transformers.modeling_utils import no_init_weights
 from transformers.models.swin2sr.configuration_swin2sr import Swin2SRConfig
 from transformers.onnx.utils import get_preprocessor
@@ -2138,10 +2138,17 @@ class ORTModelForFeatureExtractionIntegrationTest(ORTModelTestMixin):
 
         for input_type in ["pt", "np"]:
             tokens = tokenizer(text, return_tensors=input_type)
+            # Test default behavior (return_dict=False)
             onnx_outputs = onnx_model(**tokens)
-
+            self.assertIsInstance(onnx_outputs, BaseModelOutput)
             self.assertIn("last_hidden_state", onnx_outputs)
             self.assertIsInstance(onnx_outputs.last_hidden_state, self.TENSOR_ALIAS_TO_TYPE[input_type])
+
+            # Test return_dict=True
+            onnx_outputs_dict = onnx_model(**tokens, return_dict=True)
+            self.assertIsInstance(onnx_outputs_dict, dict)
+            self.assertIn("last_hidden_state", onnx_outputs_dict)
+            self.assertIsInstance(onnx_outputs_dict["last_hidden_state"], self.TENSOR_ALIAS_TO_TYPE[input_type])
 
             # compare tensor outputs
             torch.testing.assert_close(

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -59,7 +59,7 @@ from transformers import (
     PretrainedConfig,
     set_seed,
 )
-from transformers.modeling_outputs import ImageSuperResolutionOutput, BaseModelOutput
+from transformers.modeling_outputs import BaseModelOutput, ImageSuperResolutionOutput
 from transformers.modeling_utils import no_init_weights
 from transformers.models.swin2sr.configuration_swin2sr import Swin2SRConfig
 from transformers.onnx.utils import get_preprocessor


### PR DESCRIPTION
# What does this PR do?

This PR updates the `ORTModelForFeatureExtraction`'s `forward `method to accept `**kwargs`, ensuring better compatibility with Hugging Face Transformers' conventions. In particular, it adds proper support for the `return_dict `argument: when explicitly passed, the output is returned as a plain dictionary instead of being wrapped in a `ModelOutput`. Additionally, any unused keyword arguments are logged with a warning to help users identify unsupported inputs while maintaining backward compatibility.


Fixes issue : https://github.com/huggingface/optimum/issues/2266


