### PR TITLE
fix(exporters/tasks): support local timm model paths in ONNX export

### DIFF
--- a/optimum/exporters/tasks.py
+++ b/optimum/exporters/tasks.py
@@ -1174,7 +1174,12 @@ class TasksManager:
             )
 
         if library_name == "timm":
-            model = model_class(f"hf_hub:{model_name_or_path}", pretrained=True, exportable=True)
+            import os
+
+            if os.path.isdir(model_name_or_path):
+                model = model_class(model_name_or_path, pretrained=True, exportable=True)
+            else:
+                model = model_class(f"hf_hub:{model_name_or_path}", pretrained=True, exportable=True)
             model = model.to(torch_dtype).to(device)
         elif library_name == "sentence_transformers":
             token = model_kwargs.pop("token", None)

--- a/tests/exporters/common/test_tasks_manager.py
+++ b/tests/exporters/common/test_tasks_manager.py
@@ -176,16 +176,6 @@ class TasksManagerTestCase(TestCase):
         model = TasksManager.get_model_from_task("question-answering", "uclanlp/visualbert-vqa")
         self.assertTrue(isinstance(model, VisualBertForQuestionAnswering))
 
-    def test_library_detection(self):
-        self.assertEqual(
-            TasksManager.infer_library_from_model("intfloat/multilingual-e5-large"), "sentence_transformers"
-        )
-        self.assertEqual(
-            TasksManager.infer_library_from_model("stabilityai/stable-diffusion-xl-base-1.0"), "diffusers"
-        )
-        self.assertEqual(TasksManager.infer_library_from_model("gpt2"), "transformers")
-        self.assertEqual(TasksManager.infer_library_from_model("timm/mobilenetv3_large_100.ra_in1k"), "timm")
-
     def test_get_model_from_task_timm_local_dir_skips_hf_hub_prefix(self):
         # Regression test for local timm checkpoint loading: a local directory must be
         # passed to the timm model constructor as-is, while a Hub id keeps the
@@ -218,3 +208,13 @@ class TasksManagerTestCase(TestCase):
             model_class.assert_called_once_with(
                 "hf_hub:timm/mobilenetv3_large_100.ra_in1k", pretrained=True, exportable=True
             )
+
+    def test_library_detection(self):
+        self.assertEqual(
+            TasksManager.infer_library_from_model("intfloat/multilingual-e5-large"), "sentence_transformers"
+        )
+        self.assertEqual(
+            TasksManager.infer_library_from_model("stabilityai/stable-diffusion-xl-base-1.0"), "diffusers"
+        )
+        self.assertEqual(TasksManager.infer_library_from_model("gpt2"), "transformers")
+        self.assertEqual(TasksManager.infer_library_from_model("timm/mobilenetv3_large_100.ra_in1k"), "timm")

--- a/tests/exporters/common/test_tasks_manager.py
+++ b/tests/exporters/common/test_tasks_manager.py
@@ -16,6 +16,7 @@ import importlib
 import inspect
 from typing import Optional, Set
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import pytest
 from transformers import BertConfig, Pix2StructForConditionalGeneration, VisualBertForQuestionAnswering
@@ -184,3 +185,61 @@ class TasksManagerTestCase(TestCase):
         )
         self.assertEqual(TasksManager.infer_library_from_model("gpt2"), "transformers")
         self.assertEqual(TasksManager.infer_library_from_model("timm/mobilenetv3_large_100.ra_in1k"), "timm")
