### PR TITLE
Fix task inference for models with outdated pipeline_tag

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -771,6 +771,21 @@ class TasksManager:
                 transformers_info = model_info.transformersInfo
                 if pipeline_tag is not None:
                     inferred_task_name = cls.map_from_synonym(model_info.pipeline_tag)
+                    # Cross-check with transformers_info.auto_model when available.
+                    # The auto_model is derived from the model's architecture and is more
+                    # reliable than the pipeline_tag which can be outdated (e.g., models
+                    # tagged as image-to-text that should be image-text-to-text).
+                    if transformers_info is not None:
+                        transformers_auto_model = transformers_info.get("auto_model", None)
+                        if transformers_auto_model is not None:
+                            transformers_auto_model = transformers_auto_model.replace("TF", "")
+                            for task_name, model_loaders in cls._TRANSFORMERS_TASKS_TO_MODEL_LOADERS.items():
+                                if isinstance(model_loaders, str):
+                                    model_loaders = (model_loaders,)
+                                if transformers_auto_model in model_loaders:
+                                    if task_name != inferred_task_name:
+                                        inferred_task_name = task_name
+                                    break
                 elif transformers_info is not None:
                     transformers_pipeline_tag = transformers_info.get("pipeline_tag", None)
                     transformers_auto_model = transformers_info.get("auto_model", None)


### PR DESCRIPTION
Cross-check Hub pipeline_tag with transformers_info.auto_model when available. The auto_model is derived from the model's architecture and is more reliable than the pipeline_tag which can be outdated.

This fixes LLaVA models tagged as image-to-text on the Hub being rejected by the OpenVINO exporter which only supports image-text-to-text for llava.

Fixes huggingface#2400

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

<!--
For faster review, we strongly recommend you to ping the following people:
- Exporters (ONNX/OpenVINO) : @echarlaix, @JingyaHuang, @michaelbenayoun, @IlyasMoutawwakil
- GPTQ, quantization: @SunMarc, @IlyasMoutawwakil
-->
