### PR TITLE
Add namespace when loading wikitext dataset

### DIFF
--- a/optimum/gptq/data.py
+++ b/optimum/gptq/data.py
@@ -122,9 +122,9 @@ def get_wikitext2(tokenizer: Any, seqlen: int, nsamples: int, split: str = "trai
         raise ImportError(DATASETS_IMPORT_ERROR.format("get_wikitext2"))
 
     if split == "train":
-        data = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+        data = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="train")
     elif split == "validation":
-        data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+        data = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="test")
     # length of 288059 should be enough
     text = "".join([" \n" if s == "" else s for s in data["text"][:1000]])
 

--- a/optimum/gptq/eval.py
+++ b/optimum/gptq/eval.py
@@ -9,7 +9,7 @@ def evaluate_perplexity(model, tokenizer):
         return torch.exp(torch.stack(nlls).sum() / (n_samples * seqlen))
 
     # load and prepare dataset
-    data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+    data = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="test")
     data = tokenizer("\n\n".join(data["text"]), return_tensors="pt")
     data = data.input_ids.to(model.device)
 


### PR DESCRIPTION
fix https://github.com/huggingface/optimum/actions/runs/26833981869/job/79122752650 

```
FAILED tests/gptq/test_quantization.py::GPTQDataTest::test_dataset_0_wikitext2 - huggingface_hub.errors.HfUriError: Invalid HF URI 'hf://datasets/wikitext@b08601e04326c79dfdd32d625aee71d232d685c3/.huggingface.yaml'. Repository id must be 'namespace/name', got 'wikitext'.
```