### PR TITLE
Fix

### DIFF
--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -407,10 +407,6 @@ class OptimizedModel(PreTrainedModel):
             if hasattr(cls, "_export"):
                 from_pretrained_method = cls._export
             elif hasattr(cls, "_from_transformers"):
-                logger.warning(
-                    "The `export` argument is set to `True`, but the class does not implement `_export` methods. "
-                    "Using the `_from_transformers` method instead."
-                )
                 from_pretrained_method = cls._from_transformers
             else:
                 raise ValueError(

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -404,10 +404,11 @@ class OptimizedModel(PreTrainedModel):
             )
 
         if export:
-            if hasattr(cls, "_export"):
-                from_pretrained_method = cls._export
-            elif hasattr(cls, "_from_transformers"):
+            if hasattr(cls, "_from_transformers"):
+                # legacy support for models that implement `_from_transformers`
                 from_pretrained_method = cls._from_transformers
+            elif hasattr(cls, "_export"):
+                from_pretrained_method = cls._export
             else:
                 raise ValueError(
                     "The `export` argument is set to `True`, but the class does not implement `_export` methods."

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -316,6 +316,10 @@ class OptimizedModel(PreTrainedModel):
         )
 
     @classmethod
+    def _from_transformers(cls, *arg, **kwargs):
+        return cls._export(*arg, **kwargs)
+
+    @classmethod
     @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
     def from_pretrained(
         cls,

--- a/optimum/modeling_base.py
+++ b/optimum/modeling_base.py
@@ -316,8 +316,9 @@ class OptimizedModel(PreTrainedModel):
         )
 
     @classmethod
-    def _from_transformers(cls, *arg, **kwargs):
-        return cls._export(*arg, **kwargs)
+    def _from_transformers(cls, *args, **kwargs):
+        # TODO : add warning when from_pretrained_method is set to cls._export instead of cls._from_transformers when export=True
+        return cls._export(*args, **kwargs)
 
     @classmethod
     @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)


### PR DESCRIPTION
Add back deprecated `_from_transformers` method to not break inference for other subpackages which still uses it like optimum-intel  