### PR TITLE
Export optimum.__version__ without breaking the namespace package

### DIFF
--- a/optimum/__init__.py
+++ b/optimum/__init__.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pkgutil import extend_path
+
+from .version import __version__
+
+
+# Keep the `optimum` namespace split across distributions (optimum-onnx, optimum-intel, ...).
+__path__ = extend_path(__path__, __name__)

--- a/tests/common/test_version.py
+++ b/tests/common/test_version.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import optimum
+from optimum.version import __version__ as package_version
+
+
+class VersionTester(unittest.TestCase):
+    def test_dunder_version_matches_package(self):
+        self.assertEqual(optimum.__version__, package_version)
+
+    def test_dunder_version_is_nonempty_string(self):
+        self.assertIsInstance(optimum.__version__, str)
+        self.assertTrue(optimum.__version__)
+
+    def test_package_path_is_searchable(self):
+        self.assertTrue(hasattr(optimum, "__path__"))
+        self.assertGreater(len(list(optimum.__path__)), 0)


### PR DESCRIPTION
Fixes #2188

`import optimum; print(optimum.__version__)` currently raises `AttributeError`. The version string already lives in `optimum/version.py`. It was never re-exported at the package root because this tree is a namespace package (no `__init__.py`), which is how `optimum-onnx` and `optimum-intel` attach themselves.

#2406 added a bare `__init__.py` and went stale. A bare init would turn `optimum` into a regular package and drop other install paths from `__path__`.

This PR adds a thin `__init__.py` that:

1. Re-exports `__version__` from `optimum.version`.
2. Calls `pkgutil.extend_path` so split installs still resolve.

**Check**

```
PYTHONPATH=. python3 -c "import optimum; print(optimum.__version__)"
```

prints `2.4.0.dev0`. Existing `from optimum.version import __version__` is unchanged.

Added `tests/common/test_version.py` for the attribute and that `__path__` stays searchable.

Claimed with `#take` on #2188: https://github.com/huggingface/optimum/issues/2188#issuecomment-5331087868