### PR TITLE
Fix #2407: Fix get_wikitext2 tokenization bug causing sequence length warning

### DIFF
--- a/optimum/gptq/data.py
+++ b/optimum/gptq/data.py
@@ -125,17 +125,19 @@ def get_wikitext2(tokenizer: Any, seqlen: int, nsamples: int, split: str = "trai
         data = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="train")
     elif split == "validation":
         data = load_dataset("Salesforce/wikitext", "wikitext-2-raw-v1", split="test")
-    # length of 288059 should be enough
-    text = "".join([" \n" if s == "" else s for s in data["text"][:1000]])
-
-    enc = tokenizer(text, return_tensors="pt")
     dataset = []
     for _ in range(nsamples):
+        while True:
+            i = random.randint(0, len(data) - 1)
+            enc = tokenizer(data[i]["text"], return_tensors="pt")
+            if enc.input_ids.shape[1] >= seqlen:
+                break
         i = random.randint(0, enc.input_ids.shape[1] - seqlen - 1)
         j = i + seqlen
         inp = enc.input_ids[:, i:j]
         attention_mask = torch.ones_like(inp)
         dataset.append({"input_ids": inp, "attention_mask": attention_mask})
+
     return dataset
 
 


### PR DESCRIPTION
Fixes #2407

Changed `get_wikitext2` from concatenating 1000 entries into a single string and tokenizing all at once (producing 73K+ token sequences that exceed the model's max length), to per-sample tokenization with a retry loop matching `get_c4`/`get_c4_new`.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.