### PR TITLE
Fix and uniformize hub kwargs

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -15,7 +15,6 @@
 """Entry point to the optimum.exporters.onnx command line."""
 
 import argparse
-import warnings
 from pathlib import Path
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
@@ -63,15 +62,16 @@ def main_export(
     no_post_process: bool = False,
     framework: Optional[str] = None,
     atol: Optional[float] = None,
-    cache_dir: str = HUGGINGFACE_HUB_CACHE,
-    trust_remote_code: bool = False,
     pad_token_id: Optional[int] = None,
+    # hub options
     subfolder: str = "",
     revision: str = "main",
     force_download: bool = False,
     local_files_only: bool = False,
-    use_auth_token: Optional[Union[bool, str]] = None,
+    trust_remote_code: bool = False,
+    cache_dir: str = HUGGINGFACE_HUB_CACHE,
     token: Optional[Union[bool, str]] = None,
+    ########################################
     for_ort: bool = False,
     do_validation: bool = True,
     model_kwargs: Optional[Dict[str, Any]] = None,
@@ -184,15 +184,6 @@ def main_export(
     >>> main_export("gpt2", output="gpt2_onnx/")
     ```
     """
-
-    if use_auth_token is not None:
-        warnings.warn(
-            "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
-            FutureWarning,
-        )
-        if token is not None:
-            raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
-        token = use_auth_token
 
     if fp16:
         if dtype is not None:

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -320,6 +320,7 @@ class OptimizedModel(PreTrainedModel):
     def from_pretrained(
         cls,
         model_id: Union[str, Path],
+        config: Optional[PretrainedConfig] = None,
         export: bool = False,
         # hub options
         subfolder: str = "",
@@ -407,6 +408,7 @@ class OptimizedModel(PreTrainedModel):
         return from_pretrained_method(
             model_id=model_id,
             config=config,
+            # hub options
             revision=revision,
             cache_dir=cache_dir,
             force_download=force_download,

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -241,23 +241,15 @@ class OptimizedModel(PreTrainedModel):
     def _load_config(
         cls,
         config_name_or_path: Union[str, os.PathLike],
-        revision: Optional[str] = None,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        use_auth_token: Optional[Union[bool, str]] = None,
-        token: Optional[Union[bool, str]] = None,
-        force_download: bool = False,
+        # hub options
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
+        local_files_only: bool = False,
         trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
     ) -> PretrainedConfig:
-        if use_auth_token is not None:
-            warnings.warn(
-                "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
-                FutureWarning,
-            )
-            if token is not None:
-                raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
-            token = use_auth_token
-
         try:
             config = AutoConfig.from_pretrained(
                 pretrained_model_name_or_path=config_name_or_path,
@@ -290,14 +282,14 @@ class OptimizedModel(PreTrainedModel):
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],
-        config: PretrainedConfig,
-        use_auth_token: Optional[Union[bool, str]] = None,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        # hub options
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
+        trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         **kwargs,
     ) -> "OptimizedModel":
         """Overwrite this method in subclass to define how to load your model from pretrained"""
@@ -308,14 +300,14 @@ class OptimizedModel(PreTrainedModel):
         cls,
         model_id: Union[str, Path],
         config: PretrainedConfig,
-        use_auth_token: Optional[Union[bool, str]] = None,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        # hub options
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
         trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         **kwargs,
     ) -> "OptimizedModel":
         """Overwrite this method in subclass to define how to load your model from vanilla hugging face model"""
@@ -329,30 +321,20 @@ class OptimizedModel(PreTrainedModel):
         cls,
         model_id: Union[str, Path],
         export: bool = False,
-        force_download: bool = False,
-        use_auth_token: Optional[Union[bool, str]] = None,
-        token: Optional[Union[bool, str]] = None,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        # hub options
         subfolder: str = "",
-        config: Optional[PretrainedConfig] = None,
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
         trust_remote_code: bool = False,
-        revision: Optional[str] = None,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         **kwargs,
     ) -> "OptimizedModel":
         """
         Returns:
             `OptimizedModel`: The loaded optimized model.
         """
-
-        if use_auth_token is not None:
-            warnings.warn(
-                "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
-                FutureWarning,
-            )
-            if token is not None:
-                raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
-            token = use_auth_token
 
         if isinstance(model_id, Path):
             model_id = model_id.as_posix()

--- a/optimum/onnxruntime/modeling_decoder.py
+++ b/optimum/onnxruntime/modeling_decoder.py
@@ -405,13 +405,13 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
         model_id: Union[str, Path],
         config: "PretrainedConfig",
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
-        trust_remote_code: bool = False,  # forced by OptimizedModel.from_pretrained
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
+        trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # file options
         file_name: Optional[str] = None,
         # session options
@@ -654,13 +654,13 @@ class ORTModelForCausalLM(ORTModel, GenerationMixin):
         model_id: Union[str, Path],
         config: "PretrainedConfig",
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: str = "main",
-        force_download: bool = True,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
         trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # inference options
         use_cache: bool = True,
         **kwargs,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -441,6 +441,7 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
     def from_pretrained(
         cls,
         model_id: Union[str, Path],
+        config: Optional["PretrainedConfig"] = None,
         # export options
         export: bool = False,
         # hub options
@@ -548,6 +549,7 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
 
         return super().from_pretrained(
             model_id,
+            config=config,
             export=_export,
             force_download=force_download,
             token=token,

--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -281,13 +281,13 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
         model_id: Union[str, Path],
         config: "PretrainedConfig",
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
-        trust_remote_code: bool = False,  # forced by OptimizedModel.from_pretrained
+        trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # file options
         file_name: Optional[str] = None,
         # session options
@@ -395,13 +395,13 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
         model_id: Union[str, Path],
         config: "PretrainedConfig",
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
         trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # other arguments
         **kwargs,
     ) -> "ORTModel":
@@ -444,13 +444,13 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
         # export options
         export: bool = False,
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: str = "main",
-        force_download: bool = True,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
         trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # session options
         provider: str = "CPUExecutionProvider",
         providers: Optional[Sequence[str]] = None,

--- a/optimum/onnxruntime/modeling_seq2seq.py
+++ b/optimum/onnxruntime/modeling_seq2seq.py
@@ -1043,13 +1043,13 @@ class ORTModelForConditionalGeneration(ORTParentMixin, ORTModel):
         model_id: Union[str, Path],
         config: "PretrainedConfig",
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        trust_remote_code: bool = False,  # forced by OptimizedModel.from_pretrained
-        local_files_only: bool = False,
-        force_download: bool = False,
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
+        local_files_only: bool = False,
+        trust_remote_code: bool = False,
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # file options
         encoder_file_name: str = ONNX_ENCODER_NAME,
         decoder_file_name: str = ONNX_DECODER_NAME,
@@ -1297,13 +1297,13 @@ class ORTModelForConditionalGeneration(ORTParentMixin, ORTModel):
         model_id: Union[str, Path],
         config: "PretrainedConfig",
         # hub options
-        token: Optional[Union[bool, str]] = None,
-        revision: str = "main",
-        force_download: bool = True,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
+        revision: str = "main",
+        force_download: bool = False,
         local_files_only: bool = False,
         trust_remote_code: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        token: Optional[Union[bool, str]] = None,
         # inference options
         use_cache: bool = True,
         use_merged: bool = False,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In my last PR I must have changed some defaults by mistake (e.g. force_download for CausalLM)
maybe it makes sense to start using something like this for the hub kwargs to guarantee they are the same across the lib
https://github.com/huggingface/transformers/blob/46a4b7c909fab58355936e1c7109bb5e2e558267/src/transformers/models/glm4/modular_glm4.py#L63


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
