### PR TITLE
fix: resolve submodule search locations to prevent duplicate subcommands

### DIFF
--- a/optimum/commands/optimum_cli.py
+++ b/optimum/commands/optimum_cli.py
@@ -121,8 +121,7 @@ def load_optimum_namespace_cli_commands() -> (
 
     # Find all registration files and load the commands to register
     commands_to_register = []
-    for register_path in set(commands_register_spec.submodule_search_locations):
-        register_path = Path(register_path)
+    for register_path in {Path(p).resolve() for p in commands_register_spec.submodule_search_locations}:
         if not register_path.is_dir():
             # skip non-directory paths
             continue


### PR DESCRIPTION
Closes #2417.

On RHEL-family distributions, both \lib\ and \lib64\ are added to \sys.path\ even though one is a symlink to the other. This causes the \optimum.commands.register\ namespace to yield the same directory under different path strings. When \optimum-cli\ uses a plain \set()\ to deduplicate \commands_register_spec.submodule_search_locations\, it fails to collapse the symlinked paths, resulting in sub-commands like \onnx\ being registered twice and causing an \rgparse.ArgumentError\.

This PR fixes the issue by resolving the paths using \pathlib.Path.resolve()\ before deduplicating them.