### PR TITLE
Fix gptqmodel backend check

### DIFF
--- a/.github/workflows/test_gptq.yml
+++ b/.github/workflows/test_gptq.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip uv
+          uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
           uv pip install .[tests]
           uv pip install pypcre "setuptools>=78.1.1,<82"
           uv pip install "gptqmodel>=5.6.12" --no-build-isolation

--- a/.github/workflows/test_gptq.yml
+++ b/.github/workflows/test_gptq.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           pip install --upgrade pip uv
           uv pip install .[tests]
+          uv pip install pypcre "setuptools>=78.1.1,<82"
           uv pip install "gptqmodel>=5.6.12" --no-build-isolation
 
       - name: Run tests

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -669,7 +669,10 @@ class GPTQQuantizer(object):
         model.quantize_config = StoreAttr()
         model.quantize_config.desc_act = self.desc_act
         model = gptq_post_init(model, use_act_order=self.desc_act)
-        if (hasattr(BACKEND, "EXLLAMA_V1")
+        # Keep this compatibility guard for older gptqmodel versions where EXLLAMA_V1 still exists.
+        # This branch can be removed once we bump the minimum gptqmodel version and drop v1 support.
+        if (
+            hasattr(BACKEND, "EXLLAMA_V1")
             and self.backend == BACKEND.EXLLAMA_V1
             and self.desc_act
             and self.max_input_length is not None

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -669,6 +669,14 @@ class GPTQQuantizer(object):
         model.quantize_config = StoreAttr()
         model.quantize_config.desc_act = self.desc_act
         model = gptq_post_init(model, use_act_order=self.desc_act)
+        if (hasattr(BACKEND, "EXLLAMA_V1")
+            and self.backend == BACKEND.EXLLAMA_V1
+            and self.desc_act
+            and self.max_input_length is not None
+        ):
+            from gptqmodel import exllama_set_max_input_length
+
+            model = exllama_set_max_input_length(model, self.max_input_length)
 
         return model
 

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -669,8 +669,7 @@ class GPTQQuantizer(object):
         model.quantize_config = StoreAttr()
         model.quantize_config.desc_act = self.desc_act
         model = gptq_post_init(model, use_act_order=self.desc_act)
-        if self.desc_act and self.backend == BACKEND.EXLLAMA_V1 and self.max_input_length is not None:
-            model = exllama_set_max_input_length(model, self.max_input_length)
+
         return model
 
     def pack_model(

--- a/optimum/gptq/quantizer.py
+++ b/optimum/gptq/quantizer.py
@@ -47,7 +47,7 @@ if is_accelerate_available():
     from accelerate.hooks import remove_hook_from_module
 
 if is_gptqmodel_available():
-    from gptqmodel import BACKEND, QuantizeConfig, exllama_set_max_input_length
+    from gptqmodel import BACKEND, QuantizeConfig
     from gptqmodel.quantization import FORMAT, GPTQ, METHOD
     from gptqmodel.utils.importer import hf_select_quant_linear_v2
     from gptqmodel.utils.model import hf_convert_gptq_v1_to_v2_format, hf_convert_gptq_v2_to_v1_format


### PR DESCRIPTION
The GPTQModel has deprecated `EXLLAMA_V1` from `BACKEND`, so we can remove this check.

Bug reproduce:
```python
import torch
from transformers import AutoTokenizer, AutoModelForCausalLM

model_id = "hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4"
device = "auto"
prompt = "What is the meaning of life?"

tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device, dtype=torch.bfloat16)

inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
outputs = model.generate(**inputs, max_new_tokens=32)
print(tokenizer.decode(outputs[0], skip_special_tokens=True))
```

output
```
Traceback (most recent call last):
  File "/workspace/jiqing/run_gptqmodel_generation.py", line 9, in <module>
    model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device, dtype=torch.bfloat16)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformers/models/auto/auto_factory.py", line 387, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformers/modeling_utils.py", line 4156, in from_pretrained
    hf_quantizer.postprocess_model(
  File "/usr/local/lib/python3.12/dist-packages/transformers/quantizers/base.py", line 194, in postprocess_model
    return self._process_model_after_weight_loading(model, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformers/quantizers/quantizer_gptq.py", line 98, in _process_model_after_weight_loading
    model = self.optimum_quantizer.post_init_model(model)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/optimum/gptq/quantizer.py", line 672, in post_init_model
    if self.desc_act and self.backend == BACKEND.EXLLAMA_V1 and self.max_input_length is not None:
                                         ^^^^^^^^^^^^^^^^^^
AttributeError: type object 'BACKEND' has no attribute 'EXLLAMA_V1'. Did you mean: 'EXLLAMA_V2'?
```
