### PR TITLE
Respect type_vocab_size in DummyTextInputGenerator for token_type_ids

### DIFF
--- a/optimum/utils/input_generators.py
+++ b/optimum/utils/input_generators.py
@@ -412,6 +412,13 @@ class DummyTextInputGenerator(DummyInputGenerator):
         self.padding_side = padding_side
         self.normalized_config = normalized_config
 
+        if normalized_config.has_attribute("type_vocab_size"):
+            self.type_vocab_size = normalized_config.type_vocab_size
+        else:
+            self.type_vocab_size = getattr(getattr(normalized_config, "config", None), "type_vocab_size", 2)
+        if self.type_vocab_size is None or self.type_vocab_size <= 0:
+            self.type_vocab_size = 2
+
     def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
         min_value = 0
 
@@ -419,6 +426,8 @@ class DummyTextInputGenerator(DummyInputGenerator):
             max_value = self.sequence_length
         elif input_name == "input_ids":
             max_value = self.vocab_size
+        elif input_name == "token_type_ids":
+            max_value = self.type_vocab_size
         else:
             max_value = 2
 

--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -90,6 +90,7 @@ class NormalizedTextConfig(NormalizedConfig):
     NUM_LAYERS = "num_hidden_layers"
     NUM_ATTENTION_HEADS = "num_attention_heads"
     EOS_TOKEN_ID = "eos_token_id"
+    TYPE_VOCAB_SIZE = "type_vocab_size"
 
 
 class NormalizedTextConfigWithGQA(NormalizedTextConfig):

--- a/tests/utils/test_dummpy_input_generators.py
+++ b/tests/utils/test_dummpy_input_generators.py
@@ -230,3 +230,36 @@ class GenerateDummy(TestCase):
         self.validate_shape_for_all_frameworks(
             input_generator, "input_features", (batch_size, feature_size, nb_max_frames)
         )
+
+    def test_dummy_text_input_type_vocab_size(self):
+        from transformers import BertConfig
+
+        for type_vocab_size in [1, 2, 5]:
+            config = BertConfig(vocab_size=100, type_vocab_size=type_vocab_size)
+            normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
+            normalized_config = normalized_config_class(config)
+
+            self.assertEqual(normalized_config.type_vocab_size, type_vocab_size)
+
+            input_generator = DummyTextInputGenerator(
+                task="text-classification",
+                normalized_config=normalized_config,
+                batch_size=2,
+                sequence_length=16,
+            )
+
+            # Validate PyTorch generation
+            pt_token_type_ids = input_generator.generate("token_type_ids", framework="pt")
+            self.assertEqual(pt_token_type_ids.shape, (2, 16))
+            self.assertTrue((pt_token_type_ids >= 0).all().item())
+            self.assertTrue((pt_token_type_ids < type_vocab_size).all().item())
+            if type_vocab_size == 1:
+                self.assertTrue((pt_token_type_ids == 0).all().item())
+
+            # Validate NumPy generation
+            np_token_type_ids = input_generator.generate("token_type_ids", framework="np")
+            self.assertEqual(np_token_type_ids.shape, (2, 16))
+            self.assertTrue((np_token_type_ids >= 0).all())
+            self.assertTrue((np_token_type_ids < type_vocab_size).all())
+            if type_vocab_size == 1:
+                self.assertTrue((np_token_type_ids == 0).all())


### PR DESCRIPTION
# What does this PR do?

Fixes #1777

`DummyTextInputGenerator.generate` hardcoded `max_value = 2` when generating dummy `token_type_ids`. For models with `type_vocab_size = 1` (such as `ruRoPEBert` and custom BERT variants), generating a token type id of 1 causes an `IndexError` on embedding lookup during ONNX tracing and export.

This PR:
1. Adds `TYPE_VOCAB_SIZE = "type_vocab_size"` to `NormalizedTextConfig`.
2. Updates `DummyTextInputGenerator` to read `type_vocab_size` from `normalized_config`, falling back safely to 2 when unset or non-positive.
3. Uses `self.type_vocab_size` as `max_value` when generating `token_type_ids`.
4. Adds unit test `test_dummy_text_input_type_vocab_size` in `tests/utils/test_dummpy_input_generators.py` validating `token_type_ids` generation in PyTorch and NumPy for `type_vocab_size` values 1, 2, and 5.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?
- Exporters (ONNX/OpenVINO): @michaelbenayoun, @echarlaix
