### PR TITLE
Fix safetensors detection in try_collect_weight_map (missing dot in glob)

### DIFF
--- a/optimum/fx/parallelization/utils.py
+++ b/optimum/fx/parallelization/utils.py
@@ -464,7 +464,7 @@ def try_collect_weight_map(model_name_or_path: str, cache_dir: Optional[str], fo
     from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, WEIGHTS_INDEX_NAME
 
     weight_map = {}
-    use_safetensors, weight_patterns = False, ["*safetensors", "*.bin"]
+    use_safetensors, weight_patterns = False, ["*.safetensors", "*.bin"]
     for pattern in weight_patterns:
         if len(glob.glob(os.path.join(folder_path, pattern))) > 0:
             use_safetensors = pattern == "*.safetensors"


### PR DESCRIPTION
## Problem

`try_collect_weight_map` (`optimum/fx/parallelization/utils.py`) builds its weight-file glob patterns with the safetensors dot missing:

```python
use_safetensors, weight_patterns = False, ["*safetensors", "*.bin"]
for pattern in weight_patterns:
    if len(glob.glob(os.path.join(folder_path, pattern))) > 0:
        use_safetensors = pattern == "*.safetensors"   # compares against the DOTTED form
        break
```

`"*safetensors"` still matches real files (`glob("*safetensors")` matches `model.safetensors`), so the loop breaks on it — but `use_safetensors = ("*safetensors" == "*.safetensors")` is **always False**, even for a safetensors-only model.

## Impact

With `use_safetensors` stuck False, for a safetensors model:
- `index_path` uses `WEIGHTS_INDEX_NAME` (`pytorch_model.bin.index.json`) instead of `SAFE_WEIGHTS_INDEX_NAME` → the real `model.safetensors.index.json` is never read.
- `weight_files` globs `*.bin` → empty for a safetensors model.
- `convert_bin_to_safetensors` runs on every call (acquires a file lock; no-op with no bin files).

`try_collect_weight_map` is called from `optimum/fx/parallelization/api.py` in the FX tensor-parallelism `parallelize_model` flow.

## Evidence (siblings prove intent)

The three other references in the same function all use the dotted `"*.safetensors"`:
- `use_safetensors = pattern == "*.safetensors"`
- `glob.glob(os.path.join(folder_path, "*.safetensors" if use_safetensors else "*.bin"))`
- `glob.glob(os.path.join(folder_path, "*.safetensors"))`

The sibling `"*.bin"` entry in the same list has its dot; only the safetensors entry is missing it.

## Reproduction

Synthetic sharded-safetensors dir (`model-0000{1,2}-of-00002.safetensors` + `model.safetensors.index.json`):

| | use_safetensors | index used | weight_files |
|---|---|---|---|
| before (`*safetensors`) | `False` ❌ | `pytorch_model.bin.index.json` | `[]` |
| after (`*.safetensors`) | `True` ✅ | `model.safetensors.index.json` | both shards |

## Fix

```python
use_safetensors, weight_patterns = False, ["*.safetensors", "*.bin"]
```
