### PR TITLE
Export __version__ from top-level optimum package

### DIFF
--- a/optimum/__init__.py
+++ b/optimum/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__


### PR DESCRIPTION
## Summary

- Fixes #2188
- Adds `optimum/__init__.py` with `from .version import __version__` so that `import optimum; optimum.__version__` works without raising `AttributeError`
- Previously, `__version__` was defined in `optimum/version.py` but was never re-exported at the package level since the top-level `optimum/` directory had no `__init__.py` (namespace package)

## Test plan

- [ ] Verify `import optimum; print(optimum.__version__)` prints the version string instead of raising `AttributeError`
- [ ] Verify existing imports (`from optimum.version import __version__`, etc.) continue to work
- [ ] Run existing test suite to confirm no regressions