### PR TITLE
Fix 'Block pattern could not be match. Pass `block_name_to_quantize` argument in `quantize_model`' while loading Qwen VL GPTQ model

### DIFF
--- a/optimum/gptq/constants.py
+++ b/optimum/gptq/constants.py
@@ -18,6 +18,7 @@ BLOCK_PATTERNS = [
     "model.decoder.layers",
     "gpt_neox.layers",
     "model.layers",
+    "model.language_model.layers",
     # modules loaded by AutoModel vs AutoModelForCausalLM have different prefixes
     "h",
     "decoder.layers",


### PR DESCRIPTION
# What does this PR do?

This PR fixes the issue encountered when using Qwen2VLForConditionalGeneration to load the GPTQ model:
```
ValueError                                Traceback (most recent call last)

[<ipython-input-1-1109427887>](https://localhost:8080/#) in <cell line: 0>()
      4 
      5 gptq_config = GPTQConfig(bits=4, use_exllama=False)
----> 6 model = Qwen2VLForConditionalGeneration.from_pretrained(
      7     "Qwen/Qwen2-VL-2B-Instruct-GPTQ-Int4",
      8     torch_dtype=torch.float16,

5 frames

[/usr/local/lib/python3.11/dist-packages/optimum/gptq/utils.py](https://localhost:8080/#) in get_block_name_with_pattern(model)
     75         if any(name.startswith(pattern_candidate) for name in modules_names):
     76             return pattern_candidate
---> 77     raise ValueError("Block pattern could not be match. Pass `block_name_to_quantize` argument in `quantize_model`")
     78 
     79 

ValueError: Block pattern could not be match. Pass `block_name_to_quantize` argument in `quantize_model`
```

The reason for the error is 

- Transformers v4.52 will map the "language" layers to "model.language_model.layers" for Qwen2-VL/Qwen2.5-VL: https://github.com/huggingface/transformers/blob/de4cf5a38e9678b9e465867a8a6b88ea727bea52/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L1359-L1362
- The GPTQModel library has already been updated to reflect this change. See [PR #1623](https://github.com/ModelCloud/GPTQModel/pull/1623)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Test Plan:

Run the following:
```
from transformers import Qwen2VLForConditionalGeneration, AutoTokenizer, AutoProcessor, GPTQConfig
from qwen_vl_utils import process_vision_info
import torch

gptq_config = GPTQConfig(bits=4, use_exllama=False)
model = Qwen2VLForConditionalGeneration.from_pretrained(
    "Qwen/Qwen2-VL-2B-Instruct-GPTQ-Int4",
    torch_dtype=torch.float16,
    device_map="auto",
    quantization_config=gptq_config
)
```

## Who can review?

@fxmarty, @SunMarc, @Qubitium

<!--
For faster review, we strongly recommend you to ping the following people:
- ONNX / ONNX Runtime : @fxmarty, @echarlaix, @JingyaHuang, @michaelbenayoun
- ONNX Runtime Training: @JingyaHuang
- BetterTransformer: @fxmarty
- GPTQ, quantization: @fxmarty, @SunMarc
- TFLite export: @michaelbenayoun
-->
