### PR TITLE
fix(cli): resolve subpackage register paths before deduplication

### DIFF
--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -121,8 +121,16 @@ def load_optimum_namespace_cli_commands() -> (
 
     # Find all registration files and load the commands to register
     commands_to_register = []
-    for register_path in set(commands_register_spec.submodule_search_locations):
-        register_path = Path(register_path)
+    # Resolve each path before deduplicating so that symlinked locations collapse to a
+    # single entry. On RHEL/CentOS-derived distros lib64 is a symlink to lib, so both
+    # paths appear in submodule_search_locations; plain set() compares strings and
+    # would treat them as distinct, importing the same register module twice and
+    # raising "argparse.ArgumentError: conflicting subparser" at CLI startup.
+    register_paths = {
+        Path(register_path).resolve()
+        for register_path in commands_register_spec.submodule_search_locations
+    }
+    for register_path in register_paths:
         if not register_path.is_dir():
             # skip non-directory paths
             continue

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import inspect
 import os
 import shutil
@@ -20,6 +21,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import optimum.commands.base
 
@@ -84,6 +86,51 @@ class TestCLI(unittest.TestCase):
         self.assertTrue(succeeded, "The command should succeed here since it is registered.")
 
         REGISTERED_CLI_WITH_CUSTOM_COMMAND_PATH.unlink()
+
+    def test_symlinked_register_paths_are_deduplicated(self):
+        # Regression test: when optimum.commands.register's submodule_search_locations
+        # contains a directory together with a symlink that resolves to the same
+        # directory (e.g. lib64 -> lib on RHEL/CentOS-derived distros), the register
+        # module must be imported only once. Deduplicating on the raw path strings
+        # imports it twice and raises "argparse.ArgumentError: conflicting subparser"
+        # at CLI startup.
+        from optimum.commands import optimum_cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            real_dir = Path(tmp) / "register"
+            real_dir.mkdir()
+            (real_dir / "dummy_register.py").write_text("REGISTER_COMMANDS = []\n")
+
+            link_dir = Path(tmp) / "register_symlink"
+            try:
+                link_dir.symlink_to(real_dir, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks are not supported on this platform")
+
+            fake_spec = mock.MagicMock()
+            fake_spec.submodule_search_locations = [str(real_dir), str(link_dir)]
+
+            imported = []
+
+            def fake_import(name, *args, **kwargs):
+                imported.append(name)
+                module = mock.MagicMock()
+                module.REGISTER_COMMANDS = []
+                return module
+
+            with mock.patch.object(
+                optimum_cli.importlib.util, "find_spec", return_value=fake_spec
+            ), mock.patch.object(
+                optimum_cli.importlib, "import_module", side_effect=fake_import
+            ):
+                optimum_cli.load_optimum_namespace_cli_commands()
+
+            dummy_imports = [name for name in imported if name.endswith("dummy_register")]
+            self.assertEqual(
+                len(dummy_imports),
+                1,
+                f"register module should be imported exactly once, got {imported}",
+            )
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
## Problem

Closes #2417.

On RHEL / CentOS-derived distributions `lib64` is a symlink to `lib`, so both site-packages directories end up in `commands_register_spec.submodule_search_locations`:

```
/home/user/.venv/lib64/python3.12/site-packages
/home/user/.venv/lib/python3.12/site-packages
```

`register_optimum_cli_subcommands` deduplicates that list with a plain `set(...)`, which compares the raw path strings. Since the strings differ, the same register module is imported twice — once via `lib`, once via `lib64`. The duplicate `REGISTER_COMMANDS` entries then try to register identical subparsers and any `optimum-cli` invocation that pulls in a subpackage (e.g. `optimum-cli export onnx --help`) blows up with:

```
argparse.ArgumentError: argument {onnx}: conflicting subparser: onnx
```

Ubuntu / Debian only ship `lib`, so the bug never surfaced there. The reporter narrowed it down on CentOS Stream 10; it also reproduces on Fedora, RHEL 8/9 and any virtualenv created on those distros.

## Fix

Resolve each candidate path with `Path.resolve()` before building the deduplication set. Symlinked siblings collapse to one canonical absolute path, so the registration loop runs exactly once per real directory.

```python
register_paths = {
    Path(register_path).resolve()
    for register_path in commands_register_spec.submodule_search_locations
}
for register_path in register_paths:
    ...
```

The rest of the loop is unchanged — `register_path` was already being wrapped in `Path(...)` on the first line of the body, so the resolved `Path` object is a drop-in replacement.

## Why this is safe

- **No behavior change on Ubuntu / Debian / Windows / macOS** — `submodule_search_locations` contains a single entry, `Path.resolve()` returns it unchanged.
- **No new dependency** — `pathlib.Path` is already imported at the top of the module.
- **No double-iteration** — the comprehension materializes the set before the loop begins, matching the previous semantics.
- **`commands_register_spec.submodule_search_locations is None` short-circuit** is preserved (lines above the change).

## Reproduction (matches the issue)

```bash
# CentOS Stream 10 / Fedora / RHEL 8+
python3 -m venv .venv && source .venv/bin/activate
pip install optimum optimum-onnx
python -c "import sys; [print(p) for p in sys.path if 'site-packages' in p]"
# -> shows both lib and lib64 paths
optimum-cli export onnx --help
# Before: argparse.ArgumentError: conflicting subparser: onnx
# After:  prints the help text
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)