### PR TITLE
Avoid integer truncation in GPTQ perplexity tests

### DIFF
--- a/tests/gptq/test_quantization.py
+++ b/tests/gptq/test_quantization.py
@@ -113,8 +113,8 @@ class GPTQTest(unittest.TestCase):
         the perplexity of the converted models
         """
 
-        self.assertEqual(int(self.fp16_ppl), self.expected_fp16_perplexity)
-        self.assertEqual(int(self.quantized_ppl), self.expected_quantized_perplexity)
+        self.assertAlmostEqual(self.fp16_ppl, self.expected_fp16_perplexity, delta=1.0)
+        self.assertAlmostEqual(self.quantized_ppl, self.expected_quantized_perplexity, delta=1.0)
 
     def test_quantized_layers_class(self):
         """


### PR DESCRIPTION

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
Replace integer truncation in GPTQ perplexity tests with tolerance-based assertions Avoid masking small regressions caused by int() truncation


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- Exporters (ONNX/OpenVINO) : @echarlaix, @JingyaHuang, @michaelbenayoun, @IlyasMoutawwakil
- GPTQ, quantization: @SunMarc, @IlyasMoutawwakil
-->
