### PR TITLE
Add CLIP normalized configuration support

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -128,13 +128,17 @@ class NormalizedTextAndVisionConfig(NormalizedTextConfig, NormalizedVisionConfig
 
     def __getattr__(self, attr_name):
         if self.TEXT_CONFIG is not None and attr_name.upper() in dir(NormalizedTextConfig):
-            attr_name = f"{self.TEXT_CONFIG}.{attr_name}"
+            attr_name = f"{self.TEXT_CONFIG}.{getattr(NormalizedTextConfig, attr_name.upper())}"
         elif self.VISION_CONFIG is not None and attr_name.upper() in dir(NormalizedVisionConfig):
-            attr_name = f"{self.VISION_CONFIG}.{attr_name}"
+            attr_name = f"{self.VISION_CONFIG}.{getattr(NormalizedVisionConfig, attr_name.upper())}"
         return super().__getattr__(attr_name)
 
 
 Pix2StructNormalizedTextConfig = NormalizedTextAndVisionConfig.with_args(
+    text_config="text_config", vision_config="vision_config"
+)
+
+CLIPNormalizedTextAndVisionConfig = NormalizedTextAndVisionConfig.with_args(
     text_config="text_config", vision_config="vision_config"
 )
 
@@ -258,6 +262,7 @@ class NormalizedConfigManager:
         "bloom": BloomNormalizedTextConfig,
         "falcon": NormalizedTextConfig,
         "camembert": NormalizedTextConfig,
+        "clip": CLIPNormalizedTextAndVisionConfig,
         "codegen": GPT2LikeNormalizedTextConfig,
         "cvt": NormalizedVisionConfig,
         "deberta": NormalizedTextConfig,

--- a/tests/utils/test_normalized_config.py
+++ b/tests/utils/test_normalized_config.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from transformers import CLIPConfig
+
+from optimum.utils.normalized_config import NormalizedConfigManager
+
+
+class NormalizedConfigTest(TestCase):
+    def test_clip_text_and_vision_attributes(self):
+        config = CLIPConfig()
+        normalized_config_class = NormalizedConfigManager.get_normalized_config_class(config.model_type)
+        normalized_config = normalized_config_class(config)
+
+        self.assertEqual(normalized_config.vocab_size, config.text_config.vocab_size)
+        self.assertEqual(normalized_config.hidden_size, config.text_config.hidden_size)
+        self.assertEqual(normalized_config.num_layers, config.text_config.num_hidden_layers)
+        self.assertEqual(normalized_config.num_attention_heads, config.text_config.num_attention_heads)
+        self.assertEqual(normalized_config.image_size, config.vision_config.image_size)
+        self.assertEqual(normalized_config.num_channels, config.vision_config.num_channels)


### PR DESCRIPTION
## Summary\n- add the missing CLIP entry to NormalizedConfigManager\n- resolve normalized text/vision attribute names before traversing nested configs\n- add an offline regression test covering CLIP text and vision attributes\n\n## Validation\n- python -m pytest tests/utils/test_normalized_config.py -q\n- python -m compileall -q optimum/utils/normalized_config.py tests/utils/test_normalized_config.py\n- python -m ruff check optimum/utils/normalized_config.py tests/utils/test_normalized_config.py\n- git diff --check\n\nThe broader dummy-input test file could not be collected locally because the checkout does not have the parameterized dependency installed.\n\nCloses #351