### PR TITLE
Add squeezebert to NormalizedConfigManager

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -303,6 +303,7 @@ class NormalizedConfigManager:
         "segformer": NormalizedSegformerConfig,
         "speech_to_text": SpeechToTextLikeNormalizedTextConfig,
         "splinter": NormalizedTextConfig,
+        "squeezebert": NormalizedTextConfig,
         "t5": T5LikeNormalizedTextConfig,
         "trocr": TrOCRLikeNormalizedTextConfig,
         "vision-encoder-decoder": NormalizedEncoderDecoderConfig,

--- a/tests/utils/test_normalized_config.py
+++ b/tests/utils/test_normalized_config.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from optimum.utils.normalized_config import NormalizedConfigManager, NormalizedTextConfig
+
+
+class NormalizedConfigManagerTest(unittest.TestCase):
+    def test_squeezebert_is_registered(self):
+        config_class = NormalizedConfigManager.get_normalized_config_class("squeezebert")
+        self.assertIs(config_class, NormalizedTextConfig)


### PR DESCRIPTION
Part of #351

Adds the missing `NormalizedConfigManager` entry for `model_type="squeezebert"` so it can be used with ONNX Runtime optimization.