### PR TITLE
Propagate library_name parameter in from_pretrained to export

### DIFF
--- a/optimum/onnxruntime/modeling_ort.py
+++ b/optimum/onnxruntime/modeling_ort.py
@@ -299,6 +299,7 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
         use_io_binding: Optional[bool] = None,
         # other arguments
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        library_name: Optional[str] = None,
     ) -> "ORTModel":
         defaut_file_name = file_name or "model.onnx"
         onnx_files = find_files_matching_pattern(
@@ -403,6 +404,7 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         token: Optional[Union[bool, str]] = None,
         # other arguments
+        library_name: Optional[str] = None,
         **kwargs,
     ) -> "ORTModel":
         # this is garanteed to work since we it uses a mapping from model classes to task names
@@ -431,6 +433,7 @@ class ORTModel(ORTSessionMixin, OptimizedModel):
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
+            library_name=library_name,
         )
         maybe_save_preprocessors(model_id, model_save_path, src_subfolder=subfolder)
 


### PR DESCRIPTION
Resolves #2327

Hello!

## Pull Request overview
* Allow `library_name` in `ORTModel....from_pretrained("...", library_name=...)`

## Details
As described in #2327, this will allow exporting and loading models using a specific library name rather than relying on Optimum's automatic inferring of the library. For Sentence Transformers, this allows me to add ONNX exporting to [SparseEncoder](https://sbert.net/docs/sparse_encoder/usage/usage.html) models with:
```python
from pprint import pprint

import torch
from sentence_transformers import SparseEncoder
from optimum.onnxruntime import ORTModelForMaskedLM

# 1. Load a pretrained SparseEncoder model
model = SparseEncoder("naver/splade-cocondenser-ensembledistil")

# Very hackishly override the model to use ORTModelForMaskedLM
class ORTModelForMaskedLMModule(ORTModelForMaskedLM, torch.nn.Module):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        torch.nn.Module.__init__(self)

model[0].auto_model = ORTModelForMaskedLMModule.from_pretrained("naver/splade-cocondenser-ensembledistil", library_name="transformers")

# Encode some texts into sparse embeddings
embeddings = model.encode(["I'm travelling to the grocery store to buy some milk."])

# Decode the embeddings again, the beauty of sparse embeddings
decoded = model.decode(embeddings, top_k=5)
pprint(decoded)
"""
[[('milk', 2.486112356185913),
  ('grocery', 1.7925951480865479),
  ('dairy', 1.6981983184814453),
  ('traveling', 1.5185797214508057),
  ('buy', 1.3063507080078125)]]
"""
```

As Sentence Transformers only exports models in the "transformers" way, I can add this internally in Sentence Transformers so the eventual usage by the end user is simply `model = SparseEncoder("naver/splade-cocondenser-ensembledistil", backend="onnx")`. Note also that I can export with OpenVINO without `library_name` just fine, only ONNX has this issue.

Please let me know if you'd rather go in a different direction here. 

- Tom Aarsen