### PR TITLE
Fix Python 3.14+ compatibility for NORMALIZED_CONFIG_CLASS

### DIFF
--- a/optimum/exporters/base.py
+++ b/optimum/exporters/base.py
@@ -148,7 +148,9 @@ class ExporterConfig(ABC):
     ):
         self.task = task
         self._config = config
-        self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+        # Use self.__class__.NORMALIZED_CONFIG_CLASS instead of self.NORMALIZED_CONFIG_CLASS
+        # to avoid the partial being converted to a bound method
+        self._normalized_config = self.__class__.NORMALIZED_CONFIG_CLASS(self._config)
         self.int_dtype = int_dtype
         self.float_dtype = float_dtype
 


### PR DESCRIPTION
# What does this PR do?

Fixes Python 3.14+ compatibility issue where exporting models fails with:
  TypeError: NormalizedConfig.__init__() got multiple values for argument 'allow_new'

Root cause: Python 3.14 made functools.partial a method descriptor (gh-121027).
When NORMALIZED_CONFIG_CLASS is defined via with_args(), accessing it via self.X
triggers the descriptor protocol and converts it to a bound method.
Fix: access via self.__class__.X to bypass the descriptor protocol.

## Testing

Tested with manual export commands:
```bash
optimum-cli export openvino --model hf-internal-testing/tiny-random-gpt2 --task text-generation-with-past output_dir
```

Results:
- Python 3.14 + fixed code: ✅ Export succeeds
- Python 3.14 + PyPI 2.1.0: ❌ TypeError (confirms bug)
- Python 3.12 + fixed code: ✅ Export succeeds (no regression)
