### PR TITLE
Fix semantic version ordering for compatible configuration files

### DIFF
--- a/optimum/configuration_utils.py
+++ b/optimum/configuration_utils.py
@@ -111,7 +111,7 @@ class BaseConfig(PretrainedConfig):
             if search is not None:
                 v = search.groups()[0]
                 configuration_files_map[v] = file_name
-        available_versions = sorted(configuration_files_map.keys())
+        available_versions = sorted(configuration_files_map.keys(), key=version.parse)
 
         # Defaults to FULL_CONFIGURATION_FILE and then try to look at some newer versions.
         configuration_file = cls.CONFIG_NAME

--- a/tests/common/test_configuration_utils.py
+++ b/tests/common/test_configuration_utils.py
@@ -12,8 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 from huggingface_hub import login
 from transformers.testing_utils import TOKEN, TemporaryHubRepo, is_staging_test
@@ -39,6 +42,22 @@ class ConfigTester(unittest.TestCase):
             config_second = FakeConfig.from_pretrained(tmpdirname)
 
         self.assertEqual(config_second.to_dict(), config_first.to_dict())
+
+    def test_from_pretrained_selects_latest_compatible_configuration(self):
+        configuration_files = ["fake_config1.9.0.json", "fake_config1.10.0.json", "fake_config99.0.0.json"]
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            directory = Path(tmpdirname)
+            (directory / FakeConfig.CONFIG_NAME).write_text(
+                json.dumps({"configuration_files": configuration_files, "attribute": 0}), encoding="utf-8"
+            )
+            for attribute, filename in enumerate(configuration_files, start=9):
+                (directory / filename).write_text(json.dumps({"attribute": attribute}), encoding="utf-8")
+
+            for optimum_version, expected_attribute in [("1.9.0", 9), ("1.10.0", 10)]:
+                with self.subTest(optimum_version=optimum_version):
+                    with patch("optimum.configuration_utils.__version__", optimum_version):
+                        config = FakeConfig.from_pretrained(tmpdirname, local_files_only=True)
+                    self.assertEqual(config.attribute, expected_attribute)
 
 
 @is_staging_test


### PR DESCRIPTION
# What does this PR do?

I've changed the configuration-file sort to use parsed versions instead of filenames. With `config1.9.0.json` and `config1.10.0.json`, the current ordering can select 1.9.0 or stop before reaching a compatible file.

The regression loads local configuration files and covers both cases. The same reproduction selects 1.10.0 after the fix.

## Tests

- Configuration tests: 2 passed, 2 skipped, 2 subtests passed. The skipped cases require Hub staging.
- `make style` and `uv pip check` passed.

Tested on Linux/CPU in a sparse checkout. Backend, export and GPU suites were not run.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [ ] Did you make sure to update the documentation with your changes? No API or documented behavior change.
- [x] Did you write any new necessary tests?

I used AI for this patch; this has been manually reviewed.
