### PR TITLE
Add import sys.exit to optimum_cli.py

### DIFF
--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -15,6 +15,7 @@
 
 import importlib
 from pathlib import Path
+from sys import exit
 from typing import Dict, List, Optional, Tuple, Type, Union
 
 from ..subpackages import load_subpackages


### PR DESCRIPTION
Add import sys.exit to optimum_cli.py.
optimum_cli.exe when run with no parameters throws error missing name: exit.