### PR TITLE
Add XLM to NormalizedConfigManager

### DIFF
--- a/optimum/utils/normalized_config.py
+++ b/optimum/utils/normalized_config.py
@@ -201,6 +201,11 @@ DistilBertNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="n_heads",
     hidden_size="dim",
 )
+XLMNormalizedTextConfig = NormalizedTextConfig.with_args(
+    num_attention_heads="n_heads",
+    hidden_size="emb_dim",
+    num_layers="n_layers",
+)
 GPTNeoNormalizedTextConfig = NormalizedTextConfig.with_args(
     num_attention_heads="num_heads",
 )
@@ -308,6 +313,7 @@ class NormalizedConfigManager:
         "vision-encoder-decoder": NormalizedEncoderDecoderConfig,
         "vit": NormalizedVisionConfig,
         "whisper": WhisperLikeNormalizedTextConfig,
+        "xlm": XLMNormalizedTextConfig,
         "xlm-roberta": NormalizedTextConfig,
         "yolos": NormalizedVisionConfig,
         "qwen2": NormalizedTextConfig,

--- a/tests/utils/test_normalized_config.py
+++ b/tests/utils/test_normalized_config.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import XLMConfig
+
+from optimum.utils.normalized_config import NormalizedConfigManager, XLMNormalizedTextConfig
+
+
+class NormalizedConfigManagerTest(unittest.TestCase):
+    def test_xlm_is_registered(self):
+        config_class = NormalizedConfigManager.get_normalized_config_class("xlm")
+        self.assertIs(config_class, XLMNormalizedTextConfig)
+
+        normalized_config = config_class(XLMConfig(emb_dim=48, n_heads=6, n_layers=3))
+        self.assertEqual(normalized_config.hidden_size, 48)
+        self.assertEqual(normalized_config.num_attention_heads, 6)
+        self.assertEqual(normalized_config.num_layers, 3)


### PR DESCRIPTION
# What does this PR do?

`NormalizedConfigManager` is the current equivalent of `ORTConfigManager`. XLM is on the #351 list and already has `XLMOnnxConfig` in optimum-onnx, but it is still missing from `_conf`, so ONNX Runtime optimization cannot resolve its hidden size or attention-head count.

XLM does not use the BERT-style names. In `XLMConfig` they are:

- hidden size: `emb_dim`
- attention heads: `n_heads`
- layers: `n_layers`

This PR registers only `xlm`, mapping those names with `NormalizedTextConfig.with_args` the same way DistilBERT and MT5 do, and adds an offline regression test for the three normalized attributes. It does not download weights or touch other model types.

Addresses the XLM subtask in #351.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Validation
- `python -m pytest tests/utils/test_normalized_config.py -q`: 1 passed
- `make style` / `make style_check`: passed
- `git diff --check`: passed

## Who can review?

Exporters (ONNX/OpenVINO): @echarlaix, @JingyaHuang, @michaelbenayoun, @IlyasMoutawwakil