### PR TITLE
Add MobileBert to NormalizedConfigManager

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -233,7 +233,6 @@ class NormalizedConfigManager:
         'layoutlm',
         'layoutlmv3',
         'levit',
-        'mobilebert',
         'mobilevit',
         'owlv2',
         'owlvit',
@@ -315,6 +314,7 @@ class NormalizedConfigManager:
         "qwen3_moe": NormalizedTextConfig,
         "smollm3": NormalizedTextConfig,
         "granite": NormalizedTextConfigWithGQA,
+        "mobilebert": NormalizedTextConfig,
     }
 
     @classmethod

--- a/tests/utils/test_dummpy_input_generators.py
+++ b/tests/utils/test_dummpy_input_generators.py
@@ -30,7 +30,10 @@ if TYPE_CHECKING:
     from optimum.utils.input_generators import DummyInputGenerator
 
 
-TEXT_ENCODER_MODELS = {"distilbert": "hf-internal-testing/tiny-random-DistilBertModel"}
+TEXT_ENCODER_MODELS = {
+    "distilbert": "hf-internal-testing/tiny-random-DistilBertModel",
+    "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel"
+}
 
 VISION_MODELS = {"resnet": "hf-internal-testing/tiny-random-resnet"}
 


### PR DESCRIPTION
# What does this PR do?

This PR adds `MobileBert` to the `NormalizedConfigManager` to help extend ONNX optimization support. 

**Changes:**
* Mapped `mobilebert` to `NormalizedTextConfig` in `optimum/utils/normalized_config.py`.
* Removed `mobilebert` from the missing configs TODO list.
* Added a test case for `mobilebert` in `TEXT_ENCODER_MODELS` within `tests/utils/test_dummpy_input_generators.py`.

All local tests passed successfully. 

Fixes #1272

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@echarlaix @JingyaHuang @michaelbenayoun @IlyasMoutawwakil