### PR TITLE
docs: fix float16 accumulation data type

### DIFF
--- a/docs/source/concept_guides/quantization.mdx
+++ b/docs/source/concept_guides/quantization.mdx
@@ -15,7 +15,7 @@ The basic idea behind quantization is quite easy: going from high-precision repr
 floating-point) for weights and activations to a lower precision data type. The most common lower precision data types
 are:
 
-- `float16`, accumulation data type `float16`
+- `float16`, accumulation data type `float32`
 - `bfloat16`, accumulation data type `float32`
 - `int16`, accumulation data type `int32`
 - `int8`, accumulation data type `int32`


### PR DESCRIPTION
# What does this PR do?

Related to huggingface/hub-docs#1550

Corrects the accumulation data type for `float16` in the quantization concept guide.

The documentation currently lists `float16` as both the storage and accumulation data type. This is inconsistent with the surrounding explanation, which describes using a higher-precision accumulation type to avoid overflow and precision loss.

This PR updates:

`float16, accumulation data type float16`

to:

`float16, accumulation data type float32`

This is a documentation-only fix; no code changes or tests are required.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?