### PR TITLE
Add ConvBERT to NormalizedConfigManager

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -259,6 +259,7 @@ class NormalizedConfigManager:
         "falcon": NormalizedTextConfig,
         "camembert": NormalizedTextConfig,
         "codegen": GPT2LikeNormalizedTextConfig,
+        "convbert": NormalizedTextConfig,
         "cvt": NormalizedVisionConfig,
         "deberta": NormalizedTextConfig,
         "deberta-v2": NormalizedTextConfig,

--- a/tests/utils/test_dummpy_input_generators.py
+++ b/tests/utils/test_dummpy_input_generators.py
@@ -30,7 +30,10 @@ if TYPE_CHECKING:
     from optimum.utils.input_generators import DummyInputGenerator
 
 
-TEXT_ENCODER_MODELS = {"distilbert": "hf-internal-testing/tiny-random-DistilBertModel"}
+TEXT_ENCODER_MODELS = {
+    "convbert": "hf-internal-testing/tiny-random-ConvBertModel",
+    "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
+}
 
 VISION_MODELS = {"resnet": "hf-internal-testing/tiny-random-resnet"}
 


### PR DESCRIPTION
# What does this PR do?

Adds ConvBERT support to `NormalizedConfigManager`, part of the "add all models" effort in #351.

- Registers `"convbert"` in `NormalizedConfigManager._conf`, mapping to `NormalizedTextConfig` (ConvBERT exposes standard `hidden_size`, `num_hidden_layers`, `num_attention_heads` attributes).
- Adds `convbert` to `TEXT_ENCODER_MODELS` in the dummy-input-generator tests, so the existing `test_text_models` suite now covers it.

Verified locally: `pytest tests/utils/test_dummpy_input_generators.py -k text` passes (16 passed), and the normalized config resolves the correct heads/hidden/layers for ConvBERT.

Part of #351.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue? (#351)
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?