### PR TITLE
remove timm from exporters extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,21 +71,18 @@ EXTRAS_REQUIRE = {
     ],
     "exporters": [
         "onnx",
-        "timm",
         "onnxruntime",
         "protobuf>=3.20.1",
         "transformers>=4.36,<4.53.0",
     ],
     "exporters-gpu": [
         "onnx",
-        "timm",
         "onnxruntime-gpu",
         "protobuf>=3.20.1",
         "transformers>=4.36,<4.53.0",
     ],
     "exporters-tf": [
         "onnx",
-        "timm",
         "h5py",
         "tf2onnx",
         "onnxruntime",


### PR DESCRIPTION

Was added in https://github.com/huggingface/optimum/pull/403 but shouldn't be needed 