+
+    def test_get_model_from_task_timm_local_dir_skips_hf_hub_prefix(self):
+        # Regression test for local timm checkpoint loading: a local directory must be
+        # passed to the timm model constructor as-is, while a Hub id keeps the
+        # "hf_hub:" prefix. Both paths are exercised without network access by mocking
+        # the resolved model class and os.path.isdir.
+        created = MagicMock()
+        created.to.return_value = created
+        model_class = MagicMock(return_value=created)
+
+        with patch.object(TasksManager, "get_model_class_for_task", return_value=model_class):
+            with patch("os.path.isdir", return_value=True):
+                TasksManager.get_model_from_task(
+                    "image-classification",
+                    "/local/path/to/timm_model",
+                    framework="pt",
+                    library_name="timm",
+                )
+            model_class.assert_called_once_with(
+                "/local/path/to/timm_model", pretrained=True, exportable=True
+            )
+
+            model_class.reset_mock()
+            with patch("os.path.isdir", return_value=False):
+                TasksManager.get_model_from_task(
+                    "image-classification",
+                    "timm/mobilenetv3_large_100.ra_in1k",
+                    framework="pt",
+                    library_name="timm",
+                )
+            model_class.assert_called_once_with(
+                "hf_hub:timm/mobilenetv3_large_100.ra_in1k", pretrained=True, exportable=True
+            )
+
+    def test_standardize_sentence_transformers_readonly_config(self):
+        # sentence-transformers >= 5 makes `config` read-only, so the assignment must not raise.
+        class Transformer:
+            def __init__(self, config):
+                self.auto_model = type("AutoModel", (), {"config": config})()
+
+        class SentenceTransformer:
+            def __init__(self, inner):
+                self._modules = [inner]
+
+            def __getitem__(self, idx):
+                return self._modules[idx]
+
+            @property
+            def config(self):
+                return self._modules[0].auto_model.config
+
+        inner_config = BertConfig()
+        st_model = SentenceTransformer(Transformer(inner_config))
+
+        TasksManager.standardize_model_attributes(st_model, library_name="sentence_transformers")
+
+        self.assertEqual(inner_config.export_model_type, "transformer")
+        self.assertIs(st_model.config, inner_config)

--- a/tests/exporters/common/test_tasks_manager.py
+++ b/tests/exporters/common/test_tasks_manager.py
@@ -218,28 +218,3 @@ class TasksManagerTestCase(TestCase):
             model_class.assert_called_once_with(
                 "hf_hub:timm/mobilenetv3_large_100.ra_in1k", pretrained=True, exportable=True
             )
-
-    def test_standardize_sentence_transformers_readonly_config(self):
-        # sentence-transformers >= 5 makes `config` read-only, so the assignment must not raise.
-        class Transformer:
-            def __init__(self, config):
-                self.auto_model = type("AutoModel", (), {"config": config})()
-
-        class SentenceTransformer:
-            def __init__(self, inner):
-                self._modules = [inner]
-
-            def __getitem__(self, idx):
-                return self._modules[idx]
-
-            @property
-            def config(self):
-                return self._modules[0].auto_model.config
-
-        inner_config = BertConfig()
-        st_model = SentenceTransformer(Transformer(inner_config))
-
-        TasksManager.standardize_model_attributes(st_model, library_name="sentence_transformers")
-
-        self.assertEqual(inner_config.export_model_type, "transformer")
-        self.assertIs(st_model.config, inner_config)


### PR DESCRIPTION
## Problem

When exporting locally fine-tuned timm models to ONNX, the export fails with:

```
Repository Not Found for url: https://huggingface.co/my-local-model/resolve/main/config.json
```

**Root cause:** `get_model_from_task` unconditionally prepends `hf_hub:` to the model path when loading timm models (line 1177 in `optimum/exporters/tasks.py`):

```python
# Before fix — always uses HF Hub even for local paths
model = model_class(f"hf_hub:{model_name_or_path}", pretrained=True, exportable=True)
```

This forces timm's `create_model` to treat the path as an HF Hub model ID, breaking local directory paths.

## Fix

Check if `model_name_or_path` is a local directory. If so, pass it directly to `create_model`; otherwise use the `hf_hub:` prefix for Hub models.

```python
# After fix
if os.path.isdir(model_name_or_path):
    model = model_class(model_name_or_path, pretrained=True, exportable=True)
else:
    model = model_class(f"hf_hub:{model_name_or_path}", pretrained=True, exportable=True)
```

## Testing

```bash
# Local timm model (should now work)
optimum-cli export onnx --model ./my-local-timm-model --task image-classification onnx_output/

# HF Hub timm model (should still work)
optimum-cli export onnx --model timm/efficientnet_b0.ra_in1k --task image-classification onnx_output/
```

Fixes #2423