### PR TITLE
Fix get_wikitext2 tokenization bug causing sequence length warning

### DIFF
--- a/optimum/gptq/data.py
+++ b/optimum/gptq/data.py
@@ -125,12 +125,14 @@ def get_wikitext2(tokenizer: Any, seqlen: int, nsamples: int, split: str = "trai
         data = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
     elif split == "validation":
         data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
-    # length of 288059 should be enough
-    text = "".join([" \n" if s == "" else s for s in data["text"][:1000]])
 
-    enc = tokenizer(text, return_tensors="pt")
     dataset = []
     for _ in range(nsamples):
+        while True:
+            i = random.randint(0, len(data) - 1)
+            enc = tokenizer(data[i]["text"], return_tensors="pt")
+            if enc.input_ids.shape[1] >= seqlen:
+                break
         i = random.randint(0, enc.input_ids.shape[1] - seqlen - 1)
         j = i + seqlen
         inp = enc.input_ids[:, i:j]


### PR DESCRIPTION
## Summary

Fixes #2020

`get_wikitext2` was concatenating up to 1000 dataset entries into a single string and tokenizing it all at once. This produced a 73K+ token sequence that exceeds the model's maximum sequence length, triggering the warning:

> Token indices sequence length is longer than the specified maximum sequence length for this model (73218 > 2048). Running this sequence through the model will result in indexing errors

This fix changes the function to tokenize individual samples instead, consistent with how `get_c4` and `get_c4_new` already work. Each sample is tokenized separately and retried with a different random sample if it is shorter than the requested `seqlen`.

## Changes

- Removed concatenation of 1000 text entries into a single string
- Removed bulk tokenization of the entire concatenated text
- Added per-sample tokenization with retry loop (matching `get_c4` / `get_c4_new` pattern)

## Test plan

- [x] Verify `get_wikitext2(tokenizer, nsamples=128, seqlen=32, split="train")` no longer produces the sequence length warning
- [ ] Verify the returned dataset has the correct number of samples and shape
- [ ] Verify quantization workflows using wikitext2 dataset still work correctly