### PR TITLE
bump to python 3.10 for workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         runs-on: [ubuntu-22.04]
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         runs-on: [ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -44,4 +44,4 @@ jobs:
         run: |
           pytest tests/common -vvvv --durations=0
         env:
-          HUGGINGFACE_CO_STAGING: ${{ matrix.python-version == '3.9' && matrix.runs-on == 'ubuntu-22.04' }}
+          HUGGINGFACE_CO_STAGING: ${{ matrix.python-version == '3.10' && matrix.runs-on == 'ubuntu-22.04' }}

--- a/.github/workflows/test_exporters_common.yml
+++ b/.github/workflows/test_exporters_common.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         runs-on: [ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test_fx_optimization.yml
+++ b/.github/workflows/test_fx_optimization.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_pipelines.yml
+++ b/.github/workflows/test_pipelines.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         runs-on: [ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test_utils.yml
+++ b/.github/workflows/test_utils.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
         runs-on: [ubuntu-22.04, macos-14, windows-2022]
 
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
needed as python 3.9 deprecated since transformers v5 and https://github.com/huggingface/transformers/pull/41268