### PR TITLE
docs: fixed a small typo

### DIFF
--- a/docs/source/concept_guides/quantization.mdx
+++ b/docs/source/concept_guides/quantization.mdx
@@ -161,7 +161,7 @@ this works well with activations.
 
 To effectively quantize a model to `int8`, the steps to follow are:
 
-1. Choose which operators to quantize. Good operators to quantize are the one dominating it terms of computation time,
+1. Choose which operators to quantize. Good operators to quantize are the one dominating in terms of computation time,
 for instance linear projections and matrix multiplications.
 2. Try post-training dynamic quantization, if it is fast enough stop here, otherwise continue to step 3.
 3. Try post-training static quantization which can be faster than dynamic quantization but often with a drop in terms of


### PR DESCRIPTION
# What does this PR do?

It fixes a typo that I found while reading about [quantization](https://huggingface.co/docs/optimum/v1.27.0/concept_guides/quantization).

- `dominating it terms` → `dominating in terms`

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- Exporters (ONNX/OpenVINO) : @echarlaix, @JingyaHuang, @michaelbenayoun, @IlyasMoutawwakil
- GPTQ, quantization: @SunMarc, @IlyasMoutawwakil
-->
