### PR TITLE
Handle single-device models without `hf_device_map` after Transformers optimization

### DIFF
--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -61,11 +61,6 @@ def has_device_more_than_cpu():
     return torch.cuda.is_available() or (hasattr(torch, "xpu") and torch.xpu.is_available())
 
 
-def infer_single_device_map_fallback(model):
-    param = next(model.parameters())
-    return {"": param.device}
-
-
 class GPTQQuantizer(object):
     r"""
     A simple API for GPTQ Quantization
@@ -700,7 +695,7 @@ class GPTQQuantizer(object):
             device_map = model.hf_device_map
         else:
             # Transformers: skip accelerate hooks when device_map resolves to a single device
-            device_map = infer_single_device_map_fallback(model)
+            device_map = {"": next(model.parameters())}
 
         self.select_quant_linear(device_map=device_map, pack=True)
 

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -63,9 +63,7 @@ def has_device_more_than_cpu():
 
 def infer_single_device_map_fallback(model):
     param = next(model.parameters())
-    device = param.device
-
-    return {"": device.index or device.type}
+    return {"": param.device}
 
 
 class GPTQQuantizer(object):

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import json
 import os
-from collections import defaultdict
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -60,7 +59,6 @@ logger = getLogger(__name__)
 
 def has_device_more_than_cpu():
     return torch.cuda.is_available() or (hasattr(torch, "xpu") and torch.xpu.is_available())
-
 
 
 def infer_single_device_map_fallback(model):

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -65,13 +65,7 @@ def infer_single_device_map_fallback(model):
     param = next(model.parameters())
     device = param.device
 
-    if device.type == "cuda":
-        return {"": device.index}
-    elif device.type == "cpu":
-        return {"": "cpu"}
-    else:
-        # For completeness (e.g. xpu, mps, etc.)
-        return {"": str(device)}
+    return {"": device.index or device.type}
 
 
 class GPTQQuantizer(object):

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -695,7 +695,7 @@ class GPTQQuantizer(object):
             device_map = model.hf_device_map
         else:
             # Transformers: skip accelerate hooks when device_map resolves to a single device
-            device_map = {"": next(model.parameters())}
+            device_map = {"": next(model.parameters()).device}
 
         self.select_quant_linear(device_map=device_map, pack=True)
 

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -62,10 +62,6 @@ def has_device_more_than_cpu():
 
 
 def infer_single_device_map_fallback(model):
-    """
-    Infer a HF-like device_map for models that do NOT expose `hf_device_map`.
-    """
-
     param = next(model.parameters())
     device = param.device
 


### PR DESCRIPTION
# What does this PR do?
[Do not use accelerate hooks if the device_map has only 1 device ](https://github.com/huggingface/transformers/commit/315dcbe45cee1489a32fc228a80502b0a150936c)
This PR makes device map handling robust to the new Transformers behavior by:

Using `model.hf_device_map` when it is available (multi-device case)

Falling back to inferring the runtime device for single-device models when it is not

The fallback relies on the fact that, in this code path, all model parameters are guaranteed to reside on the same device.

Stacktrace:
```
_____________________________________________________________________________________ ERROR at setup of GPTQTestModuleQuant.test_serialization _____________________________________________________________________________________

cls = <class 'test_quantization.GPTQTestModuleQuant'>

    @classmethod
    def setUpClass(cls):
        """
        Setup quantized model
        """
    
        cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
    
        cls.model_fp16 = AutoModelForCausalLM.from_pretrained(
            cls.model_name, torch_dtype=torch.float16, device_map=cls.device_map_for_quantization
        )
        cls.fp16_mem = cls.model_fp16.get_memory_footprint()
    
        if cls.device_map_for_quantization != "cpu":
            cls.fp16_ppl = evaluate_perplexity(cls.model_fp16, cls.tokenizer)
    
        cls.quantizer = GPTQQuantizer(
            bits=cls.bits,
            dataset=cls.dataset,
            group_size=cls.group_size,
            sym=cls.sym,
            desc_act=cls.desc_act,
            act_group_aware=cls.act_group_aware,
            backend=cls.quant_backend,
            cache_block_outputs=cls.cache_block_outputs,
            modules_in_block_to_quantize=cls.modules_in_block_to_quantize,
        )
>       cls.quantized_model = cls.quantizer.quantize_model(cls.model_fp16, cls.tokenizer).to(cls.device_for_inference)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/gptq/test_quantization.py:96: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/root/miniconda3/envs/gp_311/lib/python3.11/site-packages/torch/utils/_contextlib.py:120: in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
optimum/gptq/quantizer.py:638: in quantize_model
    self.pack_model(model=model, quantizers=quantizers)
optimum/gptq/quantizer.py:694: in pack_model
    self.select_quant_linear(device_map=model.hf_device_map, pack=True)
                                        ^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = BloomForCausalLM(
  (transformer): BloomModel(
    (word_embeddings): Embedding(250880, 1024)
    (word_embeddings_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
    (h): ModuleList(
      (0-23): 24 x BloomBlock(
        (input_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
        (self_attention): BloomAttention(
          (query_key_value): Linear(in_features=1024, out_features=3072, bias=True)
          (dense): Linear(in_features=1024, out_features=1024, bias=True)
          (attention_dropout): Dropout(p=0.0, inplace=False)
        )
        (post_attention_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
        (mlp): BloomMLP(
          (dense_h_to_4h): Linear(in_features=1024, out_features=4096, bias=True)
          (gelu_impl): BloomGelu()
          (dense_4h_to_h): Linear(in_features=4096, out_features=1024, bias=True)
        )
      )
    )
    (ln_f): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
  )
  (lm_head): Linear(in_features=1024, out_features=250880, bias=False)
)
name = 'hf_device_map'

    def __getattr__(self, name: str) -> Union[Tensor, "Module"]:
        if "_parameters" in self.__dict__:
            _parameters = self.__dict__["_parameters"]
            if name in _parameters:
                return _parameters[name]
        if "_buffers" in self.__dict__:
            _buffers = self.__dict__["_buffers"]
            if name in _buffers:
                return _buffers[name]
        if "_modules" in self.__dict__:
            modules = self.__dict__["_modules"]
            if name in modules:
                return modules[name]
>       raise AttributeError(
            f"'{type(self).__name__}' object has no attribute '{name}'"
        )
E       AttributeError: 'BloomForCausalLM' object has no attribute 'hf_device_map'
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- Exporters (ONNX/OpenVINO) : @echarlaix, @JingyaHuang, @michaelbenayoun, @IlyasMoutawwakil
- GPTQ, quantization: @SunMarc, @IlyasMoutawwakil
-->
