### PR TITLE
docs: add empirical energy efficiency data to quantization concept guide

### DIFF
--- a/docs/source/concept_guides/quantization.mdx
+++ b/docs/source/concept_guides/quantization.mdx
@@ -172,6 +172,34 @@ counterparts.
 6. Evaluate the quantized model: is the accuracy good enough? If yes, stop here, otherwise start again at step 3 but
 with quantization aware training this time.
 
+## Energy efficiency in practice
+
+The introduction above notes that quantization "consumes less energy (in theory)." Systematic benchmarking across
+NVIDIA Ada Lovelace (RTX 4090D) and Blackwell (RTX 5090) architectures reveals that the relationship between
+quantization and energy consumption is more nuanced in practice:
+
+- **Large models (≥5B parameters)**: NF4 quantization achieves near-FP16 energy consumption with significant memory
+savings — the expected benefit holds.
+- **Small models (<3B parameters)**: NF4 quantization can *increase* energy consumption by 25–56% despite achieving
+75% memory compression. The dequantization overhead exceeds the memory bandwidth savings at this scale.
+- **INT8 mixed-precision**: The default `llm_int8_threshold=6.0` in `bitsandbytes` adds 17–33% energy overhead
+compared to FP16, which is a justified cost for maintaining model accuracy.
+- **Batch size effect**: Increasing batch size from 1 to 8–64 reduces per-token energy by 84–96%, often outweighing
+the impact of precision choice.
+
+<Tip>
+
+These findings suggest that energy-optimal deployment depends on model size, precision format, batch size, and
+hardware generation. Quantization remains beneficial for memory reduction, but its energy impact should be validated
+empirically for each deployment scenario.
+
+</Tip>
+
+For detailed benchmarks and interactive visualizations, see the
+[EcoCompute-AI toolkit](https://github.com/hongping-zh/ecocompute-ai) and
+[interactive dashboard](https://hongping-zh.github.io/ecocompute-dynamic-eval/).
+The full dataset is archived on [Zenodo](https://zenodo.org/records/18900289).
+
 ## Supported tools to perform quantization in 🤗 Optimum
 
 🤗 Optimum provides APIs to perform quantization using different tools for different targets:

--- a/docs/source/concept_guides/quantization.mdx
+++ b/docs/source/concept_guides/quantization.mdx
@@ -198,7 +198,8 @@ empirically for each deployment scenario.
 For detailed benchmarks and interactive visualizations, see the
 [EcoCompute-AI toolkit](https://github.com/hongping-zh/ecocompute-ai) and
 [interactive dashboard](https://hongping-zh.github.io/ecocompute-dynamic-eval/).
-The full dataset is archived on [Zenodo](https://zenodo.org/records/18900289).
+The full dataset is available on the [Hugging Face Hub](https://huggingface.co/datasets/hongpingzhang/ecocompute-energy-efficiency)
+and archived on [Zenodo](https://zenodo.org/records/18900289).
 
 ## Supported tools to perform quantization in 🤗 Optimum
 


### PR DESCRIPTION
## Summary

Adds an "Energy efficiency in practice" section to the quantization concept guide (`docs/source/concept_guides/quantization.mdx`), providing empirical data that addresses the existing "(in theory)" qualifier in the introduction.

## Motivation

The current documentation states that quantization "consumes less energy (in theory)." Through systematic benchmarking across multiple GPU architectures and model sizes, we found that this assumption does not always hold — particularly for small models (<3B parameters) where dequantization overhead can increase energy consumption by 25–56%.

This addition provides practitioners with concrete, data-backed guidance on when quantization helps (and when it doesn't) from an energy perspective.

## Changes

Added a new subsection covering:

- **Large models (≥5B)**: NF4 achieves near-FP16 energy with memory savings ✓
- **Small models (<3B)**: NF4 can *increase* energy by 25–56% despite 75% memory compression
- **INT8 mixed-precision**: 17–33% energy overhead as a justified accuracy trade-off
- **Batch size**: 84–96% per-token energy reduction from BS=1 to BS=8–64

## Data Source

- Hardware: NVIDIA RTX 4090D (Ada Lovelace), RTX 5090 (Blackwell), A800
- Models: TinyLlama-1.1B through Qwen2.5-14B (1B–14B parameter range)
- Methodology: NVML power monitoring at 10 Hz, repeated trials, CV < 3%
- Full dataset: [Zenodo](https://zenodo.org/records/18900289)
- Toolkit: [EcoCompute-AI](https://github.com/hongping-zh/ecocompute-ai)
- Interactive dashboard: [https://hongping-zh.github.io/ecocompute-dynamic-eval/](https://hongping-zh.github.io/ecocompute-dynamic-eval/)

## Related

- bitsandbytes PR: [bitsandbytes-foundation/bitsandbytes#1882](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1882)
- Transformers PR: [huggingface/transformers#44407](https://github.com/huggingface/transformers/pull/44407) (approved by @SunMarc)

## Notes

- Content follows existing `.mdx` formatting style and uses the `<Tip>` component
- The section is concise (~200 words) and focuses on practical implications
- Happy to adjust scope, framing, or placement based on maintainer feedback
