### PR TITLE
Fix dummy input docstring typos

### DIFF
--- a/optimum/exporters/base.py
+++ b/optimum/exporters/base.py
@@ -51,14 +51,14 @@ GENERATE_DUMMY_DOCSTRING = r"""
             image_height (`int`, defaults to {height}):
                 The height to use in the dummy inputs for vision tasks.
             num_channels (`int`, defaults to {num_channels}):
-                The number of channels to use in the dummpy inputs for vision tasks.
+                The number of channels to use in the dummy inputs for vision tasks.
             feature_size (`int`, defaults to {feature_size}):
-                The number of features to use in the dummpy inputs for audio tasks in case it is not raw audio.
+                The number of features to use in the dummy inputs for audio tasks in case it is not raw audio.
                 This is for example the number of STFT bins or MEL bins.
             nb_max_frames (`int`, defaults to {nb_max_frames}):
-                The number of frames to use in the dummpy inputs for audio tasks in case the input is not raw audio.
+                The number of frames to use in the dummy inputs for audio tasks in case the input is not raw audio.
             audio_sequence_length (`int`, defaults to {audio_sequence_length}):
-                The number of frames to use in the dummpy inputs for audio tasks in case the input is raw audio.
+                The number of frames to use in the dummy inputs for audio tasks in case the input is raw audio.
 
         Returns:
             `Dict[str, [tf.Tensor, torch.Tensor]]`: A dictionary mapping the input names to dummy tensors in the proper framework format.


### PR DESCRIPTION
# What does this PR do?

Fix four `dummpy inputs` typos in `GENERATE_DUMMY_DOCSTRING`. This template is attached to `ExporterConfig.generate_dummy_inputs`, so the misspellings surface in its generated API documentation.

This is a documentation-only change with no runtime behavior or dependency changes.

## Validation

- Parsed `optimum/exporters/base.py` with Python `ast` and compiled the source.
- Extracted the generated docstring and checked that `dummpy` is absent and the corrected parameter descriptions are present.
- Ran `git diff --check`.

## Before submitting

- [x] This PR fixes a typo or improves the docs.
- [x] No documentation or runtime tests need to be added for this text-only correction.