### PR TITLE
Fix broken Trainer documentation link in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ continue to work.
 
 For an example of a rich moved sections set please see the very end of [the
 `Trainer`
-doc](https://github.com/huggingface/transformers/blob/main/docs/source/main_classes/trainer.mdx)
+doc](https://huggingface.co/docs/transformers/main_classes/trainer)
 in `transformers`.
 
 ## Adding a new tutorial


### PR DESCRIPTION
Replaced the outdated and broken link to the Trainer documentation in the README with the correct, up-to-date URL pointing to the Hugging Face Transformers Trainer documentation. This ensures users can access the relevant Trainer docs without encountering a 404 error.