### PR TITLE
Add swinv2 to NormalizedConfigManager mapping

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -303,6 +303,7 @@ class NormalizedConfigManager:
         "segformer": NormalizedSegformerConfig,
         "speech_to_text": SpeechToTextLikeNormalizedTextConfig,
         "splinter": NormalizedTextConfig,
+        "swinv2": NormalizedVisionConfig,
         "t5": T5LikeNormalizedTextConfig,
         "trocr": TrOCRLikeNormalizedTextConfig,
         "vision-encoder-decoder": NormalizedEncoderDecoderConfig,


### PR DESCRIPTION
## What does this PR do?

Fixes #2140.

`NormalizedConfigManager` raises a `KeyError` for the `swinv2` model type
because it is missing from the `_conf` mapping in
`optimum/utils/normalized_config.py`. This breaks ONNX Runtime
optimization for Swin Transformer V2 models.

This PR adds a single entry mapping `"swinv2"` to `NormalizedVisionConfig`,
following the same pattern already used for the sibling `"donut-swin"`
entry. `Swinv2Config` exposes `image_size` and `num_channels` attributes
(see `transformers/models/swinv2/configuration_swinv2.py`), which is
exactly what `NormalizedVisionConfig` expects (`IMAGE_SIZE = "image_size"`,
`NUM_CHANNELS = "num_channels"`), so no new normalized config class is
needed.

## Change

Single-line addition, alphabetically ordered per the file's contribution
convention:

```python
"swinv2": NormalizedVisionConfig,
```

## Before submitting

- [x] Verified `Swinv2Config` attributes (`image_size`, `num_channels`)
      match `NormalizedVisionConfig` expectations
- [x] Ran `ruff check` on the modified file — all checks passed
- [x] Change is limited to `optimum/utils/normalized_config.py`

Closes #2140

> **Note:** Claude Code was used to assist in drafting this fix. All changes were reviewed by the submitter.
