### PR TITLE
upgrade windows action runner

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        runs-on: [ubuntu-22.04, windows-2019, macos-14]
+        runs-on: [ubuntu-22.04, windows-2022, macos-14]
 
     runs-on: ${{ matrix.runs-on }}
 


### PR DESCRIPTION
The windows 2019 actions runner image is deprecated since 01-06-2025