### PR TITLE
Add flags to allow dynamo usage & provide export pathway for onnx opset >= 21

### DIFF
--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -177,7 +177,8 @@ def parse_args_onnx(parser):
 
     optional_group.add_argument(
         "--use-dynamo",
-        action="store_true",
+        type=bool,
+        default=None,
         help="Use dynamo instead of torchscript for onnx model export.",
     )
 

--- a/optimum/commands/export/onnx.py
+++ b/optimum/commands/export/onnx.py
@@ -175,6 +175,24 @@ def parse_args_onnx(parser):
         help="Enables onnxslim optimization.",
     )
 
+    optional_group.add_argument(
+        "--use-dynamo",
+        action="store_true",
+        help="Use dynamo instead of torchscript for onnx model export.",
+    )
+
+    optional_group.add_argument(
+        "--verify-accuracy",
+        action="store_true",
+        help="Run torch and ORT model inference and compare outputs.",
+    )
+
+    optional_group.add_argument(
+        "--debug-reports",
+        action="store_true",
+        help="Provide debug reports for the conversion process.",
+    )
+
     input_group = parser.add_argument_group(
         "Input shapes (if necessary, this allows to override the shapes of the input given to the ONNX exporter, that requires an example input)."
     )

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -15,6 +15,7 @@
 """Entry point to the optimum.exporters.onnx command line."""
 
 import argparse
+import warnings
 from pathlib import Path
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
@@ -25,6 +26,12 @@ from transformers.utils import is_torch_available
 from ...commands.export.onnx import parse_args_onnx
 from ...utils.import_utils import is_transformers_version
 from ...utils import DEFAULT_DUMMY_SHAPES, logging
+from ...utils.import_utils import (
+    is_diffusers_available,
+    is_sentence_transformers_available,
+    is_timm_available,
+    is_transformers_version,
+)
 from ...utils.save_utils import maybe_load_preprocessors
 from ..tasks import TasksManager
 from ..utils import DisableCompileContextManager
@@ -78,6 +85,7 @@ def main_export(
     legacy: bool = False,
     no_dynamic_axes: bool = False,
     do_constant_folding: bool = True,
+    slim: bool = False,
     **kwargs_shapes,
 ):
     """
@@ -425,6 +433,7 @@ def main_export(
         task=task,
         use_subprocess=use_subprocess,
         do_constant_folding=do_constant_folding,
+        slim=slim,
         **kwargs_shapes,
     )
 

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -15,7 +15,6 @@
 """Entry point to the optimum.exporters.onnx command line."""
 
 import argparse
-import warnings
 from pathlib import Path
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
@@ -450,10 +449,6 @@ def main():
     input_shapes = {}
     for input_name in DEFAULT_DUMMY_SHAPES.keys():
         input_shapes[input_name] = getattr(args, input_name)
-
-    if args.use_dynamo == False and args.opset and args.opset >= 21:
-        warnings.warn('Support for ONNX opset >= 21 will only be supported via dynamo going forward. Switching to dynamo.', FutureWarning)
-        args.use_dynamo = True
 
     main_export(
         model_name_or_path=args.model,


### PR DESCRIPTION
# What does this PR do?

Enable flag for comparing pytorch vs ORT output of original vs coverted model
Enable flag to dump fx graph
Dump debug info into converted model location by default

Fixes #2281

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
