### PR TITLE
fix(utils): use default_factory for mutable dataclass fields

### DIFF
--- a/optimum/utils/runs.py
+++ b/optimum/utils/runs.py
@@ -227,7 +227,7 @@ class _RunDefaults:
         metadata={"description": "Maximum number of samples to use from the evaluation dataset for evaluation."},
     )
     time_benchmark_args: Optional[BenchmarkTimeArgs] = field(
-        default=BenchmarkTimeArgs(), metadata={"description": "Parameters related to time benchmark."}
+        default_factory=BenchmarkTimeArgs, metadata={"description": "Parameters related to time benchmark."}
     )
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes a `ValueError` that occurs during module initialization in modern Python versions due to the use of a mutable default value in a `dataclass`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? - This is a syntax/initialization fix, existing tests should cover it.

## Who can review?

@michaelbenayoun @IlyasMoutawwakil